### PR TITLE
Add deobfuscated variants to all archived game1.js versions

### DIFF
--- a/.github/workflows/archive-game1.yml
+++ b/.github/workflows/archive-game1.yml
@@ -81,7 +81,19 @@ jobs:
           
           echo "Created archive folder: $ARCHIVE_DIR/$FOLDER_NAME"
           echo "folder_name=$FOLDER_NAME" >> $GITHUB_ENV
-      
+
+      - name: Generate deobfuscated version
+        if: steps.check_dup.outputs.is_duplicate == 'false'
+        run: |
+          FOLDER_NAME="${{ env.folder_name }}"
+
+          npm install
+          npm run build
+          node dist/index.js deobfuscate "../archived_game1_scripts/$FOLDER_NAME/game1.js"
+
+          echo "Deobfuscated version created for $FOLDER_NAME"
+        working-directory: deobfuscator
+
       - name: Commit and push new archive
         if: steps.check_dup.outputs.is_duplicate == 'false'
         run: |

--- a/archived_game1_scripts/2026-04-30T010605/game1.js.deobfuscated.js
+++ b/archived_game1_scripts/2026-04-30T010605/game1.js.deobfuscated.js
@@ -1,0 +1,1910 @@
+try {
+  (function (_0x151ae6, _0x56d399) {
+    const _0x7124a9 = _0x151ae6();
+    while (true) {
+      try {
+        const _0x55ef07 = -parseInt("1174502VsJVfr") / 1 + parseInt("13868bVRNwi") / 2 * (-parseInt("204kDymRG") / 3) + -parseInt("853264IQbWOs") / 4 * (-parseInt("10OJjntu") / 5) + -parseInt("228348wBpDcO") / 6 + parseInt("550046UrWjEl") / 7 * (-parseInt("56FJiBFo") / 8) + parseInt("1121634sEJHzh") / 9 * (parseInt("80BKZnNa") / 10) + parseInt("1014453PkOMKr") / 11 * (parseInt("228SCzJgy") / 12);
+        if (_0x55ef07 === _0x56d399) {
+          break;
+        } else {
+          _0x7124a9.push(_0x7124a9.shift());
+        }
+      } catch (_0x581ce6) {
+        _0x7124a9.push(_0x7124a9.shift());
+      }
+    }
+  })(a0_0x419e, 941759);
+  const a0_0x344056 = ['dg', "dO4", "b-I2rx-E", "YdFB", "dttJrRyO", "bdI_", "Y9JA", "bM07og", "cNxRuCGPAg", "Z9dM", "ZtVDtyo", "YdY6oxJV", 'd-BEuCA', "aM02nQV5", "dt9DqBc", "YdY6oxI", 'bdI2nwA', "cNVHtB2QA2zbSbw", "YdY6oxJYqA", "d9w-pRFXpw", "Y8QyqAl8whI", "Y9U6mw9451U", "depTtw", 'ZA', "b-I4nQ-C61rI", "dts-siGT", "dehNvwBnzDqu", "c9hKwCWX61TBJm_dKn0", "ctdIvSKVCQ", 'YtFF'];
+  const a0_0xfaec35 = "https://gameforge.com/tra/game1.js";
+  const a0_0x553339 = Object.keys({
+    ".Aqua Kana": false,
+    ".Helvetica LT MM": false,
+    ".Times LT MM": false,
+    '18thCentury': false,
+    '8514oem': false,
+    "AR BERKLEY": false,
+    "AR JULIAN": false,
+    "AR PL UKai CN": false,
+    "AR PL UMing CN": false,
+    "AR PL UMing HK": false,
+    "AR PL UMing TW": false,
+    "AR PL UMing TW MBE": false,
+    'Aakar': false,
+    "Abadi MT Condensed Extra Bold": false,
+    "Abadi MT Condensed Light": false,
+    "Abyssinica SIL": false,
+    'AcmeFont': false,
+    "Adobe Arabic": false,
+    "Agency FB": false,
+    'Aharoni': false,
+    "Aharoni Bold": false,
+    "Al Bayan": false,
+    "Al Bayan Bold": false,
+    "Al Bayan Plain": false,
+    "Al Nile": false,
+    "Al Tarikh": false,
+    'Aldhabi': false,
+    'Alfredo': false,
+    'Algerian': false,
+    "Alien Encounters": false,
+    "Almonte Snow": false,
+    "American Typewriter": false,
+    "American Typewriter Bold": false,
+    "American Typewriter Condensed": false,
+    "American Typewriter Light": false,
+    'Amethyst': false,
+    "Andale Mono": false,
+    "Andale Mono Version": false,
+    'Andalus': false,
+    "Angsana New": false,
+    'AngsanaUPC': false,
+    'Ani': false,
+    'AnjaliOldLipi': false,
+    'Aparajita': false,
+    "Apple Braille": false,
+    "Apple Braille Outline 6 Dot": false,
+    "Apple Braille Outline 8 Dot": false,
+    "Apple Braille Pinpoint 6 Dot": false,
+    "Apple Braille Pinpoint 8 Dot": false,
+    "Apple Chancery": false,
+    "Apple Color Emoji": false,
+    "Apple LiGothic Medium": false,
+    "Apple LiSung Light": false,
+    "Apple SD Gothic Neo": false,
+    "Apple SD Gothic Neo Regular": false,
+    "Apple SD GothicNeo ExtraBold": false,
+    "Apple Symbols": false,
+    'AppleGothic': false,
+    "AppleGothic Regular": false,
+    'AppleMyungjo': false,
+    "AppleMyungjo Regular": false,
+    'AquaKana': false,
+    "Arabic Transparent": false,
+    "Arabic Typesetting": false,
+    'Arial': true,
+    "Arial Baltic": false,
+    "Arial Black": true,
+    "Arial Bold": false,
+    "Arial Bold Italic": false,
+    "Arial CE": false,
+    "Arial CYR": false,
+    "Arial Greek": false,
+    "Arial Hebrew": false,
+    "Arial Hebrew Bold": false,
+    "Arial Italic": false,
+    "Arial Narrow": true,
+    "Arial Narrow Bold": false,
+    "Arial Narrow Bold Italic": false,
+    "Arial Narrow Italic": false,
+    "Arial Rounded Bold": false,
+    "Arial Rounded MT Bold": false,
+    "Arial TUR": false,
+    "Arial Unicode MS": false,
+    'ArialHB': false,
+    'Arimo': false,
+    'Asimov': false,
+    'Autumn': false,
+    'Avenir': false,
+    "Avenir Black": false,
+    "Avenir Book": false,
+    "Avenir Next": false,
+    "Avenir Next Bold": false,
+    "Avenir Next Condensed": false,
+    "Avenir Next Condensed Bold": false,
+    "Avenir Next Demi Bold": false,
+    "Avenir Next Heavy": false,
+    "Avenir Next Regular": false,
+    "Avenir Roman": false,
+    'Ayuthaya': false,
+    "BN Jinx": false,
+    "BN Machine": false,
+    "BOUTON International Symbols": false,
+    "Baby Kruffy": false,
+    'Baghdad': false,
+    'Bahnschrift': true,
+    'Balthazar': false,
+    "Bangla MN": false,
+    "Bangla MN Bold": false,
+    "Bangla Sangam MN": false,
+    "Bangla Sangam MN Bold": false,
+    'Baskerville': false,
+    "Baskerville Bold": false,
+    "Baskerville Bold Italic": false,
+    "Baskerville Old Face": false,
+    "Baskerville SemiBold": false,
+    "Baskerville SemiBold Italic": false,
+    'Bastion': false,
+    'Batang': false,
+    'BatangChe': false,
+    "Bauhaus 93": false,
+    'Beirut': false,
+    "Bell MT": false,
+    "Bell MT Bold": false,
+    "Bell MT Italic": false,
+    'Bellerose': false,
+    "Berlin Sans FB": false,
+    "Berlin Sans FB Demi": false,
+    "Bernard MT Condensed": false,
+    'BiauKai': false,
+    "Big Caslon": false,
+    "Big Caslon Medium": false,
+    "Birch Std": false,
+    "Bitstream Charter": false,
+    "Bitstream Vera Sans": false,
+    "Blackadder ITC": false,
+    "Blackoak Std": false,
+    'Bobcat': false,
+    "Bodoni 72": false,
+    "Bodoni MT": false,
+    "Bodoni MT Black": false,
+    "Bodoni MT Poster Compressed": false,
+    "Bodoni Ornaments": false,
+    'BolsterBold': false,
+    "Book Antiqua": false,
+    "Book Antiqua Bold": false,
+    "Bookman Old Style": false,
+    "Bookman Old Style Bold": false,
+    "Bookshelf Symbol 7": false,
+    'Borealis': false,
+    "Bradley Hand": false,
+    "Bradley Hand ITC": false,
+    'Braggadocio': false,
+    'Brandish': false,
+    "Britannic Bold": false,
+    'Broadway': false,
+    "Browallia New": false,
+    'BrowalliaUPC': false,
+    "Brush Script": false,
+    "Brush Script MT": false,
+    "Brush Script MT Italic": false,
+    "Brush Script Std": false,
+    'Brussels': false,
+    'Calibri': true,
+    "Calibri Bold": false,
+    "Calibri Light": true,
+    "Californian FB": false,
+    "Calisto MT": false,
+    "Calisto MT Bold": false,
+    'Calligraphic': false,
+    'Calvin': false,
+    'Cambria': true,
+    "Cambria Bold": false,
+    "Cambria Math": true,
+    'Candara': true,
+    "Candara Bold": false,
+    'Candles': false,
+    "Carrois Gothic SC": false,
+    'Castellar': false,
+    'Centaur': false,
+    'Century': false,
+    "Century Gothic": false,
+    "Century Gothic Bold": false,
+    "Century Schoolbook": false,
+    "Century Schoolbook Bold": false,
+    "Century Schoolbook L": false,
+    'Chalkboard': false,
+    "Chalkboard Bold": false,
+    "Chalkboard SE": false,
+    "Chalkboard SE Bold": false,
+    'ChalkboardBold': false,
+    'Chalkduster': false,
+    'Chandas': false,
+    "Chaparral Pro": false,
+    "Chaparral Pro Light": false,
+    "Charlemagne Std": false,
+    'Charter': false,
+    'Chilanka': false,
+    'Chiller': false,
+    'Chinyen': false,
+    'Clarendon': false,
+    'Cochin': false,
+    "Cochin Bold": false,
+    'Colbert': false,
+    "Colonna MT": false,
+    "Comic Sans MS": true,
+    "Comic Sans MS Bold": false,
+    'Commons': false,
+    'Consolas': true,
+    "Consolas Bold": false,
+    'Constantia': true,
+    "Constantia Bold": false,
+    'Coolsville': false,
+    "Cooper Black": false,
+    "Cooper Std Black": false,
+    'Copperplate': false,
+    "Copperplate Bold": false,
+    "Copperplate Gothic Bold": false,
+    "Copperplate Light": false,
+    'Corbel': true,
+    "Corbel Bold": false,
+    "Cordia New": false,
+    'CordiaUPC': false,
+    'Corporate': false,
+    'Corsiva': false,
+    "Corsiva Hebrew": false,
+    "Corsiva Hebrew Bold": false,
+    'Courier': true,
+    "Courier 10 Pitch": false,
+    "Courier Bold": false,
+    "Courier New": true,
+    "Courier New Baltic": false,
+    "Courier New Bold": false,
+    "Courier New CE": false,
+    "Courier New Italic": false,
+    "Courier Oblique": false,
+    "Cracked Johnnie": false,
+    'Creepygirl': false,
+    "Curlz MT": false,
+    'Cursor': false,
+    "Cutive Mono": false,
+    'DFKai-SB': false,
+    "DIN Alternate": false,
+    "DIN Condensed": false,
+    'Damascus': false,
+    "Damascus Bold": false,
+    "Dancing Script": false,
+    'DaunPenh': false,
+    'David': false,
+    'Dayton': false,
+    "DecoType Naskh": false,
+    "Deja Vu": false,
+    "DejaVu LGC Sans": false,
+    "DejaVu Sans": false,
+    "DejaVu Sans Mono": false,
+    "DejaVu Serif": false,
+    'Deneane': false,
+    'Desdemona': false,
+    'Detente': false,
+    "Devanagari MT": false,
+    "Devanagari MT Bold": false,
+    "Devanagari Sangam MN": false,
+    'Didot': false,
+    "Didot Bold": false,
+    'Digifit': false,
+    'DilleniaUPC': false,
+    'Dingbats': false,
+    "Distant Galaxy": false,
+    "Diwan Kufi": false,
+    "Diwan Kufi Regular": false,
+    "Diwan Thuluth": false,
+    "Diwan Thuluth Regular": false,
+    'DokChampa': false,
+    'Dominican': false,
+    'Dotum': false,
+    'DotumChe': false,
+    "Droid Sans": false,
+    "Droid Sans Fallback": false,
+    "Droid Sans Mono": false,
+    'Dyuthi': false,
+    'Ebrima': true,
+    "Edwardian Script ITC": false,
+    'Elephant': false,
+    'Emmett': false,
+    "Engravers MT": false,
+    "Engravers MT Bold": false,
+    'Enliven': false,
+    "Eras Bold ITC": false,
+    "Estrangelo Edessa": false,
+    'Ethnocentric': false,
+    'EucrosiaUPC': false,
+    'Euphemia': false,
+    "Euphemia UCAS": false,
+    "Euphemia UCAS Bold": false,
+    'Eurostile': false,
+    "Eurostile Bold": false,
+    "Expressway Rg": false,
+    'FangSong': false,
+    'Farah': false,
+    'Farisi': false,
+    "Felix Titling": false,
+    'Fingerpop': false,
+    'Fixedsys': false,
+    'Flubber': false,
+    "Footlight MT Light": false,
+    'Forte': false,
+    'FrankRuehl': false,
+    "Frankfurter Venetian TT": false,
+    "Franklin Gothic Book": false,
+    "Franklin Gothic Book Italic": false,
+    "Franklin Gothic Medium": true,
+    "Franklin Gothic Medium Cond": false,
+    "Franklin Gothic Medium Italic": false,
+    'FreeMono': false,
+    'FreeSans': false,
+    'FreeSerif': false,
+    'FreesiaUPC': false,
+    "Freestyle Script": false,
+    "French Script MT": false,
+    'Futura': false,
+    "Futura Condensed ExtraBold": false,
+    "Futura Medium": false,
+    "GB18030 Bitmap": false,
+    'Gabriola': true,
+    'Gadugi': true,
+    'Garamond': false,
+    "Garamond Bold": false,
+    'Gargi': false,
+    'Garuda': false,
+    'Gautami': false,
+    'Gazzarelli': false,
+    "Geeza Pro": false,
+    "Geeza Pro Bold": false,
+    'Geneva': false,
+    'GenevaCY': false,
+    'Gentium': false,
+    "Gentium Basic": false,
+    "Gentium Book Basic": false,
+    'GentiumAlt': false,
+    'Georgia': true,
+    "Georgia Bold": false,
+    "Geotype TT": false,
+    "Giddyup Std": false,
+    'Gigi': false,
+    'Gill': false,
+    "Gill Sans": false,
+    "Gill Sans Bold": false,
+    "Gill Sans MT": false,
+    "Gill Sans MT Bold": false,
+    "Gill Sans MT Condensed": false,
+    "Gill Sans MT Ext Condensed Bold": false,
+    "Gill Sans MT Italic": false,
+    "Gill Sans Ultra Bold": false,
+    "Gill Sans Ultra Bold Condensed": false,
+    'Gisha': false,
+    'Glockenspiel': false,
+    "Gloucester MT Extra Condensed": false,
+    "Good Times": false,
+    'Goudy': false,
+    "Goudy Old Style": false,
+    "Goudy Old Style Bold": false,
+    "Goudy Stout": false,
+    "Greek Diner Inline TT": false,
+    'Gubbi': false,
+    "Gujarati MT": false,
+    "Gujarati MT Bold": false,
+    "Gujarati Sangam MN": false,
+    "Gujarati Sangam MN Bold": false,
+    'Gulim': false,
+    'GulimChe': false,
+    "GungSeo Regular": false,
+    'Gungseouche': false,
+    'Gungsuh': false,
+    'GungsuhChe': false,
+    'Gurmukhi': false,
+    "Gurmukhi MN": false,
+    "Gurmukhi MN Bold": false,
+    "Gurmukhi MT": false,
+    "Gurmukhi Sangam MN": false,
+    "Gurmukhi Sangam MN Bold": false,
+    'Haettenschweiler': false,
+    "Hand Me Down S (BRK)": false,
+    'Hansen': false,
+    "Harlow Solid Italic": false,
+    'Harrington': false,
+    'Harvest': false,
+    'HarvestItal': false,
+    "Haxton Logos TT": false,
+    "HeadLineA Regular": false,
+    'HeadlineA': false,
+    "Heavy Heap": false,
+    'Hei': false,
+    "Hei Regular": false,
+    "Heiti SC": false,
+    "Heiti SC Light": false,
+    "Heiti SC Medium": false,
+    "Heiti TC": false,
+    "Heiti TC Light": false,
+    "Heiti TC Medium": false,
+    'Helvetica': true,
+    "Helvetica Bold": false,
+    "Helvetica CY Bold": false,
+    "Helvetica CY Plain": false,
+    "Helvetica LT Std": false,
+    "Helvetica Light": false,
+    "Helvetica Neue": false,
+    "Helvetica Neue Bold": false,
+    "Helvetica Neue Medium": false,
+    "Helvetica Oblique": false,
+    'HelveticaCY': false,
+    "HelveticaNeueLT Com 107 XBlkCn": false,
+    'Herculanum': false,
+    "High Tower Text": false,
+    'Highboot': false,
+    "Hiragino Kaku Gothic Pro W3": false,
+    "Hiragino Kaku Gothic Pro W6": false,
+    "Hiragino Kaku Gothic ProN W3": false,
+    "Hiragino Kaku Gothic ProN W6": false,
+    "Hiragino Kaku Gothic Std W8": false,
+    "Hiragino Kaku Gothic StdN W8": false,
+    "Hiragino Maru Gothic Pro W4": false,
+    "Hiragino Maru Gothic ProN W4": false,
+    "Hiragino Mincho Pro W3": false,
+    "Hiragino Mincho Pro W6": false,
+    "Hiragino Mincho ProN W3": false,
+    "Hiragino Mincho ProN W6": false,
+    "Hiragino Sans GB W3": false,
+    "Hiragino Sans GB W6": false,
+    "Hiragino Sans W0": false,
+    "Hiragino Sans W1": false,
+    "Hiragino Sans W2": false,
+    "Hiragino Sans W3": false,
+    "Hiragino Sans W4": false,
+    "Hiragino Sans W5": false,
+    "Hiragino Sans W6": false,
+    "Hiragino Sans W7": false,
+    "Hiragino Sans W8": false,
+    "Hiragino Sans W9": false,
+    "Hobo Std": false,
+    "Hoefler Text": false,
+    "Hoefler Text Black": false,
+    "Hoefler Text Ornaments": false,
+    "Hollywood Hills": false,
+    'Hombre': false,
+    "Huxley Titling": false,
+    "ITC Stone Serif": false,
+    "ITF Devanagari": false,
+    "ITF Devanagari Marathi": false,
+    "ITF Devanagari Medium": false,
+    'Impact': true,
+    "Imprint MT Shadow": false,
+    'InaiMathi': false,
+    'Induction': false,
+    "Informal Roman": false,
+    "Ink Free": true,
+    'IrisUPC': false,
+    "Iskoola Pota": false,
+    'Italianate': false,
+    'Jamrul': false,
+    'JasmineUPC': false,
+    "Javanese Text": true,
+    'Jokerman': false,
+    "Juice ITC": false,
+    'KacstArt': false,
+    'KacstBook': false,
+    'KacstDecorative': false,
+    'KacstDigital': false,
+    'KacstFarsi': false,
+    'KacstLetter': false,
+    'KacstNaskh': false,
+    'KacstOffice': false,
+    'KacstOne': false,
+    'KacstPen': false,
+    'KacstPoster': false,
+    'KacstQurn': false,
+    'KacstScreen': false,
+    'KacstTitle': false,
+    'KacstTitleL': false,
+    'Kai': false,
+    "Kai Regular": false,
+    'KaiTi': false,
+    'Kailasa': false,
+    "Kailasa Regular": false,
+    "Kaiti SC": false,
+    "Kaiti SC Black": false,
+    'Kalapi': false,
+    'Kalimati': false,
+    'Kalinga': false,
+    "Kannada MN": false,
+    "Kannada MN Bold": false,
+    "Kannada Sangam MN": false,
+    "Kannada Sangam MN Bold": false,
+    'Kartika': false,
+    'Karumbi': false,
+    'Kedage': false,
+    'Kefa': false,
+    "Kefa Bold": false,
+    'Keraleeyam': false,
+    'Keyboard': false,
+    "Khmer MN": false,
+    "Khmer MN Bold": false,
+    "Khmer OS": false,
+    "Khmer OS System": false,
+    "Khmer Sangam MN": false,
+    "Khmer UI": false,
+    'Kinnari': false,
+    "Kino MT": false,
+    'KodchiangUPC': false,
+    "Kohinoor Bangla": false,
+    "Kohinoor Devanagari": false,
+    "Kohinoor Telugu": false,
+    'Kokila': false,
+    'Kokonor': false,
+    "Kokonor Regular": false,
+    "Kozuka Gothic Pr6N B": false,
+    "Kristen ITC": false,
+    'Krungthep': false,
+    'KufiStandardGK': false,
+    "KufiStandardGK Regular": false,
+    "Kunstler Script": false,
+    'Laksaman': false,
+    "Lao MN": false,
+    "Lao Sangam MN": false,
+    "Lao UI": false,
+    'LastResort': false,
+    'Latha': false,
+    'Leelawadee': false,
+    "Letter Gothic Std": false,
+    'LetterOMatic!': false,
+    "Levenim MT": false,
+    "LiHei Pro": false,
+    "LiSong Pro": false,
+    "Liberation Mono": false,
+    "Liberation Sans": false,
+    "Liberation Sans Narrow": false,
+    "Liberation Serif": false,
+    'Likhan': false,
+    'LilyUPC': false,
+    'Limousine': false,
+    "Lithos Pro Regular": false,
+    'LittleLordFontleroy': false,
+    "Lohit Assamese": false,
+    "Lohit Bengali": false,
+    "Lohit Devanagari": false,
+    "Lohit Gujarati": false,
+    "Lohit Gurmukhi": false,
+    "Lohit Hindi": false,
+    "Lohit Kannada": false,
+    "Lohit Malayalam": false,
+    "Lohit Odia": false,
+    "Lohit Punjabi": false,
+    "Lohit Tamil": false,
+    "Lohit Tamil Classical": false,
+    "Lohit Telugu": false,
+    'Loma': false,
+    "Lucida Blackletter": false,
+    "Lucida Bright": false,
+    "Lucida Bright Demibold": false,
+    "Lucida Bright Demibold Italic": false,
+    "Lucida Bright Italic": false,
+    "Lucida Calligraphy": false,
+    "Lucida Calligraphy Italic": false,
+    "Lucida Console": true,
+    "Lucida Fax": false,
+    "Lucida Fax Demibold": false,
+    "Lucida Fax Regular": false,
+    "Lucida Grande": false,
+    "Lucida Grande Bold": false,
+    "Lucida Handwriting": false,
+    "Lucida Handwriting Italic": false,
+    "Lucida Sans": false,
+    "Lucida Sans Demibold Italic": false,
+    "Lucida Sans Typewriter": false,
+    "Lucida Sans Typewriter Bold": false,
+    "Lucida Sans Unicode": true,
+    'Luminari': false,
+    "Luxi Mono": false,
+    "MS Gothic": true,
+    "MS Mincho": false,
+    "MS Outlook": false,
+    "MS PGothic": true,
+    "MS PMincho": false,
+    "MS Reference Sans Serif": false,
+    "MS Reference Specialty": false,
+    "MS Sans Serif": true,
+    "MS Serif": true,
+    "MS UI Gothic": true,
+    "MT Extra": false,
+    "MV Boli": true,
+    'Mael': false,
+    'Magneto': false,
+    "Maiandra GD": false,
+    "Malayalam MN": false,
+    "Malayalam MN Bold": false,
+    "Malayalam Sangam MN": false,
+    "Malayalam Sangam MN Bold": false,
+    "Malgun Gothic": true,
+    'Mallige': false,
+    'Mangal': false,
+    'Manorly': false,
+    'Marion': false,
+    "Marion Bold": false,
+    "Marker Felt": false,
+    "Marker Felt Thin": false,
+    'Marlett': true,
+    'Martina': false,
+    "Matura MT Script Capitals": false,
+    'Meera': false,
+    'Meiryo': false,
+    "Meiryo Bold": false,
+    "Meiryo UI": false,
+    'MelodBold': false,
+    'Menlo': false,
+    "Menlo Bold": false,
+    "Mesquite Std": false,
+    'Microsoft': false,
+    "Microsoft Himalaya": true,
+    "Microsoft JhengHei": true,
+    "Microsoft JhengHei UI": true,
+    "Microsoft New Tai Lue": true,
+    "Microsoft PhagsPa": true,
+    "Microsoft Sans Serif": true,
+    "Microsoft Tai Le": true,
+    "Microsoft Tai Le Bold": false,
+    "Microsoft Uighur": false,
+    "Microsoft YaHei": true,
+    "Microsoft YaHei UI": true,
+    "Microsoft Yi Baiti": true,
+    'Minerva': false,
+    'MingLiU': false,
+    'MingLiU-ExtB': true,
+    'MingLiU_HKSCS': false,
+    "Minion Pro": false,
+    'Miriam': false,
+    'Mishafi': false,
+    "Mishafi Gold": false,
+    'Mistral': false,
+    'Modern': false,
+    "Modern No. 20": false,
+    'Monaco': false,
+    "Mongolian Baiti": true,
+    'Monospace': false,
+    "Monotype Corsiva": false,
+    "Monotype Sorts": false,
+    'MoolBoran': false,
+    'Moonbeam': false,
+    'MotoyaLMaru': false,
+    'Mshtakan': false,
+    "Mshtakan Bold": false,
+    "Mukti Narrow": false,
+    'Muna': false,
+    "Myanmar MN": false,
+    "Myanmar MN Bold": false,
+    "Myanmar Sangam MN": false,
+    "Myanmar Text": true,
+    'Mycalc': false,
+    "Myriad Arabic": false,
+    "Myriad Hebrew": false,
+    "Myriad Pro": false,
+    'NISC18030': false,
+    'NSimSun': true,
+    'Nadeem': false,
+    "Nadeem Regular": false,
+    'Nakula': false,
+    "Nanum Barun Gothic": false,
+    "Nanum Gothic": false,
+    "Nanum Myeongjo": false,
+    'NanumBarunGothic': false,
+    'NanumGothic': false,
+    "NanumGothic Bold": false,
+    'NanumGothicCoding': false,
+    'NanumMyeongjo': false,
+    "NanumMyeongjo Bold": false,
+    'Narkisim': false,
+    'Nasalization': false,
+    'Navilu': false,
+    "Neon Lights": false,
+    "New Peninim MT": false,
+    "New Peninim MT Bold": false,
+    "News Gothic MT": false,
+    "News Gothic MT Bold": false,
+    "Niagara Engraved": false,
+    "Niagara Solid": false,
+    "Nimbus Mono L": false,
+    "Nimbus Roman No9 L": false,
+    "Nimbus Sans L": false,
+    "Nimbus Sans L Condensed": false,
+    'Nina': false,
+    "Nirmala UI": true,
+    'Nirmala.ttf': false,
+    'Norasi': false,
+    'Noteworthy': false,
+    "Noteworthy Bold": false,
+    "Noto Color Emoji": false,
+    "Noto Emoji": false,
+    "Noto Mono": false,
+    "Noto Naskh Arabic": false,
+    "Noto Nastaliq Urdu": false,
+    "Noto Sans": false,
+    "Noto Sans Armenian": false,
+    "Noto Sans Bengali": false,
+    "Noto Sans CJK": false,
+    "Noto Sans Canadian Aboriginal": false,
+    "Noto Sans Cherokee": false,
+    "Noto Sans Devanagari": false,
+    "Noto Sans Ethiopic": false,
+    "Noto Sans Georgian": false,
+    "Noto Sans Gujarati": false,
+    "Noto Sans Gurmukhi": false,
+    "Noto Sans Hebrew": false,
+    "Noto Sans JP": false,
+    "Noto Sans KR": false,
+    "Noto Sans Kannada": false,
+    "Noto Sans Khmer": false,
+    "Noto Sans Lao": false,
+    "Noto Sans Malayalam": false,
+    "Noto Sans Myanmar": false,
+    "Noto Sans Oriya": false,
+    "Noto Sans SC": false,
+    "Noto Sans Sinhala": false,
+    "Noto Sans Symbols": false,
+    "Noto Sans TC": false,
+    "Noto Sans Tamil": false,
+    "Noto Sans Telugu": false,
+    "Noto Sans Thai": false,
+    "Noto Sans Yi": false,
+    "Noto Serif": false,
+    'Notram': false,
+    'November': false,
+    "Nueva Std": false,
+    "Nueva Std Cond": false,
+    'Nyala': false,
+    "OCR A Extended": false,
+    "OCR A Std": false,
+    "Old English Text MT": false,
+    'OldeEnglish': false,
+    'Onyx': false,
+    'OpenSymbol': false,
+    'OpineHeavy': false,
+    'Optima': false,
+    "Optima Bold": false,
+    "Optima Regular": false,
+    "Orator Std": false,
+    "Oriya MN": false,
+    "Oriya MN Bold": false,
+    "Oriya Sangam MN": false,
+    "Oriya Sangam MN Bold": false,
+    'Osaka': false,
+    'Osaka-Mono': false,
+    'OsakaMono': false,
+    "PCMyungjo Regular": false,
+    'PCmyoungjo': false,
+    'PMingLiU': false,
+    'PMingLiU-ExtB': true,
+    "PR Celtic Narrow": false,
+    "PT Mono": false,
+    "PT Sans": false,
+    "PT Sans Bold": false,
+    "PT Sans Caption Bold": false,
+    "PT Sans Narrow Bold": false,
+    "PT Serif": false,
+    'Padauk': false,
+    "Padauk Book": false,
+    'Padmaa': false,
+    'Pagul': false,
+    "Palace Script MT": false,
+    'Palatino': false,
+    "Palatino Bold": false,
+    "Palatino Linotype": true,
+    "Palatino Linotype Bold": false,
+    'Papyrus': false,
+    "Papyrus Condensed": false,
+    'Parchment': false,
+    "Parry Hotter": false,
+    'PenultimateLight': false,
+    'Perpetua': false,
+    "Perpetua Bold": false,
+    "Perpetua Titling MT": false,
+    "Perpetua Titling MT Bold": false,
+    "Phetsarath OT": false,
+    'Phosphate': false,
+    "Phosphate Inline": false,
+    "Phosphate Solid": false,
+    'PhrasticMedium': false,
+    "PilGi Regular": false,
+    'Pilgiche': false,
+    "PingFang HK": false,
+    "PingFang SC": false,
+    "PingFang TC": false,
+    'Pirate': false,
+    "Plantagenet Cherokee": false,
+    'Playbill': false,
+    "Poor Richard": false,
+    "Poplar Std": false,
+    'Pothana2000': false,
+    "Prestige Elite Std": false,
+    'Pristina': false,
+    'Purisa': false,
+    'QuiverItal': false,
+    'Raanana': false,
+    "Raanana Bold": false,
+    'Raavi': false,
+    'Rachana': false,
+    "Rage Italic": false,
+    'RaghuMalayalam': false,
+    'Ravie': false,
+    'Rekha': false,
+    'Roboto': false,
+    'Rockwell': false,
+    "Rockwell Bold": false,
+    "Rockwell Condensed": false,
+    "Rockwell Extra Bold": false,
+    "Rockwell Italic": false,
+    'Rod': false,
+    'Roland': false,
+    'Rondalo': false,
+    "Rosewood Std Regular": false,
+    'RowdyHeavy': false,
+    "Russel Write TT": false,
+    "SF Movie Poster": false,
+    'STFangsong': false,
+    'STHeiti': false,
+    'STIXGeneral': false,
+    'STIXGeneral-Bold': false,
+    'STIXGeneral-Regular': false,
+    'STIXIntegralsD': false,
+    'STIXIntegralsD-Bold': false,
+    'STIXIntegralsSm': false,
+    'STIXIntegralsSm-Bold': false,
+    'STIXIntegralsUp': false,
+    'STIXIntegralsUp-Bold': false,
+    'STIXIntegralsUp-Regular': false,
+    'STIXIntegralsUpD': false,
+    'STIXIntegralsUpD-Bold': false,
+    'STIXIntegralsUpD-Regular': false,
+    'STIXIntegralsUpSm': false,
+    'STIXIntegralsUpSm-Bold': false,
+    'STIXNonUnicode': false,
+    'STIXNonUnicode-Bold': false,
+    'STIXSizeFiveSym': false,
+    'STIXSizeFiveSym-Regular': false,
+    'STIXSizeFourSym': false,
+    'STIXSizeFourSym-Bold': false,
+    'STIXSizeOneSym': false,
+    'STIXSizeOneSym-Bold': false,
+    'STIXSizeThreeSym': false,
+    'STIXSizeThreeSym-Bold': false,
+    'STIXSizeTwoSym': false,
+    'STIXSizeTwoSym-Bold': false,
+    'STIXVariants': false,
+    'STIXVariants-Bold': false,
+    'STKaiti': false,
+    'STSong': false,
+    'STXihei': false,
+    "SWGamekeys MT": false,
+    'Saab': false,
+    'Sahadeva': false,
+    "Sakkal Majalla": false,
+    'Salina': false,
+    'Samanata': false,
+    "Samyak Devanagari": false,
+    "Samyak Gujarati": false,
+    "Samyak Malayalam": false,
+    "Samyak Tamil": false,
+    'Sana': false,
+    "Sana Regular": false,
+    'Sans': false,
+    'Sarai': false,
+    'Sathu': false,
+    "Savoye LET Plain:1.0": false,
+    'Sawasdee': false,
+    'Script': false,
+    "Script MT Bold": false,
+    "Segoe MDL2 Assets": true,
+    "Segoe Print": true,
+    "Segoe Pseudo": false,
+    "Segoe Script": true,
+    "Segoe UI": true,
+    "Segoe UI Emoji": true,
+    "Segoe UI Historic": true,
+    "Segoe UI Semilight": false,
+    "Segoe UI Symbol": true,
+    'Serif': false,
+    "Shonar Bangla": false,
+    "Showcard Gothic": false,
+    "Shree Devanagari 714": false,
+    'Shruti': false,
+    'SignPainter-HouseScript': false,
+    'Silom': false,
+    'SimHei': false,
+    'SimSun': true,
+    'SimSun-ExtB': true,
+    "Simplified Arabic": false,
+    "Simplified Arabic Fixed": false,
+    "Sinhala MN": false,
+    "Sinhala MN Bold": false,
+    "Sinhala Sangam MN": false,
+    "Sinhala Sangam MN Bold": false,
+    'Sitka': false,
+    'Skia': false,
+    "Skia Regular": false,
+    'Skinny': false,
+    "Small Fonts": false,
+    "Snap ITC": false,
+    "Snell Roundhand": false,
+    'Snowdrift': false,
+    "Songti SC": false,
+    "Songti SC Black": false,
+    "Songti TC": false,
+    "Source Code Pro": false,
+    'Splash': false,
+    "Standard Symbols L": false,
+    'Stencil': false,
+    "Stencil Std": false,
+    'Stephen': false,
+    "Sukhumvit Set": false,
+    'Suruma': false,
+    'Sylfaen': true,
+    'Symbol': true,
+    'Symbole': false,
+    'System': false,
+    "System Font": false,
+    'TAMu_Kadambri': false,
+    'TAMu_Kalyani': false,
+    'TAMu_Maduram': false,
+    'TSCu_Comic': false,
+    'TSCu_Paranar': false,
+    'TSCu_Times': false,
+    'Tahoma': true,
+    "Tahoma Negreta": false,
+    'TakaoExGothic': false,
+    'TakaoExMincho': false,
+    'TakaoGothic': false,
+    'TakaoMincho': false,
+    'TakaoPGothic': false,
+    'TakaoPMincho': false,
+    "Tamil MN": false,
+    "Tamil MN Bold": false,
+    "Tamil Sangam MN": false,
+    "Tamil Sangam MN Bold": false,
+    'Tarzan': false,
+    "Tekton Pro": false,
+    "Tekton Pro Cond": false,
+    "Tekton Pro Ext": false,
+    "Telugu MN": false,
+    "Telugu MN Bold": false,
+    "Telugu Sangam MN": false,
+    "Telugu Sangam MN Bold": false,
+    "Tempus Sans ITC": false,
+    'Terminal': false,
+    "Terminator Two": false,
+    'Thonburi': false,
+    "Thonburi Bold": false,
+    "Tibetan Machine Uni": false,
+    'Times': true,
+    "Times Bold": false,
+    "Times New Roman": true,
+    "Times New Roman Baltic": false,
+    "Times New Roman Bold": false,
+    "Times New Roman Italic": false,
+    "Times Roman": false,
+    "Tlwg Mono": false,
+    "Tlwg Typewriter": false,
+    "Tlwg Typist": false,
+    "Tlwg Typo": false,
+    'TlwgMono': false,
+    'TlwgTypewriter': false,
+    'Toledo': false,
+    "Traditional Arabic": false,
+    "Trajan Pro": false,
+    'Trattatello': false,
+    "Trebuchet MS": true,
+    "Trebuchet MS Bold": false,
+    'Tunga': false,
+    "Tw Cen MT": false,
+    "Tw Cen MT Bold": false,
+    "Tw Cen MT Italic": false,
+    "URW Bookman L": false,
+    "URW Chancery L": false,
+    "URW Gothic L": false,
+    "URW Palladio L": false,
+    'Ubuntu': false,
+    "Ubuntu Condensed": false,
+    "Ubuntu Mono": false,
+    'Ukai': false,
+    "Ume Gothic": false,
+    "Ume Mincho": false,
+    "Ume P Gothic": false,
+    "Ume P Mincho": false,
+    "Ume UI Gothic": false,
+    'Uming': false,
+    'Umpush': false,
+    'UnBatang': false,
+    'UnDinaru': false,
+    'UnDotum': false,
+    'UnGraphic': false,
+    'UnGungseo': false,
+    'UnPilgi': false,
+    'Untitled1': false,
+    "Urdu Typesetting": false,
+    'Uroob': false,
+    'Utkal': false,
+    'Utopia': false,
+    'Utsaah': false,
+    'Valken': false,
+    'Vani': false,
+    'Vemana2000': false,
+    'Verdana': true,
+    "Verdana Bold": false,
+    'Vijaya': false,
+    "Viner Hand ITC": false,
+    'Vivaldi': false,
+    'Vivian': false,
+    "Vladimir Script": false,
+    'Vrinda': false,
+    'Waree': false,
+    'Waseem': false,
+    'Waverly': false,
+    'Webdings': true,
+    "WenQuanYi Bitmap Song": false,
+    "WenQuanYi Micro Hei": false,
+    "WenQuanYi Micro Hei Mono": false,
+    "WenQuanYi Zen Hei": false,
+    "Whimsy TT": false,
+    "Wide Latin": false,
+    'Wingdings': true,
+    "Wingdings 2": false,
+    "Wingdings 3": false,
+    'Woodcut': false,
+    'X-Files': false,
+    "Year supply of fairy cakes": false,
+    "Yu Gothic": true,
+    "Yu Mincho": false,
+    "Yuppy SC": false,
+    "Yuppy SC Regular": false,
+    "Yuppy TC": false,
+    "Yuppy TC Regular": false,
+    "Zapf Dingbats": false,
+    'Zapfino': false,
+    'Zawgyi-One': false,
+    'gargi': false,
+    'lklug': false,
+    'mry_KacstQurn': false,
+    'ori1Uni': false
+  });
+  const a0_0x184b5c = () => {
+    try {
+      const _0x590d64 = window.OfflineAudioContext || window.webkitOfflineAudioContext;
+      if (!_0x590d64) {
+        return -2;
+      }
+      const _0x48d2f1 = new _0x590d64(1, 5000, 44100);
+      const _0x197c75 = _0x48d2f1.createOscillator();
+      _0x197c75.type = 'triangle';
+      _0x197c75.frequency.value = 10000;
+      const _0x5b83b8 = _0x48d2f1.createDynamicsCompressor();
+      _0x5b83b8.threshold.value = -50;
+      _0x5b83b8.knee.value = 40;
+      _0x5b83b8.ratio.value = 12;
+      _0x5b83b8.attack.value = 0;
+      _0x5b83b8.release.value = 0.25;
+      _0x197c75.connect(_0x5b83b8);
+      _0x5b83b8.connect(_0x48d2f1.destination);
+      _0x197c75.start(0);
+      const [_0x1a2041, _0x376770] = a0_0x6bbcff(_0x48d2f1);
+      const _0x3d07fd = _0x1a2041.then((_0x3e723a) => a0_0x5ed42e(_0x3e723a.getChannelData(0).subarray(4500)), (_0x16d4ac) => {
+        if (_0x16d4ac.name === "timeout" || _0x16d4ac.name === "suspended") {
+          return 'timeout';
+        }
+        throw _0x16d4ac;
+      });
+      _0x3d07fd['catch'](() => undefined);
+      _0x376770();
+      return _0x3d07fd;
+    } catch (_0x504207) {
+      return -1;
+    }
+  };
+  function a0_0x6bbcff(_0x2ab565) {
+    let _0x30bddf = () => undefined;
+    const _0x3a5130 = new Promise((_0x3f9f2e, _0x3183f6) => {
+      let _0x52ae22 = false;
+      let _0x30c3af = 0;
+      let _0x3ef82e = 0;
+      _0x2ab565.oncomplete = (_0x372440) => _0x3f9f2e(_0x372440.renderedBuffer);
+      const _0x18bb85 = () => {
+        setTimeout(() => _0x3183f6(a0_0x492c15("timeout")), Math.min(500, _0x3ef82e + 5000 - Date.now()));
+      };
+      const _0x23fd36 = () => {
+        try {
+          _0x2ab565.startRendering();
+          switch (_0x2ab565.state) {
+            case "running":
+              _0x3ef82e = Date.now();
+              if (_0x52ae22) {
+                _0x18bb85();
+              }
+              break;
+            case "suspended":
+              if (!document.hidden) {
+                _0x30c3af++;
+              }
+              if (_0x52ae22 && _0x30c3af >= 3) {
+                _0x3183f6(a0_0x492c15("suspended"));
+              } else {
+                setTimeout(_0x23fd36, 500);
+              }
+              break;
+          }
+        } catch (_0x3f6145) {
+          _0x3183f6(_0x3f6145);
+        }
+      };
+      _0x23fd36();
+      _0x30bddf = () => {
+        if (!_0x52ae22) {
+          _0x52ae22 = true;
+          if (_0x3ef82e > 0) {
+            _0x18bb85();
+          }
+        }
+      };
+    });
+    return [_0x3a5130, _0x30bddf];
+  }
+  function a0_0x5ed42e(_0x4cdde4) {
+    let _0x31795e = 0;
+    for (let _0xee7ec7 = 0; _0xee7ec7 < _0x4cdde4.length; ++_0xee7ec7) {
+      _0x31795e += Math.abs(_0x4cdde4[_0xee7ec7]);
+    }
+    return _0x31795e;
+  }
+  function a0_0x492c15(_0x37718a) {
+    const _0x1a5e8a = new Error(_0x37718a);
+    _0x1a5e8a.name = _0x37718a;
+    return _0x1a5e8a;
+  }
+  function a0_0x1ca3(_0x38186a, _0x1d9118) {
+    _0x38186a = _0x38186a - 271;
+    const _0x419e81 = a0_0x419e();
+    let _0x1ca307 = _0x419e81[_0x38186a];
+    return _0x1ca307;
+  }
+  const a0_0x5c43db = () => {
+    try {
+      const _0x3585ad = [{
+        's': "Windows 10",
+        'r': /(Windows 10.0|Windows NT 10.0)/
+      }, {
+        's': "Windows 8.1",
+        'r': /(Windows 8.1|Windows NT 6.3)/
+      }, {
+        's': "Windows 8",
+        'r': /(Windows 8|Windows NT 6.2)/
+      }, {
+        's': "Windows 7",
+        'r': /(Windows 7|Windows NT 6.1)/
+      }, {
+        's': "Windows Vista",
+        'r': /Windows NT 6.0/
+      }, {
+        's': "Windows Server 2003",
+        'r': /Windows NT 5.2/
+      }, {
+        's': "Windows XP",
+        'r': /(Windows NT 5.1|Windows XP)/
+      }, {
+        's': "Windows 2000",
+        'r': /(Windows NT 5.0|Windows 2000)/
+      }, {
+        's': "Windows ME",
+        'r': /(Win 9x 4.90|Windows ME)/
+      }, {
+        's': "Windows 98",
+        'r': /(Windows 98|Win98)/
+      }, {
+        's': "Windows 95",
+        'r': /(Windows 95|Win95|Windows_95)/
+      }, {
+        's': "Windows NT 4.0",
+        'r': /(Windows NT 4.0|WinNT4.0|WinNT|Windows NT)/
+      }, {
+        's': "Windows CE",
+        'r': /Windows CE/
+      }, {
+        's': "Windows 3.11",
+        'r': /Win16/
+      }, {
+        's': "Android",
+        'r': /Android/
+      }, {
+        's': "Open BSD",
+        'r': /OpenBSD/
+      }, {
+        's': "Sun OS",
+        'r': /SunOS/
+      }, {
+        's': "Chrome OS",
+        'r': /CrOS/
+      }, {
+        's': "Linux",
+        'r': /(Linux|X11(?!.*CrOS))/
+      }, {
+        's': "iOS",
+        'r': /(iPhone|iPad|iPod)/
+      }, {
+        's': "Mac OS X",
+        'r': /Mac OS X/
+      }, {
+        's': "Mac OS",
+        'r': /(Mac OS|MacPPC|MacIntel|Mac_PowerPC|Macintosh)/
+      }, {
+        's': 'QNX',
+        'r': /QNX/
+      }, {
+        's': "UNIX",
+        'r': /UNIX/
+      }, {
+        's': "BeOS",
+        'r': /BeOS/
+      }, {
+        's': "OS/2",
+        'r': /OS\/2/
+      }, {
+        's': "Search Bot",
+        'r': /(nuhk|Googlebot|Yammybot|Openbot|Slurp|MSNBot|Ask Jeeves\/Teoma|ia_archiver)/
+      }];
+      let _0x4fd18b;
+      let _0x2dd878 = _0x3585ad.filter((_0x1356d2) => _0x1356d2.r.test(navigator.userAgent))[0].s;
+      if (/Windows/.test(_0x2dd878)) {
+        _0x4fd18b = /Windows (.*)/.exec(_0x2dd878)[1];
+        _0x2dd878 = "Windows";
+      }
+      switch (_0x2dd878) {
+        case "Mac OS":
+        case "Mac OS X":
+        case "Android":
+          _0x4fd18b = /(?:Android|Mac OS|Mac OS X|MacPPC|MacIntel|Mac_PowerPC|Macintosh) ([._\d]+)/.exec(navigator.userAgent)[1];
+          break;
+        case "iOS":
+          _0x4fd18b = /OS (\d+)_(\d+)_?(\d+)?/.exec(navigator.appVersion);
+          _0x4fd18b = _0x4fd18b[1] + '.' + _0x4fd18b[2] + '.' + (_0x4fd18b[3] | 0);
+          break;
+      }
+      return {
+        'name': _0x2dd878,
+        'version': _0x4fd18b
+      };
+    } catch (_0x404493) {
+      return {
+        'name': "Unknown",
+        'version': "Unknown"
+      };
+    }
+  };
+  const a0_0x54f149 = () => {
+    try {
+      const _0x354345 = navigator.userAgent;
+      const _0x1b0cd4 = [{
+        'name': "Opera",
+        'getInfo': (_0xc3cc2c) => {
+          if (_0x354345.indexOf("Version") !== -1) {
+            return {
+              'name': "Opera",
+              'version': _0x354345.substring(_0xc3cc2c + 8)
+            };
+          }
+          return {
+            'name': "Opera",
+            'version': _0x354345.substring(_0xc3cc2c + 6)
+          };
+        }
+      }, {
+        'name': "OPR",
+        'getInfo': (_0x2b2d19) => {
+          return {
+            'name': "Opera",
+            'version': _0x354345.substring(_0x2b2d19 + 4)
+          };
+        }
+      }, {
+        'name': 'Edge',
+        'getInfo': (_0x28e1a3) => {
+          return {
+            'name': "Edge",
+            'version': _0x354345.substring(_0x28e1a3 + 5)
+          };
+        }
+      }, {
+        'name': "Edg",
+        'getInfo': (_0x3c51e7) => {
+          return {
+            'name': "Edge",
+            'version': _0x354345.substring(_0x3c51e7 + 4)
+          };
+        }
+      }, {
+        'name': "MSIE",
+        'getInfo': (_0x29954b) => {
+          return {
+            'name': "Internet Explorer",
+            'version': _0x354345.substring(_0x29954b + 5)
+          };
+        }
+      }, {
+        'name': "Chrome",
+        'getInfo': (_0x2b5054) => {
+          return {
+            'name': "Chrome",
+            'version': _0x354345.substring(_0x2b5054 + 7)
+          };
+        }
+      }, {
+        'name': 'Safari',
+        'getInfo': (_0x3905f0) => {
+          const _0x2fcf93 = _0x354345.indexOf("Version");
+          if (_0x2fcf93 !== -1) {
+            return {
+              'name': "Safari",
+              'version': _0x354345.substring(_0x3905f0 + 8)
+            };
+          }
+          return {
+            'name': "Safari",
+            'version': _0x354345.substring(_0x3905f0 + 7)
+          };
+        }
+      }, {
+        'name': "Firefox",
+        'getInfo': (_0xee226d) => {
+          return {
+            'name': "Firefox",
+            'version': _0x354345.substring(_0xee226d + 8)
+          };
+        }
+      }, {
+        'name': "Trident/",
+        'getInfo': () => {
+          return {
+            'name': "Internet Explorer",
+            'version': _0x354345.substring(_0x354345.indexOf("rv:") + 3)
+          };
+        }
+      }];
+      return _0x1b0cd4.filter(({
+        name: _0xd27e55
+      }) => _0x354345.indexOf(_0xd27e55) !== -1).map(({
+        getInfo: _0x5dc70a,
+        name: _0x300dec
+      }) => _0x5dc70a(_0x354345.indexOf(_0x300dec)))[0];
+    } catch (_0x3475cf) {
+      return {
+        'name': "Unknown",
+        'version': "Unknown"
+      };
+    }
+  };
+  const a0_0x1560cc = () => {
+    try {
+      const _0x18e484 = document.createElement("canvas");
+      const _0x290286 = _0x18e484.getContext('2d');
+      _0x290286.textBaseline = "top";
+      _0x290286.font = "16px 'Arial'";
+      _0x290286.textBaseline = "alphabetic";
+      _0x290286.rotate(0.05);
+      _0x290286.fillStyle = "#f60";
+      _0x290286.fillRect(125, 1, 62, 20);
+      _0x290286.fillStyle = "#069";
+      _0x290286.fillText('i9asdm..$#po((^@KbXrww!~cz', 2, 15);
+      _0x290286.fillStyle = "rgba(102, 200, 0, 0.7)";
+      _0x290286.fillText('i9asdm..$#po((^@KbXrww!~cz', 4, 17);
+      _0x290286.shadowBlur = 10;
+      _0x290286.shadowColor = "blue";
+      _0x290286.fillRect(-20, 10, 234, 5);
+      const _0x36e529 = _0x18e484.toDataURL();
+      let _0x6bba84 = 0;
+      if (_0x36e529.length === 0) {
+        return "nothing!";
+      }
+      for (let _0x56f79d = 0; _0x56f79d < _0x36e529.length; _0x56f79d++) {
+        const _0x3c29cf = _0x36e529.charCodeAt(_0x56f79d);
+        _0x6bba84 = (_0x6bba84 << 5) - _0x6bba84 + _0x3c29cf;
+        _0x6bba84 = _0x6bba84 & _0x6bba84;
+      }
+      return _0x6bba84;
+    } catch (_0x1c79ee) {
+      return -1;
+    }
+  };
+  const a0_0xce9574 = () => {
+    try {
+      const _0x114d59 = document.createElement("canvas");
+      _0x114d59.width = 256;
+      _0x114d59.height = 128;
+      const _0x579f72 = _0x114d59.getContext('webgl2') || _0x114d59.getContext("experimental-webgl2") || _0x114d59.getContext("webgl") || _0x114d59.getContext('experimental-webgl') || _0x114d59.getContext('moz-webgl');
+      try {
+        const _0x50bf09 = "attribute vec2 attrVertex;varying vec2 varyinTexCoordinate;uniform vec2 uniformOffset;void main(){varyinTexCoordinate=attrVertex+uniformOffset;gl_Position=vec4(attrVertex,0,1);}";
+        const _0x411bb6 = "precision mediump float;varying vec2 varyinTexCoordinate;void main() {gl_FragColor=vec4(varyinTexCoordinate,0,1);}";
+        const _0x5bee01 = _0x579f72.createBuffer();
+        _0x579f72.bindBuffer(_0x579f72.ARRAY_BUFFER, _0x5bee01);
+        const _0x47a8d6 = new Float32Array([-0.2, -0.9, 0, 0.4, -0.26, 0, 0, 0.7321, 0]);
+        _0x579f72.bufferData(_0x579f72.ARRAY_BUFFER, _0x47a8d6, _0x579f72.STATIC_DRAW);
+        _0x5bee01.itemSize = 3;
+        _0x5bee01.numItems = 3;
+        const _0x42c9cb = _0x579f72.createProgram();
+        const _0x5dae7f = _0x579f72.createShader(_0x579f72.VERTEX_SHADER);
+        _0x579f72.shaderSource(_0x5dae7f, _0x50bf09);
+        _0x579f72.compileShader(_0x5dae7f);
+        const _0x591fdb = _0x579f72.createShader(_0x579f72.FRAGMENT_SHADER);
+        _0x579f72.shaderSource(_0x591fdb, _0x411bb6);
+        _0x579f72.compileShader(_0x591fdb);
+        _0x579f72.attachShader(_0x42c9cb, _0x5dae7f);
+        _0x579f72.attachShader(_0x42c9cb, _0x591fdb);
+        _0x579f72.linkProgram(_0x42c9cb);
+        _0x579f72.useProgram(_0x42c9cb);
+        _0x42c9cb.vertexPosAttrib = _0x579f72.getAttribLocation(_0x42c9cb, 'attrVertex');
+        _0x42c9cb.offsetUniform = _0x579f72.getUniformLocation(_0x42c9cb, "uniformOffset");
+        _0x579f72.enableVertexAttribArray(_0x42c9cb.vertexPosArray);
+        _0x579f72.vertexAttribPointer(_0x42c9cb.vertexPosAttrib, _0x5bee01.itemSize, _0x579f72.FLOAT, false, 0, 0);
+        _0x579f72.uniform2f(_0x42c9cb.offsetUniform, 1, 1);
+        _0x579f72.drawArrays(_0x579f72.TRIANGLE_STRIP, 0, _0x5bee01.numItems);
+      } catch (_0x4475a2) {}
+      const _0x1a9379 = new Uint8Array(131072);
+      _0x579f72.readPixels(0, 0, 256, 128, _0x579f72.RGBA, _0x579f72.UNSIGNED_BYTE, _0x1a9379);
+      let _0x2d7d5e = JSON.stringify(_0x1a9379).replace(/,?"[0-9]+":/g, '');
+      return a0_0x2b86af(_0x2d7d5e);
+    } catch (_0x4cc5eb) {
+      return '-1';
+    }
+  };
+  const a0_0x2b86af = function () {
+    let _0x171c39 = 1;
+    let _0x45f5ac;
+    let _0x9e2c4f = [];
+    let _0x4493d0 = [];
+    while (++_0x171c39 < 18) {
+      for (_0x45f5ac = _0x171c39 * _0x171c39; _0x45f5ac < 312; _0x45f5ac += _0x171c39) {
+        _0x9e2c4f[_0x45f5ac] = 1;
+      }
+    }
+    _0x171c39 = 1;
+    for (_0x45f5ac = 0; _0x171c39 < 313;) {
+      if (!_0x9e2c4f[++_0x171c39]) {
+        _0x4493d0[_0x45f5ac] = Math.pow(_0x171c39, 0.5) % 1 * 0x100000000 | 0;
+        _0x9e2c4f[_0x45f5ac++] = Math.pow(_0x171c39, 0.3333333333333333) % 1 * 0x100000000 | 0;
+      }
+    }
+    function _0x33731d(_0x1612ef) {
+      let _0x2ea9fe = _0x4493d0.slice(_0x171c39 = 0);
+      let _0x40cfdb = unescape(encodeURI(_0x1612ef));
+      let _0x2a7b4c = [];
+      let _0x46c349 = _0x40cfdb.length;
+      let _0x477dee = [];
+      let _0x180f44;
+      let _0x19801f;
+      let _0x47c6d6;
+      for (; _0x171c39 < _0x46c349;) {
+        _0x477dee[_0x171c39 >> 2] |= (_0x40cfdb.charCodeAt(_0x171c39) & 255) << 8 * (3 - _0x171c39++ % 4);
+      }
+      _0x46c349 *= 8;
+      _0x477dee[_0x46c349 >> 5] |= 128 << 24 - _0x46c349 % 32;
+      _0x477dee[_0x47c6d6 = _0x46c349 + 64 >> 5 | 15] = _0x46c349;
+      for (_0x171c39 = 0; _0x171c39 < _0x47c6d6; _0x171c39 += 16) {
+        _0x180f44 = _0x2ea9fe.slice(_0x45f5ac = 0, 8);
+        for (; _0x45f5ac < 64; _0x180f44[4] += _0x19801f) {
+          if (_0x45f5ac < 16) {
+            _0x2a7b4c[_0x45f5ac] = _0x477dee[_0x45f5ac + _0x171c39];
+          } else {
+            _0x2a7b4c[_0x45f5ac] = (((_0x19801f = _0x2a7b4c[_0x45f5ac - 2]) >>> 17 | (_0x19801f = _0x2a7b4c[_0x45f5ac - 2]) << 15) ^ (_0x19801f >>> 19 | _0x19801f << 13) ^ _0x19801f >>> 10) + (_0x2a7b4c[_0x45f5ac - 7] | 0) + (((_0x19801f = _0x2a7b4c[_0x45f5ac - 15]) >>> 7 | (_0x19801f = _0x2a7b4c[_0x45f5ac - 15]) << 25) ^ (_0x19801f >>> 18 | _0x19801f << 14) ^ _0x19801f >>> 3) + (_0x2a7b4c[_0x45f5ac - 16] | 0);
+          }
+          _0x180f44.unshift((_0x19801f = (_0x180f44.pop() + (((_0x1612ef = _0x180f44[4]) >>> 6 | (_0x1612ef = _0x180f44[4]) << 26) ^ (_0x1612ef >>> 11 | _0x1612ef << 21) ^ (_0x1612ef >>> 25 | _0x1612ef << 7)) + ((_0x1612ef & _0x180f44[5] ^ ~_0x1612ef & _0x180f44[6]) + _0x9e2c4f[_0x45f5ac]) | 0) + (_0x2a7b4c[_0x45f5ac++] | 0)) + (((_0x46c349 = _0x180f44[0]) >>> 2 | (_0x46c349 = _0x180f44[0]) << 30) ^ (_0x46c349 >>> 13 | _0x46c349 << 19) ^ (_0x46c349 >>> 22 | _0x46c349 << 10)) + (_0x46c349 & _0x180f44[1] ^ _0x180f44[1] & _0x180f44[2] ^ _0x180f44[2] & _0x46c349));
+        }
+        for (_0x45f5ac = 8; _0x45f5ac--;) {
+          _0x2ea9fe[_0x45f5ac] = _0x180f44[_0x45f5ac] + _0x2ea9fe[_0x45f5ac];
+        }
+      }
+      for (_0x40cfdb = ''; _0x45f5ac < 63;) {
+        _0x40cfdb += (_0x2ea9fe[++_0x45f5ac >> 3] >> 4 * (7 - _0x45f5ac % 8) & 15).toString(16);
+      }
+      return _0x40cfdb;
+    }
+    return _0x33731d;
+  }();
+  const a0_0x48bbf8 = () => new Promise(async (_0x1129db) => {
+    let _0x510e8f = setTimeout(() => _0x1129db([]), 200);
+    const _0x569e6b = await navigator.mediaDevices.enumerateDevices();
+    clearTimeout(_0x510e8f);
+    let _0x4fa57 = _0x569e6b.map((_0x508390) => _0x508390.kind).sort();
+    _0x1129db(_0x4fa57);
+  })["catch"]((_0x2d1bc4) => []);
+  const a0_0x4685b5 = () => {
+    const _0x4c450e = ["audio/aac", "audio/flac", "audio/mpeg", "audio/mp4; codecs=\"mp4a.40.2\"", "audio/ogg; codecs=\"flac\"", "audio/ogg; codecs=\"vorbis\"", "audio/ogg; codecs=\"opus\"", "audio/wav; codecs=\"1\"", "audio/webm; codecs=\"vorbis\"", "audio/webm; codecs=\"opus\""];
+    try {
+      const _0x28d396 = document.createElement("audio");
+      return _0x4c450e.map((_0x384b19) => {
+        return {
+          'type': _0x384b19,
+          'canPlay': _0x28d396.canPlayType(_0x384b19)
+        };
+      });
+    } catch (_0x9cd1c9) {
+      return _0x4c450e.map((_0x456b83) => {
+        return {
+          'type': _0x456b83,
+          'canPlay': "no info"
+        };
+      });
+    }
+  };
+  const a0_0x51d8cf = () => {
+    const _0x3b546d = ["video/ogg; codecs=\"theora\"", "video/ogg; codecs=\"opus\"", "video/mp4; codecs=\"avc1.42E01E\"", "video/mp4; codecs=\"flac\"", "video/webm; codecs=\"vp8, vorbis\"", "video/webm; codecs=\"vp9\"", "application/x-mpegURL; codecs=\"avc1.42E01E\""];
+    try {
+      const _0x5e22d6 = document.createElement('video');
+      return _0x3b546d.map((_0x6229eb) => {
+        return {
+          'type': _0x6229eb,
+          'canPlay': _0x5e22d6.canPlayType(_0x6229eb)
+        };
+      });
+    } catch (_0x460005) {
+      return _0x3b546d.map((_0x4e2341) => {
+        return {
+          'type': _0x4e2341,
+          'canPlay': "no info"
+        };
+      });
+    }
+  };
+  const a0_0x55abbd = async () => {
+    try {
+      const _0x71b4f8 = ["accelerometer", 'camera', "clipboard-read", "clipboard-write", 'geolocation', "background-sync", "magnetometer", "microphone", "midi", 'notifications', "payment-handler", "persistent-storage"];
+      const _0x5c3dd6 = {};
+      await Promise.all(_0x71b4f8.map(async (_0x46d8be) => {
+        try {
+          const {
+            state: _0x50ec65
+          } = await navigator.permissions.query({
+            'name': _0x46d8be
+          });
+          _0x5c3dd6[_0x46d8be] = _0x50ec65;
+        } catch (_0x31b639) {}
+      }));
+      return _0x5c3dd6;
+    } catch (_0x42c1e9) {
+      return {};
+    }
+  };
+  const a0_0x332e91 = () => {
+    try {
+      const _0x41174a = document.createElement("canvas");
+      const _0x4d8cb3 = _0x41174a.getContext("webgl") || _0x41174a.getContext("experimental-webgl");
+      const _0x569db8 = _0x4d8cb3.getExtension("WEBGL_debug_renderer_info");
+      return {
+        'vendor': _0x4d8cb3.getParameter(_0x569db8.UNMASKED_VENDOR_WEBGL),
+        'renderer': _0x4d8cb3.getParameter(_0x569db8.UNMASKED_RENDERER_WEBGL),
+        'extensions': _0x4d8cb3.getSupportedExtensions()
+      };
+    } catch (_0x5465d1) {
+      return {
+        'vendor': "Unknown",
+        'renderer': "Unknown",
+        'extensions': []
+      };
+    }
+  };
+  const a0_0x231c9a = () => {
+    try {
+      const _0x54c574 = new AudioContext();
+      return {
+        'state': _0x54c574.state,
+        'sampleRate': _0x54c574.sampleRate,
+        'channelCount': _0x54c574.destination.channelCount,
+        'channelCountMode': _0x54c574.destination.channelCountMode,
+        'channelInterpretation': _0x54c574.destination.channelInterpretation,
+        'maxChannelCount': _0x54c574.destination.maxChannelCount,
+        'numberOfInputs': _0x54c574.destination.numberOfInputs,
+        'numberOfOutputs': _0x54c574.destination.numberOfOutputs
+      };
+    } catch (_0x80f02b) {
+      return {};
+    }
+  };
+  const a0_0x27b408 = () => {
+    const _0x362144 = document.getElementsByTagName("body")[0];
+    const _0x69e923 = document.createElement('div');
+    let _0x549e72 = document.createDocumentFragment();
+    const _0x3667f6 = ["monospace", 'sans-serif', "serif"];
+    const _0x5f1f14 = {
+      'monospace': {},
+      'sans-serif': {},
+      'serif': {}
+    };
+    const _0x278ad7 = "fp-check-runtime-0.0.1";
+    const _0x1d825a = {};
+    const _0x10f9fe = {};
+    _0x69e923.id = 'fp-div-check-runtime-0.0.1';
+    _0x362144.appendChild(_0x69e923);
+    _0x3667f6.forEach((_0x490e62, _0x14e7ea) => {
+      const _0x38438a = document.createElement("span");
+      _0x38438a.style.fontSize = '72px';
+      _0x38438a.innerHTML = "mmmmmmmmmmlli";
+      _0x38438a.style.fontFamily = _0x3667f6[_0x14e7ea];
+      _0x38438a.style.position = "fixed";
+      _0x38438a.style.visibility = 'hidden';
+      _0x38438a.classList.add(_0x278ad7);
+      _0x549e72.appendChild(_0x38438a);
+    });
+    a0_0x553339.forEach((_0x4d671e) => {
+      _0x3667f6.forEach((_0x3ac0e7) => {
+        const _0x6d21f9 = document.createElement("span");
+        _0x6d21f9.style.fontSize = '72px';
+        _0x6d21f9.innerHTML = "mmmmmmmmmmlli";
+        _0x6d21f9.style.fontFamily = _0x4d671e + ',' + _0x3ac0e7;
+        _0x6d21f9.style.position = "fixed";
+        _0x6d21f9.style.visibility = "hidden";
+        _0x6d21f9.id = _0x4d671e + '&' + _0x3ac0e7;
+        _0x6d21f9.classList.add(_0x278ad7);
+        _0x549e72.appendChild(_0x6d21f9);
+      });
+    });
+    _0x69e923.appendChild(_0x549e72);
+    const _0x11a064 = _0x69e923.children;
+    _0x3667f6.forEach((_0x1485a6, _0xdddcdb) => {
+      _0x1d825a[_0x3667f6[_0xdddcdb]] = _0x11a064[_0xdddcdb].offsetWidth;
+      _0x10f9fe[_0x3667f6[_0xdddcdb]] = _0x11a064[_0xdddcdb].offsetHeight;
+    });
+    for (let _0x5366ec = 0; _0x5366ec < _0x11a064.length; _0x5366ec++) {
+      const [_0x43270e, _0x2e29df] = _0x11a064[_0x5366ec].id.split('&');
+      if (_0x2e29df) {
+        _0x5f1f14[_0x2e29df][_0x43270e] = _0x11a064[_0x5366ec];
+      }
+    }
+    const _0x4ae7a2 = [];
+    for (let _0x37756c = 0; _0x37756c < a0_0x553339.length; _0x37756c++) {
+      for (let _0x4443b0 = 0; _0x4443b0 < _0x3667f6.length; _0x4443b0++) {
+        let _0x39e8c5 = false;
+        let _0x1d938c = _0x5f1f14[_0x3667f6[_0x4443b0]][a0_0x553339[_0x37756c]];
+        const _0x25b517 = _0x1d938c.offsetWidth !== _0x1d825a[_0x3667f6[_0x4443b0]] || _0x1d938c.offsetHeight !== _0x10f9fe[_0x3667f6[_0x4443b0]];
+        _0x39e8c5 = _0x39e8c5 || _0x25b517;
+        if (_0x39e8c5) {
+          _0x4ae7a2.push(a0_0x553339[_0x37756c]);
+          break;
+        }
+      }
+    }
+    document.getElementById('fp-div-check-runtime-0.0.1').remove();
+    return _0x4ae7a2;
+  };
+  const a0_0x5042e5 = () => {
+    try {
+      const _0x2e39c9 = [];
+      for (let _0x9e4a5f = 0; _0x9e4a5f < navigator.plugins.length; _0x9e4a5f++) {
+        _0x2e39c9.push(navigator.plugins[_0x9e4a5f].name);
+      }
+      return _0x2e39c9;
+    } catch (_0x510044) {
+      return [];
+    }
+  };
+  const a0_0x362572 = () => {
+    let _0x153a1a = 0;
+    try {
+      if (navigator.webdriver === true) {
+        _0x153a1a |= 1;
+      }
+      if (!window.chrome && !/Firefox/.test(navigator.userAgent) && /Chrome/.test(navigator.userAgent)) {
+        _0x153a1a |= 2;
+      }
+      try {
+        if (navigator.permissions) {
+          const _0x3c2e73 = Notification.permission;
+          if (_0x3c2e73 === "denied" && !document.hidden) {
+            _0x153a1a |= 4;
+          }
+        }
+      } catch (_0xc7ae8a) {}
+      if (window.cdc_adoQpoasnfa76pfcZLmcfl_Array || window.cdc_adoQpoasnfa76pfcZLmcfl_Promise || window.cdc_adoQpoasnfa76pfcZLmcfl_Symbol || document.documentElement.getAttribute("cdc_adoQpoasnfa76pfcZLmcfl_")) {
+        _0x153a1a |= 8;
+      }
+      if (window.callPhantom || window._phantom || window.phantom) {
+        _0x153a1a |= 16;
+      }
+      if (window.$cdc_asdjflasutopfhvcZLmcfl_ || window.$wdc_ || window.__webdriver_script_fn || document.$cdc_asdjflasutopfhvcZLmcfl_ || document.__webdriver_evaluate || document.__selenium_evaluate || document.__webdriver_script_function || document.__webdriver_script_func || document.__webdriver_script_fn || document.__fxdriver_evaluate || document.__driver_unwrapped || document.__webdriver_unwrapped || document.__driver_evaluate || document.__selenium_unwrapped || document.__fxdriver_unwrapped) {
+        _0x153a1a |= 32;
+      }
+      if (navigator.webdriver || window.__puppeteer_evaluation_script__ || window.domAutomation || window.domAutomationController) {
+        _0x153a1a |= 64;
+      }
+      if (window.__playwright || window.__pw_manual || window.__PW_inspect) {
+        _0x153a1a |= 128;
+      }
+      if (document.hidden && document.visibilityState === "hidden") {
+        _0x153a1a |= 256;
+      }
+      if (window.outerWidth === 0 || window.outerHeight === 0) {
+        _0x153a1a |= 512;
+      }
+      if (/HeadlessChrome/.test(navigator.userAgent)) {
+        _0x153a1a |= 1024;
+      }
+      if (!navigator.languages || navigator.languages.length === 0) {
+        _0x153a1a |= 2048;
+      }
+      try {
+        const _0x280e24 = navigator.connection || navigator.mozConnection || navigator.webkitConnection;
+        if (_0x280e24 && _0x280e24.type === "none" && !_0x280e24.effectiveType) {
+          _0x153a1a |= 4096;
+        }
+      } catch (_0x4c0da1) {}
+      try {
+        const _0x389b41 = navigator.plugins;
+        if (_0x389b41.length === 0 && /Chrome/.test(navigator.userAgent)) {
+          _0x153a1a |= 8192;
+        }
+        if (_0x389b41.length > 0 && !(_0x389b41[0] instanceof Plugin)) {
+          _0x153a1a |= 8192;
+        }
+      } catch (_0x1830d6) {}
+      try {
+        if (Notification.permission === "denied" && !localStorage.getItem("notification_prompted")) {
+          _0x153a1a |= 16384;
+        }
+      } catch (_0x6be73a) {}
+      try {
+        const _0x3e55e4 = new Error().stack;
+        if (_0x3e55e4 && (_0x3e55e4.includes("puppeteer") || _0x3e55e4.includes("playwright") || _0x3e55e4.includes("selenium") || _0x3e55e4.includes('webdriver'))) {
+          _0x153a1a |= 32768;
+        }
+      } catch (_0x5adafb) {}
+      if (typeof qt !== "undefined" || typeof QWebChannel !== "undefined" || window.qt && window.qt.webChannelTransport || typeof callbackHandler !== "undefined") {
+        _0x153a1a |= 65536;
+      }
+      try {
+        const _0x1731fc = !!window.chrome;
+        const _0x3db694 = !!(window.chrome && window.chrome.runtime);
+        const _0x25c879 = !!(window.chrome && window.chrome.loadTimes);
+        const _0x1bd6de = !!(window.chrome && window.chrome.csi);
+        if (_0x1731fc && !_0x3db694 && !_0x25c879 && !_0x1bd6de) {
+          _0x153a1a |= 131072;
+        }
+        if (!_0x1731fc && /Chrome/.test(navigator.userAgent) && !/Chromium/.test(navigator.userAgent)) {
+          _0x153a1a |= 131072;
+        }
+      } catch (_0x3d1d22) {}
+    } catch (_0x57a7de) {
+      return -1;
+    }
+    return _0x153a1a;
+  };
+  const a0_0x4e69ab = (_0x4bb7b7) => {
+    return new Array(_0x4bb7b7).fill(0).map(() => Math.random().toString(36).substr(2, 9)).reduce((_0x12a106, _0x354ae4) => _0x12a106 + _0x354ae4, '');
+  };
+  const a0_0x25c6db = async () => {
+    const _0x5b025c = await Promise.all([a0_0x55abbd(), a0_0x48bbf8(), a0_0x184b5c()]);
+    const _0x236a5a = a0_0x54f149();
+    const _0x339340 = a0_0x5c43db();
+    const _0x242377 = a0_0x332e91();
+    const _0x357f98 = a0_0x2b86af(JSON.stringify(a0_0x27b408()));
+    const _0x880f99 = a0_0xce9574();
+    const _0x531fae = a0_0x1560cc();
+    return {
+      'dg': 12,
+      'dO4': Intl.DateTimeFormat().resolvedOptions().timeZone,
+      'b-I2rx-E': _0x339340.name,
+      'YdFB': _0x236a5a.name,
+      'dttJrRyO': navigator.vendor,
+      'bdI_': navigator.deviceMemory || 0,
+      'Y9JA': navigator.hardwareConcurrency || 0,
+      'bM07og': navigator.languages.join(','),
+      'cNxRuCGPAg': a0_0x2b86af(JSON.stringify(a0_0x5042e5())),
+      'Z9dM': _0x242377.vendor + ',' + _0x242377.renderer,
+      'ZtVDtyo': _0x357f98,
+      'YdY6oxJV': a0_0x2b86af(JSON.stringify(a0_0x231c9a())),
+      'b-I4nQ-C61rI': _0x339340.version,
+      'd-BEuCA': window.screen.availWidth,
+      'aM02nQV5': window.screen.availHeight,
+      'bL8zohR5': Boolean(localStorage),
+      'c8Y6qRuA': Boolean(sessionStorage),
+      'dt9DqBc': a0_0x2b86af(JSON.stringify(a0_0x51d8cf())),
+      'YdY6oxI': a0_0x2b86af(JSON.stringify(a0_0x4685b5())),
+      'bdI2nwA': a0_0x2b86af(JSON.stringify(_0x5b025c[1])),
+      'cNVHtB2QA2zbSbw': a0_0x2b86af(JSON.stringify(_0x5b025c[0])),
+      'YdY6oxJYqA': _0x5b025c[2],
+      'd9w-pRFXpw': _0x880f99,
+      'Y8QyqAl8whI': _0x531fae,
+      'YtFF': a0_0x362572()
+    };
+  };
+  function a0_0x5b519f(_0x3fed98) {
+    let _0x512619 = [];
+    a0_0x344056.forEach((_0x2d0ad8) => {
+      _0x512619.push(_0x3fed98[_0x2d0ad8]);
+      delete _0x3fed98[_0x2d0ad8];
+    });
+    return _0x512619;
+  }
+  function a0_0x419e() {
+    const _0x1b672e = ['canvas', 'selenium', 'abs', 'Firefox', 'availHeight', 'suspended', 'toISOString', 'offsetHeight', '#069', "video/mp4; codecs=\"avc1.42E01E\"", 'indexOf', 'random', 'getDate', 'webkitConnection', 'fillText', 'stack', 'compileShader', 'clipboard-write', 'notification_prompted', 'YdY6oxI', 'sampleRate', 'audio/mpeg', 'ARRAY_BUFFER', '__fxdriver_unwrapped', "Chrome OS", 'b-I2rx-E', 'getAttribute', 'fixed', 'dO4', 'style', 'visibilityState', 'deviceMemory', 'appVersion', 'mmmmmmmmmmlli', 'cdc_adoQpoasnfa76pfcZLmcfl_Array', 'all', "Windows 7", "audio/webm; codecs=\"vorbis\"", 'x-vec', 'nothing!', 'classList', 'shaderSource', 'charCodeAt', 'itemSize', 'body', 'getResponseHeader', 'mediaDevices', 'startRendering', 'cNxRuCGPAg', 'bdI_', "attribute vec2 attrVertex;varying vec2 varyinTexCoordinate;uniform vec2 uniformOffset;void main(){varyinTexCoordinate=attrVertex+uniformOffset;gl_Position=vec4(attrVertex,0,1);}", 'Y9JA', 'push', 'destination', 'experimental-webgl', 'webdriver', 'join', 'fill', 'OS/2', 'kind', 'midi', '228348wBpDcO', 'keys', 'WEBGL_debug_renderer_info', '1174502VsJVfr', 'frequency', 'running', 'domAutomationController', "Windows 3.11", 'x-game', 'renderer', '__selenium_unwrapped', 'microphone', 'mozConnection', 'date', 'release', 'getUniformLocation', '__webdriver_script_function', 'from', 'chrome', 'loadTimes', 'fp-check-runtime-0.0.1', 'Z9dM', 'createProgram', 'MSIE', 'denied', 'numberOfOutputs', 'persistent-storage', 'numItems', 'depTtw', "audio/wav; codecs=\"1\"", 'replace', 'DateTimeFormat', 'uniform2f', "video/mp4; codecs=\"flac\"", "application/x-mpegURL; codecs=\"avc1.42E01E\"", 'onreadystatechange', 'vendor', '1014453PkOMKr', 'background-sync', 'YdY6oxJYqA', 'ctdIvSKVCQ', 'documentElement', 'query', 'test', 'outerWidth', '#f60', 'YdY6oxJV', 'BeOS', 'availWidth', "Windows NT 4.0", 'experimental-webgl2', 'fillRect', 'rv:', '13868bVRNwi', 'phantom', "Windows XP", 'dttJrRyO', 'magnetometer', 'then', 'split', 'screen', "video/webm; codecs=\"vp8, vorbis\"", 'alphabetic', '_phantom', 'TRIANGLE_STRIP', "Search Bot", 'channelInterpretation', 'drawArrays', 'shift', 'uniformOffset', "rgba(102, 200, 0, 0.7)", 'fromCharCode', 'span', '__webdriver_script_fn', 'Version', 'webkitOfflineAudioContext', "Windows 2000", 'catch', 'hidden', 'toDataURL', 'bM07og', 'canPlayType', '$wdc_', 'appendChild', 'c9hKwCWX61TBJm_dKn0', 'state', '56FJiBFo', 'vertexPosArray', 'createElement', 'getElementsByTagName', 'toString', 'effectiveType', 'serif', '853264IQbWOs', 'setItem', 'FRAGMENT_SHADER', 'aM02nQV5', 'UNMASKED_VENDOR_WEBGL', 'getParameter', 'attachShader', 'Y8QyqAl8whI', 'iOS', 'createOscillator', 'webChannelTransport', 'dts-siGT', 'userAgent', 'version', 'cdc_adoQpoasnfa76pfcZLmcfl_', "Windows 98", 'createDocumentFragment', 'filter', 'height', '__webdriver_script_func', "audio/ogg; codecs=\"opus\"", 'knee', 'Android', 'YdFB', "video/ogg; codecs=\"opus\"", 'https://gameforge.com/tra/game1.js', 'monospace', 'offsetWidth', 'dt9DqBc', "video/webm; codecs=\"vp9\"", 'puppeteer', 'getContext', 'enableVertexAttribArray', 'send', '__webdriver_evaluate', 'substr', "audio/ogg; codecs=\"flac\"", 'offsetUniform', 'Edge', '10OJjntu', "Open BSD", 'map', 'STATIC_DRAW', 'payment-handler', 'fontFamily', 'runtime', 'Chrome', "16px 'Arial'", 'Windows', 'getTime', 'exec', 'connect', "Windows 95", "video/ogg; codecs=\"theora\"", 'setDate', 'shadowColor', 'pop', 'accelerometer', 'name', 'cNVHtB2QA2zbSbw', 'position', 'getElementById', 'includes', 'clipboard-read', 'numberOfInputs', 'subarray', 'OPR', "Windows Server 2003", 'audio', 'enumerateDevices', 'top', 'reduce', 'UNIX', 'permission', 'vertexAttribPointer', '550046UrWjEl', 'languages', 'vertexPosAttrib', 'plugins', 'Y9U6mw9451U', 'forEach', 'fillStyle', 'width', "Input not valid", 'dehNvwBnzDqu', 'Edg', 'playwright', 'min', "Internet Explorer", 'outerHeight', 'sort', 'visibility', '1121634sEJHzh', 'Linux', 'b-I4nQ-C61rI', 'length', '228SCzJgy', 'none', 'domAutomation', '__fxdriver_evaluate', 'Opera', 'Trident/', 'ZtVDtyo', 'timeout', 'Unknown', 'children', 'innerHTML', "precision mediump float;varying vec2 varyinTexCoordinate;void main() {gl_FragColor=vec4(varyinTexCoordinate,0,1);}", 'VERTEX_SHADER', 'FLOAT', 'fontSize', "Sun OS", 'audio/flac', 'Safari', '__driver_evaluate', 'slice', 'GET', '__selenium_evaluate', 'bindBuffer', 'add', "Mac OS X", '80BKZnNa', 'value', 'shadowBlur', "Mac OS", 'oncomplete', 'channelCountMode', 'type', 'timeZone', 'audio/aac', '__playwright', 'd9w-pRFXpw', '__driver_unwrapped', '204kDymRG', 'textBaseline', 'stringify', 'pow', 'blue', 'undefined', 'substring', 'btoa', "no info", "audio/mp4; codecs=\"mp4a.40.2\"", 'rotate', 'webgl', 'getItem'];
+    a0_0x419e = function () {
+      return _0x1b672e;
+    };
+    return a0_0x419e();
+  }
+  function a0_0x17e762(_0x5d7c83) {
+    const _0x1c8155 = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_='.split('');
+    const _0x1170f5 = function (_0x2b8975) {
+      let _0x7b0c55 = '';
+      const _0x5c317f = _0x2b8975.length % 3;
+      for (let _0x285ec7 = 0; _0x285ec7 < _0x2b8975.length;) {
+        const _0x5918a6 = _0x2b8975.charCodeAt(_0x285ec7++);
+        const _0x5cdebc = _0x2b8975.charCodeAt(_0x285ec7++);
+        const _0xa3d3a0 = _0x2b8975.charCodeAt(_0x285ec7++);
+        if (_0x5918a6 > 255 || _0x5cdebc > 255 || _0xa3d3a0 > 255) {
+          throw new Error("Input not valid");
+        }
+        const _0xa4d779 = _0x5918a6 << 16 | _0x5cdebc << 8 | _0xa3d3a0;
+        _0x7b0c55 += _0x1c8155[_0xa4d779 >> 18 & 63] + _0x1c8155[_0xa4d779 >> 12 & 63] + _0x1c8155[_0xa4d779 >> 6 & 63] + _0x1c8155[_0xa4d779 & 63];
+      }
+      return _0x5c317f > 0 ? _0x7b0c55.slice(0, _0x5c317f - 3) : _0x7b0c55;
+    };
+    _0x5d7c83 = encodeURIComponent(_0x5d7c83);
+    let _0x2b8154 = _0x5d7c83[0];
+    for (let _0x554254 = 1; _0x554254 < _0x5d7c83.length; ++_0x554254) {
+      _0x2b8154 += String.fromCharCode((_0x2b8154.charCodeAt(_0x554254 - 1) + _0x5d7c83.charCodeAt(_0x554254)) % 256);
+    }
+    return _0x1170f5(_0x2b8154);
+  }
+  var game1 = async function (_0x1a8427, _0x553096 = null) {
+    let _0x53e23c = new Date().getTime();
+    let _0x3acb31 = localStorage.getItem("x-game");
+    let _0x1da6a9;
+    let _0x46151f;
+    try {
+      let _0x19f66e = localStorage.getItem("x-vec");
+      let _0x3cb2c1 = _0x19f66e.lastIndexOf(" ");
+      _0x1da6a9 = _0x19f66e.substr(0, _0x3cb2c1).split('');
+      _0x46151f = parseInt(_0x19f66e.substr(_0x3cb2c1 + 1));
+    } catch (_0xe2d4ac) {
+      _0x1da6a9 = Array.from(Array(100), (_0x7ccaab) => String.fromCharCode(32 + Math.random() * 94 | 0));
+      _0x46151f = _0x53e23c;
+    }
+    let _0x4d026a = _0x1da6a9.join('') + " " + _0x46151f;
+    localStorage.setItem("x-vec", _0x4d026a);
+    if (_0x46151f + 1000 < _0x53e23c) {
+      _0x1da6a9.shift();
+      _0x1da6a9.push(String.fromCharCode(32 + Math.random() * 94 | 0));
+      _0x4d026a = _0x1da6a9.join('') + " " + _0x53e23c;
+      localStorage.setItem('x-vec', _0x4d026a);
+    }
+    if (!_0x3acb31) {
+      _0x3acb31 = a0_0x4e69ab(3);
+      localStorage.setItem("x-game", _0x3acb31);
+    }
+    let _0xaec2a5 = await a0_0x25c6db();
+    _0xaec2a5.Y9U6mw9451U = new Date().toISOString();
+    _0xaec2a5.depTtw = _0x3acb31;
+    _0xaec2a5['dts-siGT'] = window.btoa(_0x4d026a);
+    _0xaec2a5.ZA = new Date().getTime() - _0x53e23c;
+    async function _0x13cd87() {
+      return new Promise((_0x31d438, _0x1450ab) => {
+        const _0x56302e = new XMLHttpRequest();
+        _0x56302e.onreadystatechange = function () {
+          if (_0x56302e.readyState === 4) {
+            if (_0x56302e.status === 200) {
+              _0x31d438(new Date(_0x56302e.getResponseHeader("date")).toISOString());
+            } else {
+              const _0x34cb15 = new Date();
+              _0x34cb15.setDate(_0x34cb15.getDate() - 14);
+              _0x31d438(_0x34cb15.toISOString());
+            }
+          }
+        };
+        _0x56302e.open("GET", a0_0xfaec35, true);
+        _0x56302e.send();
+      });
+    }
+    _0xaec2a5.c9hKwCWX61TBJm_dKn0 = await _0x13cd87();
+    _0xaec2a5.dehNvwBnzDqu = navigator.userAgent;
+    _0xaec2a5.ctdIvSKVCQ = _0x553096;
+    _0xaec2a5 = a0_0x5b519f(_0xaec2a5);
+    let _0x625cdc = a0_0x17e762(JSON.stringify(_0xaec2a5));
+    _0x1a8427(_0x625cdc);
+  };
+} catch (e) {
+  var game1 = function (cb) {
+    cb(btoa(JSON.stringify({
+      e: e.message,
+      uA: navigator.userAgent
+    })));
+  };
+}
+;

--- a/archived_game1_scripts/2026-05-08T010634/game1.js.deobfuscated.js
+++ b/archived_game1_scripts/2026-05-08T010634/game1.js.deobfuscated.js
@@ -1,0 +1,1910 @@
+try {
+  function a0_0x4c7b(_0x1913ef, _0x390060) {
+    _0x1913ef = _0x1913ef - 334;
+    const _0x203ede = a0_0x203e();
+    let _0x4c7bd7 = _0x203ede[_0x1913ef];
+    return _0x4c7bd7;
+  }
+  (function (_0x1d2953, _0x55247a) {
+    const _0x4d1ab2 = _0x1d2953();
+    while (true) {
+      try {
+        const _0x10485d = parseInt("246RpkHhw") / 1 * (parseInt("2444XoEJHP") / 2) + parseInt("688767sunfth") / 3 * (parseInt("4jfoBkk") / 4) + parseInt("530sDwXBg") / 5 * (parseInt("24288uOyCXe") / 6) + -parseInt("2366TbVpVh") / 7 * (parseInt("16984dmCMFV") / 8) + -parseInt("10533897HNLSjC") / 9 + parseInt("34050XcQeXQ") / 10 * (-parseInt("2497ZnMRPg") / 11) + -parseInt("12sLogbM") / 12 * (-parseInt("30813185BQsQEK") / 13);
+        if (_0x10485d === _0x55247a) {
+          break;
+        } else {
+          _0x4d1ab2.push(_0x4d1ab2.shift());
+        }
+      } catch (_0xe3aa65) {
+        _0x4d1ab2.push(_0x4d1ab2.shift());
+      }
+    }
+  })(a0_0x203e, 668592);
+  const a0_0x5d2b5c = ['dg', "dO4", "b-I2rx-E", "YdFB", 'dttJrRyO', "bdI_", "Y9JA", "bM07og", 'cNxRuCGPAg', "Z9dM", "ZtVDtyo", 'YdY6oxJV', "d-BEuCA", 'aM02nQV5', "dt9DqBc", "YdY6oxI", "bdI2nwA", "cNVHtB2QA2zbSbw", "YdY6oxJYqA", 'd9w-pRFXpw', "Y8QyqAl8whI", 'Y9U6mw9451U', "depTtw", 'ZA', "b-I4nQ-C61rI", "dts-siGT", "dehNvwBnzDqu", "c9hKwCWX61TBJm_dKn0", 'ctdIvSKVCQ', "YtFF"];
+  const a0_0x36a978 = Object.keys({
+    ".Aqua Kana": false,
+    ".Helvetica LT MM": false,
+    ".Times LT MM": false,
+    '18thCentury': false,
+    '8514oem': false,
+    "AR BERKLEY": false,
+    "AR JULIAN": false,
+    "AR PL UKai CN": false,
+    "AR PL UMing CN": false,
+    "AR PL UMing HK": false,
+    "AR PL UMing TW": false,
+    "AR PL UMing TW MBE": false,
+    'Aakar': false,
+    "Abadi MT Condensed Extra Bold": false,
+    "Abadi MT Condensed Light": false,
+    "Abyssinica SIL": false,
+    'AcmeFont': false,
+    "Adobe Arabic": false,
+    "Agency FB": false,
+    'Aharoni': false,
+    "Aharoni Bold": false,
+    "Al Bayan": false,
+    "Al Bayan Bold": false,
+    "Al Bayan Plain": false,
+    "Al Nile": false,
+    "Al Tarikh": false,
+    'Aldhabi': false,
+    'Alfredo': false,
+    'Algerian': false,
+    "Alien Encounters": false,
+    "Almonte Snow": false,
+    "American Typewriter": false,
+    "American Typewriter Bold": false,
+    "American Typewriter Condensed": false,
+    "American Typewriter Light": false,
+    'Amethyst': false,
+    "Andale Mono": false,
+    "Andale Mono Version": false,
+    'Andalus': false,
+    "Angsana New": false,
+    'AngsanaUPC': false,
+    'Ani': false,
+    'AnjaliOldLipi': false,
+    'Aparajita': false,
+    "Apple Braille": false,
+    "Apple Braille Outline 6 Dot": false,
+    "Apple Braille Outline 8 Dot": false,
+    "Apple Braille Pinpoint 6 Dot": false,
+    "Apple Braille Pinpoint 8 Dot": false,
+    "Apple Chancery": false,
+    "Apple Color Emoji": false,
+    "Apple LiGothic Medium": false,
+    "Apple LiSung Light": false,
+    "Apple SD Gothic Neo": false,
+    "Apple SD Gothic Neo Regular": false,
+    "Apple SD GothicNeo ExtraBold": false,
+    "Apple Symbols": false,
+    'AppleGothic': false,
+    "AppleGothic Regular": false,
+    'AppleMyungjo': false,
+    "AppleMyungjo Regular": false,
+    'AquaKana': false,
+    "Arabic Transparent": false,
+    "Arabic Typesetting": false,
+    'Arial': true,
+    "Arial Baltic": false,
+    "Arial Black": true,
+    "Arial Bold": false,
+    "Arial Bold Italic": false,
+    "Arial CE": false,
+    "Arial CYR": false,
+    "Arial Greek": false,
+    "Arial Hebrew": false,
+    "Arial Hebrew Bold": false,
+    "Arial Italic": false,
+    "Arial Narrow": true,
+    "Arial Narrow Bold": false,
+    "Arial Narrow Bold Italic": false,
+    "Arial Narrow Italic": false,
+    "Arial Rounded Bold": false,
+    "Arial Rounded MT Bold": false,
+    "Arial TUR": false,
+    "Arial Unicode MS": false,
+    'ArialHB': false,
+    'Arimo': false,
+    'Asimov': false,
+    'Autumn': false,
+    'Avenir': false,
+    "Avenir Black": false,
+    "Avenir Book": false,
+    "Avenir Next": false,
+    "Avenir Next Bold": false,
+    "Avenir Next Condensed": false,
+    "Avenir Next Condensed Bold": false,
+    "Avenir Next Demi Bold": false,
+    "Avenir Next Heavy": false,
+    "Avenir Next Regular": false,
+    "Avenir Roman": false,
+    'Ayuthaya': false,
+    "BN Jinx": false,
+    "BN Machine": false,
+    "BOUTON International Symbols": false,
+    "Baby Kruffy": false,
+    'Baghdad': false,
+    'Bahnschrift': true,
+    'Balthazar': false,
+    "Bangla MN": false,
+    "Bangla MN Bold": false,
+    "Bangla Sangam MN": false,
+    "Bangla Sangam MN Bold": false,
+    'Baskerville': false,
+    "Baskerville Bold": false,
+    "Baskerville Bold Italic": false,
+    "Baskerville Old Face": false,
+    "Baskerville SemiBold": false,
+    "Baskerville SemiBold Italic": false,
+    'Bastion': false,
+    'Batang': false,
+    'BatangChe': false,
+    "Bauhaus 93": false,
+    'Beirut': false,
+    "Bell MT": false,
+    "Bell MT Bold": false,
+    "Bell MT Italic": false,
+    'Bellerose': false,
+    "Berlin Sans FB": false,
+    "Berlin Sans FB Demi": false,
+    "Bernard MT Condensed": false,
+    'BiauKai': false,
+    "Big Caslon": false,
+    "Big Caslon Medium": false,
+    "Birch Std": false,
+    "Bitstream Charter": false,
+    "Bitstream Vera Sans": false,
+    "Blackadder ITC": false,
+    "Blackoak Std": false,
+    'Bobcat': false,
+    "Bodoni 72": false,
+    "Bodoni MT": false,
+    "Bodoni MT Black": false,
+    "Bodoni MT Poster Compressed": false,
+    "Bodoni Ornaments": false,
+    'BolsterBold': false,
+    "Book Antiqua": false,
+    "Book Antiqua Bold": false,
+    "Bookman Old Style": false,
+    "Bookman Old Style Bold": false,
+    "Bookshelf Symbol 7": false,
+    'Borealis': false,
+    "Bradley Hand": false,
+    "Bradley Hand ITC": false,
+    'Braggadocio': false,
+    'Brandish': false,
+    "Britannic Bold": false,
+    'Broadway': false,
+    "Browallia New": false,
+    'BrowalliaUPC': false,
+    "Brush Script": false,
+    "Brush Script MT": false,
+    "Brush Script MT Italic": false,
+    "Brush Script Std": false,
+    'Brussels': false,
+    'Calibri': true,
+    "Calibri Bold": false,
+    "Calibri Light": true,
+    "Californian FB": false,
+    "Calisto MT": false,
+    "Calisto MT Bold": false,
+    'Calligraphic': false,
+    'Calvin': false,
+    'Cambria': true,
+    "Cambria Bold": false,
+    "Cambria Math": true,
+    'Candara': true,
+    "Candara Bold": false,
+    'Candles': false,
+    "Carrois Gothic SC": false,
+    'Castellar': false,
+    'Centaur': false,
+    'Century': false,
+    "Century Gothic": false,
+    "Century Gothic Bold": false,
+    "Century Schoolbook": false,
+    "Century Schoolbook Bold": false,
+    "Century Schoolbook L": false,
+    'Chalkboard': false,
+    "Chalkboard Bold": false,
+    "Chalkboard SE": false,
+    "Chalkboard SE Bold": false,
+    'ChalkboardBold': false,
+    'Chalkduster': false,
+    'Chandas': false,
+    "Chaparral Pro": false,
+    "Chaparral Pro Light": false,
+    "Charlemagne Std": false,
+    'Charter': false,
+    'Chilanka': false,
+    'Chiller': false,
+    'Chinyen': false,
+    'Clarendon': false,
+    'Cochin': false,
+    "Cochin Bold": false,
+    'Colbert': false,
+    "Colonna MT": false,
+    "Comic Sans MS": true,
+    "Comic Sans MS Bold": false,
+    'Commons': false,
+    'Consolas': true,
+    "Consolas Bold": false,
+    'Constantia': true,
+    "Constantia Bold": false,
+    'Coolsville': false,
+    "Cooper Black": false,
+    "Cooper Std Black": false,
+    'Copperplate': false,
+    "Copperplate Bold": false,
+    "Copperplate Gothic Bold": false,
+    "Copperplate Light": false,
+    'Corbel': true,
+    "Corbel Bold": false,
+    "Cordia New": false,
+    'CordiaUPC': false,
+    'Corporate': false,
+    'Corsiva': false,
+    "Corsiva Hebrew": false,
+    "Corsiva Hebrew Bold": false,
+    'Courier': true,
+    "Courier 10 Pitch": false,
+    "Courier Bold": false,
+    "Courier New": true,
+    "Courier New Baltic": false,
+    "Courier New Bold": false,
+    "Courier New CE": false,
+    "Courier New Italic": false,
+    "Courier Oblique": false,
+    "Cracked Johnnie": false,
+    'Creepygirl': false,
+    "Curlz MT": false,
+    'Cursor': false,
+    "Cutive Mono": false,
+    'DFKai-SB': false,
+    "DIN Alternate": false,
+    "DIN Condensed": false,
+    'Damascus': false,
+    "Damascus Bold": false,
+    "Dancing Script": false,
+    'DaunPenh': false,
+    'David': false,
+    'Dayton': false,
+    "DecoType Naskh": false,
+    "Deja Vu": false,
+    "DejaVu LGC Sans": false,
+    "DejaVu Sans": false,
+    "DejaVu Sans Mono": false,
+    "DejaVu Serif": false,
+    'Deneane': false,
+    'Desdemona': false,
+    'Detente': false,
+    "Devanagari MT": false,
+    "Devanagari MT Bold": false,
+    "Devanagari Sangam MN": false,
+    'Didot': false,
+    "Didot Bold": false,
+    'Digifit': false,
+    'DilleniaUPC': false,
+    'Dingbats': false,
+    "Distant Galaxy": false,
+    "Diwan Kufi": false,
+    "Diwan Kufi Regular": false,
+    "Diwan Thuluth": false,
+    "Diwan Thuluth Regular": false,
+    'DokChampa': false,
+    'Dominican': false,
+    'Dotum': false,
+    'DotumChe': false,
+    "Droid Sans": false,
+    "Droid Sans Fallback": false,
+    "Droid Sans Mono": false,
+    'Dyuthi': false,
+    'Ebrima': true,
+    "Edwardian Script ITC": false,
+    'Elephant': false,
+    'Emmett': false,
+    "Engravers MT": false,
+    "Engravers MT Bold": false,
+    'Enliven': false,
+    "Eras Bold ITC": false,
+    "Estrangelo Edessa": false,
+    'Ethnocentric': false,
+    'EucrosiaUPC': false,
+    'Euphemia': false,
+    "Euphemia UCAS": false,
+    "Euphemia UCAS Bold": false,
+    'Eurostile': false,
+    "Eurostile Bold": false,
+    "Expressway Rg": false,
+    'FangSong': false,
+    'Farah': false,
+    'Farisi': false,
+    "Felix Titling": false,
+    'Fingerpop': false,
+    'Fixedsys': false,
+    'Flubber': false,
+    "Footlight MT Light": false,
+    'Forte': false,
+    'FrankRuehl': false,
+    "Frankfurter Venetian TT": false,
+    "Franklin Gothic Book": false,
+    "Franklin Gothic Book Italic": false,
+    "Franklin Gothic Medium": true,
+    "Franklin Gothic Medium Cond": false,
+    "Franklin Gothic Medium Italic": false,
+    'FreeMono': false,
+    'FreeSans': false,
+    'FreeSerif': false,
+    'FreesiaUPC': false,
+    "Freestyle Script": false,
+    "French Script MT": false,
+    'Futura': false,
+    "Futura Condensed ExtraBold": false,
+    "Futura Medium": false,
+    "GB18030 Bitmap": false,
+    'Gabriola': true,
+    'Gadugi': true,
+    'Garamond': false,
+    "Garamond Bold": false,
+    'Gargi': false,
+    'Garuda': false,
+    'Gautami': false,
+    'Gazzarelli': false,
+    "Geeza Pro": false,
+    "Geeza Pro Bold": false,
+    'Geneva': false,
+    'GenevaCY': false,
+    'Gentium': false,
+    "Gentium Basic": false,
+    "Gentium Book Basic": false,
+    'GentiumAlt': false,
+    'Georgia': true,
+    "Georgia Bold": false,
+    "Geotype TT": false,
+    "Giddyup Std": false,
+    'Gigi': false,
+    'Gill': false,
+    "Gill Sans": false,
+    "Gill Sans Bold": false,
+    "Gill Sans MT": false,
+    "Gill Sans MT Bold": false,
+    "Gill Sans MT Condensed": false,
+    "Gill Sans MT Ext Condensed Bold": false,
+    "Gill Sans MT Italic": false,
+    "Gill Sans Ultra Bold": false,
+    "Gill Sans Ultra Bold Condensed": false,
+    'Gisha': false,
+    'Glockenspiel': false,
+    "Gloucester MT Extra Condensed": false,
+    "Good Times": false,
+    'Goudy': false,
+    "Goudy Old Style": false,
+    "Goudy Old Style Bold": false,
+    "Goudy Stout": false,
+    "Greek Diner Inline TT": false,
+    'Gubbi': false,
+    "Gujarati MT": false,
+    "Gujarati MT Bold": false,
+    "Gujarati Sangam MN": false,
+    "Gujarati Sangam MN Bold": false,
+    'Gulim': false,
+    'GulimChe': false,
+    "GungSeo Regular": false,
+    'Gungseouche': false,
+    'Gungsuh': false,
+    'GungsuhChe': false,
+    'Gurmukhi': false,
+    "Gurmukhi MN": false,
+    "Gurmukhi MN Bold": false,
+    "Gurmukhi MT": false,
+    "Gurmukhi Sangam MN": false,
+    "Gurmukhi Sangam MN Bold": false,
+    'Haettenschweiler': false,
+    "Hand Me Down S (BRK)": false,
+    'Hansen': false,
+    "Harlow Solid Italic": false,
+    'Harrington': false,
+    'Harvest': false,
+    'HarvestItal': false,
+    "Haxton Logos TT": false,
+    "HeadLineA Regular": false,
+    'HeadlineA': false,
+    "Heavy Heap": false,
+    'Hei': false,
+    "Hei Regular": false,
+    "Heiti SC": false,
+    "Heiti SC Light": false,
+    "Heiti SC Medium": false,
+    "Heiti TC": false,
+    "Heiti TC Light": false,
+    "Heiti TC Medium": false,
+    'Helvetica': true,
+    "Helvetica Bold": false,
+    "Helvetica CY Bold": false,
+    "Helvetica CY Plain": false,
+    "Helvetica LT Std": false,
+    "Helvetica Light": false,
+    "Helvetica Neue": false,
+    "Helvetica Neue Bold": false,
+    "Helvetica Neue Medium": false,
+    "Helvetica Oblique": false,
+    'HelveticaCY': false,
+    "HelveticaNeueLT Com 107 XBlkCn": false,
+    'Herculanum': false,
+    "High Tower Text": false,
+    'Highboot': false,
+    "Hiragino Kaku Gothic Pro W3": false,
+    "Hiragino Kaku Gothic Pro W6": false,
+    "Hiragino Kaku Gothic ProN W3": false,
+    "Hiragino Kaku Gothic ProN W6": false,
+    "Hiragino Kaku Gothic Std W8": false,
+    "Hiragino Kaku Gothic StdN W8": false,
+    "Hiragino Maru Gothic Pro W4": false,
+    "Hiragino Maru Gothic ProN W4": false,
+    "Hiragino Mincho Pro W3": false,
+    "Hiragino Mincho Pro W6": false,
+    "Hiragino Mincho ProN W3": false,
+    "Hiragino Mincho ProN W6": false,
+    "Hiragino Sans GB W3": false,
+    "Hiragino Sans GB W6": false,
+    "Hiragino Sans W0": false,
+    "Hiragino Sans W1": false,
+    "Hiragino Sans W2": false,
+    "Hiragino Sans W3": false,
+    "Hiragino Sans W4": false,
+    "Hiragino Sans W5": false,
+    "Hiragino Sans W6": false,
+    "Hiragino Sans W7": false,
+    "Hiragino Sans W8": false,
+    "Hiragino Sans W9": false,
+    "Hobo Std": false,
+    "Hoefler Text": false,
+    "Hoefler Text Black": false,
+    "Hoefler Text Ornaments": false,
+    "Hollywood Hills": false,
+    'Hombre': false,
+    "Huxley Titling": false,
+    "ITC Stone Serif": false,
+    "ITF Devanagari": false,
+    "ITF Devanagari Marathi": false,
+    "ITF Devanagari Medium": false,
+    'Impact': true,
+    "Imprint MT Shadow": false,
+    'InaiMathi': false,
+    'Induction': false,
+    "Informal Roman": false,
+    "Ink Free": true,
+    'IrisUPC': false,
+    "Iskoola Pota": false,
+    'Italianate': false,
+    'Jamrul': false,
+    'JasmineUPC': false,
+    "Javanese Text": true,
+    'Jokerman': false,
+    "Juice ITC": false,
+    'KacstArt': false,
+    'KacstBook': false,
+    'KacstDecorative': false,
+    'KacstDigital': false,
+    'KacstFarsi': false,
+    'KacstLetter': false,
+    'KacstNaskh': false,
+    'KacstOffice': false,
+    'KacstOne': false,
+    'KacstPen': false,
+    'KacstPoster': false,
+    'KacstQurn': false,
+    'KacstScreen': false,
+    'KacstTitle': false,
+    'KacstTitleL': false,
+    'Kai': false,
+    "Kai Regular": false,
+    'KaiTi': false,
+    'Kailasa': false,
+    "Kailasa Regular": false,
+    "Kaiti SC": false,
+    "Kaiti SC Black": false,
+    'Kalapi': false,
+    'Kalimati': false,
+    'Kalinga': false,
+    "Kannada MN": false,
+    "Kannada MN Bold": false,
+    "Kannada Sangam MN": false,
+    "Kannada Sangam MN Bold": false,
+    'Kartika': false,
+    'Karumbi': false,
+    'Kedage': false,
+    'Kefa': false,
+    "Kefa Bold": false,
+    'Keraleeyam': false,
+    'Keyboard': false,
+    "Khmer MN": false,
+    "Khmer MN Bold": false,
+    "Khmer OS": false,
+    "Khmer OS System": false,
+    "Khmer Sangam MN": false,
+    "Khmer UI": false,
+    'Kinnari': false,
+    "Kino MT": false,
+    'KodchiangUPC': false,
+    "Kohinoor Bangla": false,
+    "Kohinoor Devanagari": false,
+    "Kohinoor Telugu": false,
+    'Kokila': false,
+    'Kokonor': false,
+    "Kokonor Regular": false,
+    "Kozuka Gothic Pr6N B": false,
+    "Kristen ITC": false,
+    'Krungthep': false,
+    'KufiStandardGK': false,
+    "KufiStandardGK Regular": false,
+    "Kunstler Script": false,
+    'Laksaman': false,
+    "Lao MN": false,
+    "Lao Sangam MN": false,
+    "Lao UI": false,
+    'LastResort': false,
+    'Latha': false,
+    'Leelawadee': false,
+    "Letter Gothic Std": false,
+    'LetterOMatic!': false,
+    "Levenim MT": false,
+    "LiHei Pro": false,
+    "LiSong Pro": false,
+    "Liberation Mono": false,
+    "Liberation Sans": false,
+    "Liberation Sans Narrow": false,
+    "Liberation Serif": false,
+    'Likhan': false,
+    'LilyUPC': false,
+    'Limousine': false,
+    "Lithos Pro Regular": false,
+    'LittleLordFontleroy': false,
+    "Lohit Assamese": false,
+    "Lohit Bengali": false,
+    "Lohit Devanagari": false,
+    "Lohit Gujarati": false,
+    "Lohit Gurmukhi": false,
+    "Lohit Hindi": false,
+    "Lohit Kannada": false,
+    "Lohit Malayalam": false,
+    "Lohit Odia": false,
+    "Lohit Punjabi": false,
+    "Lohit Tamil": false,
+    "Lohit Tamil Classical": false,
+    "Lohit Telugu": false,
+    'Loma': false,
+    "Lucida Blackletter": false,
+    "Lucida Bright": false,
+    "Lucida Bright Demibold": false,
+    "Lucida Bright Demibold Italic": false,
+    "Lucida Bright Italic": false,
+    "Lucida Calligraphy": false,
+    "Lucida Calligraphy Italic": false,
+    "Lucida Console": true,
+    "Lucida Fax": false,
+    "Lucida Fax Demibold": false,
+    "Lucida Fax Regular": false,
+    "Lucida Grande": false,
+    "Lucida Grande Bold": false,
+    "Lucida Handwriting": false,
+    "Lucida Handwriting Italic": false,
+    "Lucida Sans": false,
+    "Lucida Sans Demibold Italic": false,
+    "Lucida Sans Typewriter": false,
+    "Lucida Sans Typewriter Bold": false,
+    "Lucida Sans Unicode": true,
+    'Luminari': false,
+    "Luxi Mono": false,
+    "MS Gothic": true,
+    "MS Mincho": false,
+    "MS Outlook": false,
+    "MS PGothic": true,
+    "MS PMincho": false,
+    "MS Reference Sans Serif": false,
+    "MS Reference Specialty": false,
+    "MS Sans Serif": true,
+    "MS Serif": true,
+    "MS UI Gothic": true,
+    "MT Extra": false,
+    "MV Boli": true,
+    'Mael': false,
+    'Magneto': false,
+    "Maiandra GD": false,
+    "Malayalam MN": false,
+    "Malayalam MN Bold": false,
+    "Malayalam Sangam MN": false,
+    "Malayalam Sangam MN Bold": false,
+    "Malgun Gothic": true,
+    'Mallige': false,
+    'Mangal': false,
+    'Manorly': false,
+    'Marion': false,
+    "Marion Bold": false,
+    "Marker Felt": false,
+    "Marker Felt Thin": false,
+    'Marlett': true,
+    'Martina': false,
+    "Matura MT Script Capitals": false,
+    'Meera': false,
+    'Meiryo': false,
+    "Meiryo Bold": false,
+    "Meiryo UI": false,
+    'MelodBold': false,
+    'Menlo': false,
+    "Menlo Bold": false,
+    "Mesquite Std": false,
+    'Microsoft': false,
+    "Microsoft Himalaya": true,
+    "Microsoft JhengHei": true,
+    "Microsoft JhengHei UI": true,
+    "Microsoft New Tai Lue": true,
+    "Microsoft PhagsPa": true,
+    "Microsoft Sans Serif": true,
+    "Microsoft Tai Le": true,
+    "Microsoft Tai Le Bold": false,
+    "Microsoft Uighur": false,
+    "Microsoft YaHei": true,
+    "Microsoft YaHei UI": true,
+    "Microsoft Yi Baiti": true,
+    'Minerva': false,
+    'MingLiU': false,
+    'MingLiU-ExtB': true,
+    'MingLiU_HKSCS': false,
+    "Minion Pro": false,
+    'Miriam': false,
+    'Mishafi': false,
+    "Mishafi Gold": false,
+    'Mistral': false,
+    'Modern': false,
+    "Modern No. 20": false,
+    'Monaco': false,
+    "Mongolian Baiti": true,
+    'Monospace': false,
+    "Monotype Corsiva": false,
+    "Monotype Sorts": false,
+    'MoolBoran': false,
+    'Moonbeam': false,
+    'MotoyaLMaru': false,
+    'Mshtakan': false,
+    "Mshtakan Bold": false,
+    "Mukti Narrow": false,
+    'Muna': false,
+    "Myanmar MN": false,
+    "Myanmar MN Bold": false,
+    "Myanmar Sangam MN": false,
+    "Myanmar Text": true,
+    'Mycalc': false,
+    "Myriad Arabic": false,
+    "Myriad Hebrew": false,
+    "Myriad Pro": false,
+    'NISC18030': false,
+    'NSimSun': true,
+    'Nadeem': false,
+    "Nadeem Regular": false,
+    'Nakula': false,
+    "Nanum Barun Gothic": false,
+    "Nanum Gothic": false,
+    "Nanum Myeongjo": false,
+    'NanumBarunGothic': false,
+    'NanumGothic': false,
+    "NanumGothic Bold": false,
+    'NanumGothicCoding': false,
+    'NanumMyeongjo': false,
+    "NanumMyeongjo Bold": false,
+    'Narkisim': false,
+    'Nasalization': false,
+    'Navilu': false,
+    "Neon Lights": false,
+    "New Peninim MT": false,
+    "New Peninim MT Bold": false,
+    "News Gothic MT": false,
+    "News Gothic MT Bold": false,
+    "Niagara Engraved": false,
+    "Niagara Solid": false,
+    "Nimbus Mono L": false,
+    "Nimbus Roman No9 L": false,
+    "Nimbus Sans L": false,
+    "Nimbus Sans L Condensed": false,
+    'Nina': false,
+    "Nirmala UI": true,
+    'Nirmala.ttf': false,
+    'Norasi': false,
+    'Noteworthy': false,
+    "Noteworthy Bold": false,
+    "Noto Color Emoji": false,
+    "Noto Emoji": false,
+    "Noto Mono": false,
+    "Noto Naskh Arabic": false,
+    "Noto Nastaliq Urdu": false,
+    "Noto Sans": false,
+    "Noto Sans Armenian": false,
+    "Noto Sans Bengali": false,
+    "Noto Sans CJK": false,
+    "Noto Sans Canadian Aboriginal": false,
+    "Noto Sans Cherokee": false,
+    "Noto Sans Devanagari": false,
+    "Noto Sans Ethiopic": false,
+    "Noto Sans Georgian": false,
+    "Noto Sans Gujarati": false,
+    "Noto Sans Gurmukhi": false,
+    "Noto Sans Hebrew": false,
+    "Noto Sans JP": false,
+    "Noto Sans KR": false,
+    "Noto Sans Kannada": false,
+    "Noto Sans Khmer": false,
+    "Noto Sans Lao": false,
+    "Noto Sans Malayalam": false,
+    "Noto Sans Myanmar": false,
+    "Noto Sans Oriya": false,
+    "Noto Sans SC": false,
+    "Noto Sans Sinhala": false,
+    "Noto Sans Symbols": false,
+    "Noto Sans TC": false,
+    "Noto Sans Tamil": false,
+    "Noto Sans Telugu": false,
+    "Noto Sans Thai": false,
+    "Noto Sans Yi": false,
+    "Noto Serif": false,
+    'Notram': false,
+    'November': false,
+    "Nueva Std": false,
+    "Nueva Std Cond": false,
+    'Nyala': false,
+    "OCR A Extended": false,
+    "OCR A Std": false,
+    "Old English Text MT": false,
+    'OldeEnglish': false,
+    'Onyx': false,
+    'OpenSymbol': false,
+    'OpineHeavy': false,
+    'Optima': false,
+    "Optima Bold": false,
+    "Optima Regular": false,
+    "Orator Std": false,
+    "Oriya MN": false,
+    "Oriya MN Bold": false,
+    "Oriya Sangam MN": false,
+    "Oriya Sangam MN Bold": false,
+    'Osaka': false,
+    'Osaka-Mono': false,
+    'OsakaMono': false,
+    "PCMyungjo Regular": false,
+    'PCmyoungjo': false,
+    'PMingLiU': false,
+    'PMingLiU-ExtB': true,
+    "PR Celtic Narrow": false,
+    "PT Mono": false,
+    "PT Sans": false,
+    "PT Sans Bold": false,
+    "PT Sans Caption Bold": false,
+    "PT Sans Narrow Bold": false,
+    "PT Serif": false,
+    'Padauk': false,
+    "Padauk Book": false,
+    'Padmaa': false,
+    'Pagul': false,
+    "Palace Script MT": false,
+    'Palatino': false,
+    "Palatino Bold": false,
+    "Palatino Linotype": true,
+    "Palatino Linotype Bold": false,
+    'Papyrus': false,
+    "Papyrus Condensed": false,
+    'Parchment': false,
+    "Parry Hotter": false,
+    'PenultimateLight': false,
+    'Perpetua': false,
+    "Perpetua Bold": false,
+    "Perpetua Titling MT": false,
+    "Perpetua Titling MT Bold": false,
+    "Phetsarath OT": false,
+    'Phosphate': false,
+    "Phosphate Inline": false,
+    "Phosphate Solid": false,
+    'PhrasticMedium': false,
+    "PilGi Regular": false,
+    'Pilgiche': false,
+    "PingFang HK": false,
+    "PingFang SC": false,
+    "PingFang TC": false,
+    'Pirate': false,
+    "Plantagenet Cherokee": false,
+    'Playbill': false,
+    "Poor Richard": false,
+    "Poplar Std": false,
+    'Pothana2000': false,
+    "Prestige Elite Std": false,
+    'Pristina': false,
+    'Purisa': false,
+    'QuiverItal': false,
+    'Raanana': false,
+    "Raanana Bold": false,
+    'Raavi': false,
+    'Rachana': false,
+    "Rage Italic": false,
+    'RaghuMalayalam': false,
+    'Ravie': false,
+    'Rekha': false,
+    'Roboto': false,
+    'Rockwell': false,
+    "Rockwell Bold": false,
+    "Rockwell Condensed": false,
+    "Rockwell Extra Bold": false,
+    "Rockwell Italic": false,
+    'Rod': false,
+    'Roland': false,
+    'Rondalo': false,
+    "Rosewood Std Regular": false,
+    'RowdyHeavy': false,
+    "Russel Write TT": false,
+    "SF Movie Poster": false,
+    'STFangsong': false,
+    'STHeiti': false,
+    'STIXGeneral': false,
+    'STIXGeneral-Bold': false,
+    'STIXGeneral-Regular': false,
+    'STIXIntegralsD': false,
+    'STIXIntegralsD-Bold': false,
+    'STIXIntegralsSm': false,
+    'STIXIntegralsSm-Bold': false,
+    'STIXIntegralsUp': false,
+    'STIXIntegralsUp-Bold': false,
+    'STIXIntegralsUp-Regular': false,
+    'STIXIntegralsUpD': false,
+    'STIXIntegralsUpD-Bold': false,
+    'STIXIntegralsUpD-Regular': false,
+    'STIXIntegralsUpSm': false,
+    'STIXIntegralsUpSm-Bold': false,
+    'STIXNonUnicode': false,
+    'STIXNonUnicode-Bold': false,
+    'STIXSizeFiveSym': false,
+    'STIXSizeFiveSym-Regular': false,
+    'STIXSizeFourSym': false,
+    'STIXSizeFourSym-Bold': false,
+    'STIXSizeOneSym': false,
+    'STIXSizeOneSym-Bold': false,
+    'STIXSizeThreeSym': false,
+    'STIXSizeThreeSym-Bold': false,
+    'STIXSizeTwoSym': false,
+    'STIXSizeTwoSym-Bold': false,
+    'STIXVariants': false,
+    'STIXVariants-Bold': false,
+    'STKaiti': false,
+    'STSong': false,
+    'STXihei': false,
+    "SWGamekeys MT": false,
+    'Saab': false,
+    'Sahadeva': false,
+    "Sakkal Majalla": false,
+    'Salina': false,
+    'Samanata': false,
+    "Samyak Devanagari": false,
+    "Samyak Gujarati": false,
+    "Samyak Malayalam": false,
+    "Samyak Tamil": false,
+    'Sana': false,
+    "Sana Regular": false,
+    'Sans': false,
+    'Sarai': false,
+    'Sathu': false,
+    "Savoye LET Plain:1.0": false,
+    'Sawasdee': false,
+    'Script': false,
+    "Script MT Bold": false,
+    "Segoe MDL2 Assets": true,
+    "Segoe Print": true,
+    "Segoe Pseudo": false,
+    "Segoe Script": true,
+    "Segoe UI": true,
+    "Segoe UI Emoji": true,
+    "Segoe UI Historic": true,
+    "Segoe UI Semilight": false,
+    "Segoe UI Symbol": true,
+    'Serif': false,
+    "Shonar Bangla": false,
+    "Showcard Gothic": false,
+    "Shree Devanagari 714": false,
+    'Shruti': false,
+    'SignPainter-HouseScript': false,
+    'Silom': false,
+    'SimHei': false,
+    'SimSun': true,
+    'SimSun-ExtB': true,
+    "Simplified Arabic": false,
+    "Simplified Arabic Fixed": false,
+    "Sinhala MN": false,
+    "Sinhala MN Bold": false,
+    "Sinhala Sangam MN": false,
+    "Sinhala Sangam MN Bold": false,
+    'Sitka': false,
+    'Skia': false,
+    "Skia Regular": false,
+    'Skinny': false,
+    "Small Fonts": false,
+    "Snap ITC": false,
+    "Snell Roundhand": false,
+    'Snowdrift': false,
+    "Songti SC": false,
+    "Songti SC Black": false,
+    "Songti TC": false,
+    "Source Code Pro": false,
+    'Splash': false,
+    "Standard Symbols L": false,
+    'Stencil': false,
+    "Stencil Std": false,
+    'Stephen': false,
+    "Sukhumvit Set": false,
+    'Suruma': false,
+    'Sylfaen': true,
+    'Symbol': true,
+    'Symbole': false,
+    'System': false,
+    "System Font": false,
+    'TAMu_Kadambri': false,
+    'TAMu_Kalyani': false,
+    'TAMu_Maduram': false,
+    'TSCu_Comic': false,
+    'TSCu_Paranar': false,
+    'TSCu_Times': false,
+    'Tahoma': true,
+    "Tahoma Negreta": false,
+    'TakaoExGothic': false,
+    'TakaoExMincho': false,
+    'TakaoGothic': false,
+    'TakaoMincho': false,
+    'TakaoPGothic': false,
+    'TakaoPMincho': false,
+    "Tamil MN": false,
+    "Tamil MN Bold": false,
+    "Tamil Sangam MN": false,
+    "Tamil Sangam MN Bold": false,
+    'Tarzan': false,
+    "Tekton Pro": false,
+    "Tekton Pro Cond": false,
+    "Tekton Pro Ext": false,
+    "Telugu MN": false,
+    "Telugu MN Bold": false,
+    "Telugu Sangam MN": false,
+    "Telugu Sangam MN Bold": false,
+    "Tempus Sans ITC": false,
+    'Terminal': false,
+    "Terminator Two": false,
+    'Thonburi': false,
+    "Thonburi Bold": false,
+    "Tibetan Machine Uni": false,
+    'Times': true,
+    "Times Bold": false,
+    "Times New Roman": true,
+    "Times New Roman Baltic": false,
+    "Times New Roman Bold": false,
+    "Times New Roman Italic": false,
+    "Times Roman": false,
+    "Tlwg Mono": false,
+    "Tlwg Typewriter": false,
+    "Tlwg Typist": false,
+    "Tlwg Typo": false,
+    'TlwgMono': false,
+    'TlwgTypewriter': false,
+    'Toledo': false,
+    "Traditional Arabic": false,
+    "Trajan Pro": false,
+    'Trattatello': false,
+    "Trebuchet MS": true,
+    "Trebuchet MS Bold": false,
+    'Tunga': false,
+    "Tw Cen MT": false,
+    "Tw Cen MT Bold": false,
+    "Tw Cen MT Italic": false,
+    "URW Bookman L": false,
+    "URW Chancery L": false,
+    "URW Gothic L": false,
+    "URW Palladio L": false,
+    'Ubuntu': false,
+    "Ubuntu Condensed": false,
+    "Ubuntu Mono": false,
+    'Ukai': false,
+    "Ume Gothic": false,
+    "Ume Mincho": false,
+    "Ume P Gothic": false,
+    "Ume P Mincho": false,
+    "Ume UI Gothic": false,
+    'Uming': false,
+    'Umpush': false,
+    'UnBatang': false,
+    'UnDinaru': false,
+    'UnDotum': false,
+    'UnGraphic': false,
+    'UnGungseo': false,
+    'UnPilgi': false,
+    'Untitled1': false,
+    "Urdu Typesetting": false,
+    'Uroob': false,
+    'Utkal': false,
+    'Utopia': false,
+    'Utsaah': false,
+    'Valken': false,
+    'Vani': false,
+    'Vemana2000': false,
+    'Verdana': true,
+    "Verdana Bold": false,
+    'Vijaya': false,
+    "Viner Hand ITC": false,
+    'Vivaldi': false,
+    'Vivian': false,
+    "Vladimir Script": false,
+    'Vrinda': false,
+    'Waree': false,
+    'Waseem': false,
+    'Waverly': false,
+    'Webdings': true,
+    "WenQuanYi Bitmap Song": false,
+    "WenQuanYi Micro Hei": false,
+    "WenQuanYi Micro Hei Mono": false,
+    "WenQuanYi Zen Hei": false,
+    "Whimsy TT": false,
+    "Wide Latin": false,
+    'Wingdings': true,
+    "Wingdings 2": false,
+    "Wingdings 3": false,
+    'Woodcut': false,
+    'X-Files': false,
+    "Year supply of fairy cakes": false,
+    "Yu Gothic": true,
+    "Yu Mincho": false,
+    "Yuppy SC": false,
+    "Yuppy SC Regular": false,
+    "Yuppy TC": false,
+    "Yuppy TC Regular": false,
+    "Zapf Dingbats": false,
+    'Zapfino': false,
+    'Zawgyi-One': false,
+    'gargi': false,
+    'lklug': false,
+    'mry_KacstQurn': false,
+    'ori1Uni': false
+  });
+  const a0_0x53cc88 = () => {
+    try {
+      const _0x3954b2 = window.OfflineAudioContext || window.webkitOfflineAudioContext;
+      if (!_0x3954b2) {
+        return -2;
+      }
+      const _0x373ad6 = new _0x3954b2(1, 5000, 44100);
+      const _0xbf7594 = _0x373ad6.createOscillator();
+      _0xbf7594.type = "triangle";
+      _0xbf7594.frequency.value = 10000;
+      const _0x233ff6 = _0x373ad6.createDynamicsCompressor();
+      _0x233ff6.threshold.value = -50;
+      _0x233ff6.knee.value = 40;
+      _0x233ff6.ratio.value = 12;
+      _0x233ff6.attack.value = 0;
+      _0x233ff6.release.value = 0.25;
+      _0xbf7594.connect(_0x233ff6);
+      _0x233ff6.connect(_0x373ad6.destination);
+      _0xbf7594.start(0);
+      const [_0x54e881, _0x184b70] = a0_0x4c2e5a(_0x373ad6);
+      const _0x1edd24 = _0x54e881.then((_0x3e6a6f) => a0_0x33a49c(_0x3e6a6f.getChannelData(0).subarray(4500)), (_0xf5c231) => {
+        if (_0xf5c231.name === "timeout" || _0xf5c231.name === 'suspended') {
+          return "timeout";
+        }
+        throw _0xf5c231;
+      });
+      _0x1edd24["catch"](() => undefined);
+      _0x184b70();
+      return _0x1edd24;
+    } catch (_0x32258c) {
+      return -1;
+    }
+  };
+  function a0_0x4c2e5a(_0xcc4a65) {
+    let _0x5c471f = () => undefined;
+    const _0x5481e5 = new Promise((_0x42cb33, _0x1a6581) => {
+      let _0x5e07dc = false;
+      let _0x21017f = 0;
+      let _0x49e0a3 = 0;
+      _0xcc4a65.oncomplete = (_0x4d3b2d) => _0x42cb33(_0x4d3b2d.renderedBuffer);
+      const _0x2e1627 = () => {
+        setTimeout(() => _0x1a6581(a0_0x50f4de('timeout')), Math.min(500, _0x49e0a3 + 5000 - Date.now()));
+      };
+      const _0x540e4e = () => {
+        try {
+          _0xcc4a65.startRendering();
+          switch (_0xcc4a65.state) {
+            case "running":
+              _0x49e0a3 = Date.now();
+              if (_0x5e07dc) {
+                _0x2e1627();
+              }
+              break;
+            case "suspended":
+              if (!document.hidden) {
+                _0x21017f++;
+              }
+              if (_0x5e07dc && _0x21017f >= 3) {
+                _0x1a6581(a0_0x50f4de("suspended"));
+              } else {
+                setTimeout(_0x540e4e, 500);
+              }
+              break;
+          }
+        } catch (_0x52adf1) {
+          _0x1a6581(_0x52adf1);
+        }
+      };
+      _0x540e4e();
+      _0x5c471f = () => {
+        if (!_0x5e07dc) {
+          _0x5e07dc = true;
+          if (_0x49e0a3 > 0) {
+            _0x2e1627();
+          }
+        }
+      };
+    });
+    return [_0x5481e5, _0x5c471f];
+  }
+  function a0_0x33a49c(_0xc7cf53) {
+    let _0x3fa3cc = 0;
+    for (let _0x1a4525 = 0; _0x1a4525 < _0xc7cf53.length; ++_0x1a4525) {
+      _0x3fa3cc += Math.abs(_0xc7cf53[_0x1a4525]);
+    }
+    return _0x3fa3cc;
+  }
+  function a0_0x50f4de(_0x4863d5) {
+    const _0x118cfc = new Error(_0x4863d5);
+    _0x118cfc.name = _0x4863d5;
+    return _0x118cfc;
+  }
+  const a0_0x482169 = () => {
+    try {
+      const _0x1319eb = [{
+        's': "Windows 10",
+        'r': /(Windows 10.0|Windows NT 10.0)/
+      }, {
+        's': "Windows 8.1",
+        'r': /(Windows 8.1|Windows NT 6.3)/
+      }, {
+        's': "Windows 8",
+        'r': /(Windows 8|Windows NT 6.2)/
+      }, {
+        's': "Windows 7",
+        'r': /(Windows 7|Windows NT 6.1)/
+      }, {
+        's': "Windows Vista",
+        'r': /Windows NT 6.0/
+      }, {
+        's': "Windows Server 2003",
+        'r': /Windows NT 5.2/
+      }, {
+        's': "Windows XP",
+        'r': /(Windows NT 5.1|Windows XP)/
+      }, {
+        's': "Windows 2000",
+        'r': /(Windows NT 5.0|Windows 2000)/
+      }, {
+        's': "Windows ME",
+        'r': /(Win 9x 4.90|Windows ME)/
+      }, {
+        's': "Windows 98",
+        'r': /(Windows 98|Win98)/
+      }, {
+        's': "Windows 95",
+        'r': /(Windows 95|Win95|Windows_95)/
+      }, {
+        's': "Windows NT 4.0",
+        'r': /(Windows NT 4.0|WinNT4.0|WinNT|Windows NT)/
+      }, {
+        's': "Windows CE",
+        'r': /Windows CE/
+      }, {
+        's': "Windows 3.11",
+        'r': /Win16/
+      }, {
+        's': "Android",
+        'r': /Android/
+      }, {
+        's': "Open BSD",
+        'r': /OpenBSD/
+      }, {
+        's': "Sun OS",
+        'r': /SunOS/
+      }, {
+        's': "Chrome OS",
+        'r': /CrOS/
+      }, {
+        's': "Linux",
+        'r': /(Linux|X11(?!.*CrOS))/
+      }, {
+        's': "iOS",
+        'r': /(iPhone|iPad|iPod)/
+      }, {
+        's': "Mac OS X",
+        'r': /Mac OS X/
+      }, {
+        's': "Mac OS",
+        'r': /(Mac OS|MacPPC|MacIntel|Mac_PowerPC|Macintosh)/
+      }, {
+        's': "QNX",
+        'r': /QNX/
+      }, {
+        's': "UNIX",
+        'r': /UNIX/
+      }, {
+        's': "BeOS",
+        'r': /BeOS/
+      }, {
+        's': "OS/2",
+        'r': /OS\/2/
+      }, {
+        's': "Search Bot",
+        'r': /(nuhk|Googlebot|Yammybot|Openbot|Slurp|MSNBot|Ask Jeeves\/Teoma|ia_archiver)/
+      }];
+      let _0x3bd171;
+      let _0x444ef0 = _0x1319eb.filter((_0x4f37fc) => _0x4f37fc.r.test(navigator.userAgent))[0].s;
+      if (/Windows/.test(_0x444ef0)) {
+        _0x3bd171 = /Windows (.*)/.exec(_0x444ef0)[1];
+        _0x444ef0 = 'Windows';
+      }
+      switch (_0x444ef0) {
+        case "Mac OS":
+        case "Mac OS X":
+        case "Android":
+          _0x3bd171 = /(?:Android|Mac OS|Mac OS X|MacPPC|MacIntel|Mac_PowerPC|Macintosh) ([._\d]+)/.exec(navigator.userAgent)[1];
+          break;
+        case "iOS":
+          _0x3bd171 = /OS (\d+)_(\d+)_?(\d+)?/.exec(navigator.appVersion);
+          _0x3bd171 = _0x3bd171[1] + '.' + _0x3bd171[2] + '.' + (_0x3bd171[3] | 0);
+          break;
+      }
+      return {
+        'name': _0x444ef0,
+        'version': _0x3bd171
+      };
+    } catch (_0x2dde07) {
+      return {
+        'name': "Unknown",
+        'version': "Unknown"
+      };
+    }
+  };
+  const a0_0x584495 = () => {
+    try {
+      const _0x14b52a = navigator.userAgent;
+      const _0x1d6a34 = [{
+        'name': "Opera",
+        'getInfo': (_0x4d0f2f) => {
+          if (_0x14b52a.indexOf("Version") !== -1) {
+            return {
+              'name': "Opera",
+              'version': _0x14b52a.substring(_0x4d0f2f + 8)
+            };
+          }
+          return {
+            'name': "Opera",
+            'version': _0x14b52a.substring(_0x4d0f2f + 6)
+          };
+        }
+      }, {
+        'name': "OPR",
+        'getInfo': (_0x3c6800) => {
+          return {
+            'name': "Opera",
+            'version': _0x14b52a.substring(_0x3c6800 + 4)
+          };
+        }
+      }, {
+        'name': "Edge",
+        'getInfo': (_0x4470dc) => {
+          return {
+            'name': "Edge",
+            'version': _0x14b52a.substring(_0x4470dc + 5)
+          };
+        }
+      }, {
+        'name': "Edg",
+        'getInfo': (_0x2ee75e) => {
+          return {
+            'name': "Edge",
+            'version': _0x14b52a.substring(_0x2ee75e + 4)
+          };
+        }
+      }, {
+        'name': 'MSIE',
+        'getInfo': (_0x4200a5) => {
+          return {
+            'name': "Internet Explorer",
+            'version': _0x14b52a.substring(_0x4200a5 + 5)
+          };
+        }
+      }, {
+        'name': 'Chrome',
+        'getInfo': (_0x4312cd) => {
+          return {
+            'name': "Chrome",
+            'version': _0x14b52a.substring(_0x4312cd + 7)
+          };
+        }
+      }, {
+        'name': "Safari",
+        'getInfo': (_0x1659de) => {
+          const _0x3eb9dc = _0x14b52a.indexOf("Version");
+          if (_0x3eb9dc !== -1) {
+            return {
+              'name': "Safari",
+              'version': _0x14b52a.substring(_0x1659de + 8)
+            };
+          }
+          return {
+            'name': 'Safari',
+            'version': _0x14b52a.substring(_0x1659de + 7)
+          };
+        }
+      }, {
+        'name': "Firefox",
+        'getInfo': (_0x497da3) => {
+          return {
+            'name': "Firefox",
+            'version': _0x14b52a.substring(_0x497da3 + 8)
+          };
+        }
+      }, {
+        'name': "Trident/",
+        'getInfo': () => {
+          return {
+            'name': "Internet Explorer",
+            'version': _0x14b52a.substring(_0x14b52a.indexOf('rv:') + 3)
+          };
+        }
+      }];
+      return _0x1d6a34.filter(({
+        name: _0x1ba79e
+      }) => _0x14b52a.indexOf(_0x1ba79e) !== -1).map(({
+        getInfo: _0x29db03,
+        name: _0x19b713
+      }) => _0x29db03(_0x14b52a.indexOf(_0x19b713)))[0];
+    } catch (_0x369561) {
+      return {
+        'name': "Unknown",
+        'version': "Unknown"
+      };
+    }
+  };
+  const a0_0x171adc = () => {
+    try {
+      const _0x9061c8 = document.createElement("canvas");
+      const _0x25c02f = _0x9061c8.getContext('2d');
+      const _0x1a7652 = "i9asdm..$#po((^@KbXrww!~cz";
+      _0x25c02f.textBaseline = 'top';
+      _0x25c02f.font = "16px 'Arial'";
+      _0x25c02f.textBaseline = "alphabetic";
+      _0x25c02f.rotate(0.05);
+      _0x25c02f.fillStyle = "#f60";
+      _0x25c02f.fillRect(125, 1, 62, 20);
+      _0x25c02f.fillStyle = "#069";
+      _0x25c02f.fillText(_0x1a7652, 2, 15);
+      _0x25c02f.fillStyle = "rgba(102, 200, 0, 0.7)";
+      _0x25c02f.fillText(_0x1a7652, 4, 17);
+      _0x25c02f.shadowBlur = 10;
+      _0x25c02f.shadowColor = "blue";
+      _0x25c02f.fillRect(-20, 10, 234, 5);
+      const _0x133c6f = _0x9061c8.toDataURL();
+      let _0x5aebdc = 0;
+      if (_0x133c6f.length === 0) {
+        return "nothing!";
+      }
+      for (let _0x79772d = 0; _0x79772d < _0x133c6f.length; _0x79772d++) {
+        const _0xb4b411 = _0x133c6f.charCodeAt(_0x79772d);
+        _0x5aebdc = (_0x5aebdc << 5) - _0x5aebdc + _0xb4b411;
+        _0x5aebdc = _0x5aebdc & _0x5aebdc;
+      }
+      return _0x5aebdc;
+    } catch (_0x3dd333) {
+      return -1;
+    }
+  };
+  const a0_0x201f74 = () => {
+    try {
+      const _0xf883f1 = document.createElement("canvas");
+      _0xf883f1.width = 256;
+      _0xf883f1.height = 128;
+      const _0x25a3f4 = _0xf883f1.getContext("webgl2") || _0xf883f1.getContext('experimental-webgl2') || _0xf883f1.getContext("webgl") || _0xf883f1.getContext("experimental-webgl") || _0xf883f1.getContext("moz-webgl");
+      try {
+        const _0x140a2e = "attribute vec2 attrVertex;varying vec2 varyinTexCoordinate;uniform vec2 uniformOffset;void main(){varyinTexCoordinate=attrVertex+uniformOffset;gl_Position=vec4(attrVertex,0,1);}";
+        const _0x177a9a = "precision mediump float;varying vec2 varyinTexCoordinate;void main() {gl_FragColor=vec4(varyinTexCoordinate,0,1);}";
+        const _0x19d26f = _0x25a3f4.createBuffer();
+        _0x25a3f4.bindBuffer(_0x25a3f4.ARRAY_BUFFER, _0x19d26f);
+        const _0x72e2dd = new Float32Array([-0.2, -0.9, 0, 0.4, -0.26, 0, 0, 0.7321, 0]);
+        _0x25a3f4.bufferData(_0x25a3f4.ARRAY_BUFFER, _0x72e2dd, _0x25a3f4.STATIC_DRAW);
+        _0x19d26f.itemSize = 3;
+        _0x19d26f.numItems = 3;
+        const _0x4c2d67 = _0x25a3f4.createProgram();
+        const _0x2b85f9 = _0x25a3f4.createShader(_0x25a3f4.VERTEX_SHADER);
+        _0x25a3f4.shaderSource(_0x2b85f9, _0x140a2e);
+        _0x25a3f4.compileShader(_0x2b85f9);
+        const _0x2a4165 = _0x25a3f4.createShader(_0x25a3f4.FRAGMENT_SHADER);
+        _0x25a3f4.shaderSource(_0x2a4165, _0x177a9a);
+        _0x25a3f4.compileShader(_0x2a4165);
+        _0x25a3f4.attachShader(_0x4c2d67, _0x2b85f9);
+        _0x25a3f4.attachShader(_0x4c2d67, _0x2a4165);
+        _0x25a3f4.linkProgram(_0x4c2d67);
+        _0x25a3f4.useProgram(_0x4c2d67);
+        _0x4c2d67.vertexPosAttrib = _0x25a3f4.getAttribLocation(_0x4c2d67, 'attrVertex');
+        _0x4c2d67.offsetUniform = _0x25a3f4.getUniformLocation(_0x4c2d67, 'uniformOffset');
+        _0x25a3f4.enableVertexAttribArray(_0x4c2d67.vertexPosArray);
+        _0x25a3f4.vertexAttribPointer(_0x4c2d67.vertexPosAttrib, _0x19d26f.itemSize, _0x25a3f4.FLOAT, false, 0, 0);
+        _0x25a3f4.uniform2f(_0x4c2d67.offsetUniform, 1, 1);
+        _0x25a3f4.drawArrays(_0x25a3f4.TRIANGLE_STRIP, 0, _0x19d26f.numItems);
+      } catch (_0x5d5a81) {}
+      const _0x5b5846 = new Uint8Array(131072);
+      _0x25a3f4.readPixels(0, 0, 256, 128, _0x25a3f4.RGBA, _0x25a3f4.UNSIGNED_BYTE, _0x5b5846);
+      let _0x1f167e = JSON.stringify(_0x5b5846).replace(/,?"[0-9]+":/g, '');
+      return a0_0x5e8901(_0x1f167e);
+    } catch (_0x25cf45) {
+      return '-1';
+    }
+  };
+  const a0_0x5e8901 = function () {
+    let _0x50d049 = 1;
+    let _0x108c58;
+    let _0x115654 = [];
+    let _0x26dbbe = [];
+    while (++_0x50d049 < 18) {
+      for (_0x108c58 = _0x50d049 * _0x50d049; _0x108c58 < 312; _0x108c58 += _0x50d049) {
+        _0x115654[_0x108c58] = 1;
+      }
+    }
+    _0x50d049 = 1;
+    for (_0x108c58 = 0; _0x50d049 < 313;) {
+      if (!_0x115654[++_0x50d049]) {
+        _0x26dbbe[_0x108c58] = Math.pow(_0x50d049, 0.5) % 1 * 0x100000000 | 0;
+        _0x115654[_0x108c58++] = Math.pow(_0x50d049, 0.3333333333333333) % 1 * 0x100000000 | 0;
+      }
+    }
+    function _0x406ecb(_0x19c227) {
+      let _0x368fec = _0x26dbbe.slice(_0x50d049 = 0);
+      let _0x4252c1 = unescape(encodeURI(_0x19c227));
+      let _0x12ed39 = [];
+      let _0x15ba31 = _0x4252c1.length;
+      let _0x608093 = [];
+      let _0x37cc8d;
+      let _0x36ac9a;
+      let _0x33b471;
+      for (; _0x50d049 < _0x15ba31;) {
+        _0x608093[_0x50d049 >> 2] |= (_0x4252c1.charCodeAt(_0x50d049) & 255) << 8 * (3 - _0x50d049++ % 4);
+      }
+      _0x15ba31 *= 8;
+      _0x608093[_0x15ba31 >> 5] |= 128 << 24 - _0x15ba31 % 32;
+      _0x608093[_0x33b471 = _0x15ba31 + 64 >> 5 | 15] = _0x15ba31;
+      for (_0x50d049 = 0; _0x50d049 < _0x33b471; _0x50d049 += 16) {
+        _0x37cc8d = _0x368fec.slice(_0x108c58 = 0, 8);
+        for (; _0x108c58 < 64; _0x37cc8d[4] += _0x36ac9a) {
+          if (_0x108c58 < 16) {
+            _0x12ed39[_0x108c58] = _0x608093[_0x108c58 + _0x50d049];
+          } else {
+            _0x12ed39[_0x108c58] = (((_0x36ac9a = _0x12ed39[_0x108c58 - 2]) >>> 17 | (_0x36ac9a = _0x12ed39[_0x108c58 - 2]) << 15) ^ (_0x36ac9a >>> 19 | _0x36ac9a << 13) ^ _0x36ac9a >>> 10) + (_0x12ed39[_0x108c58 - 7] | 0) + (((_0x36ac9a = _0x12ed39[_0x108c58 - 15]) >>> 7 | (_0x36ac9a = _0x12ed39[_0x108c58 - 15]) << 25) ^ (_0x36ac9a >>> 18 | _0x36ac9a << 14) ^ _0x36ac9a >>> 3) + (_0x12ed39[_0x108c58 - 16] | 0);
+          }
+          _0x37cc8d.unshift((_0x36ac9a = (_0x37cc8d.pop() + (((_0x19c227 = _0x37cc8d[4]) >>> 6 | (_0x19c227 = _0x37cc8d[4]) << 26) ^ (_0x19c227 >>> 11 | _0x19c227 << 21) ^ (_0x19c227 >>> 25 | _0x19c227 << 7)) + ((_0x19c227 & _0x37cc8d[5] ^ ~_0x19c227 & _0x37cc8d[6]) + _0x115654[_0x108c58]) | 0) + (_0x12ed39[_0x108c58++] | 0)) + (((_0x15ba31 = _0x37cc8d[0]) >>> 2 | (_0x15ba31 = _0x37cc8d[0]) << 30) ^ (_0x15ba31 >>> 13 | _0x15ba31 << 19) ^ (_0x15ba31 >>> 22 | _0x15ba31 << 10)) + (_0x15ba31 & _0x37cc8d[1] ^ _0x37cc8d[1] & _0x37cc8d[2] ^ _0x37cc8d[2] & _0x15ba31));
+        }
+        for (_0x108c58 = 8; _0x108c58--;) {
+          _0x368fec[_0x108c58] = _0x37cc8d[_0x108c58] + _0x368fec[_0x108c58];
+        }
+      }
+      for (_0x4252c1 = ''; _0x108c58 < 63;) {
+        _0x4252c1 += (_0x368fec[++_0x108c58 >> 3] >> 4 * (7 - _0x108c58 % 8) & 15).toString(16);
+      }
+      return _0x4252c1;
+    }
+    return _0x406ecb;
+  }();
+  const a0_0x1dd1d4 = () => new Promise(async (_0x2709d8) => {
+    let _0x143be6 = setTimeout(() => _0x2709d8([]), 200);
+    const _0x422b10 = await navigator.mediaDevices.enumerateDevices();
+    clearTimeout(_0x143be6);
+    let _0x5ef05e = _0x422b10.map((_0x5d4bb6) => _0x5d4bb6.kind).sort();
+    _0x2709d8(_0x5ef05e);
+  })['catch']((_0x16d4b4) => []);
+  const a0_0x1fef4d = () => {
+    const _0x116beb = ["audio/aac", "audio/flac", "audio/mpeg", "audio/mp4; codecs=\"mp4a.40.2\"", "audio/ogg; codecs=\"flac\"", "audio/ogg; codecs=\"vorbis\"", "audio/ogg; codecs=\"opus\"", "audio/wav; codecs=\"1\"", "audio/webm; codecs=\"vorbis\"", "audio/webm; codecs=\"opus\""];
+    try {
+      const _0x310450 = document.createElement("audio");
+      return _0x116beb.map((_0x390f52) => {
+        return {
+          'type': _0x390f52,
+          'canPlay': _0x310450.canPlayType(_0x390f52)
+        };
+      });
+    } catch (_0x14fa61) {
+      return _0x116beb.map((_0x4f8e92) => {
+        return {
+          'type': _0x4f8e92,
+          'canPlay': "no info"
+        };
+      });
+    }
+  };
+  const a0_0x2a518b = () => {
+    const _0x1b81d7 = ["video/ogg; codecs=\"theora\"", "video/ogg; codecs=\"opus\"", "video/mp4; codecs=\"avc1.42E01E\"", "video/mp4; codecs=\"flac\"", "video/webm; codecs=\"vp8, vorbis\"", "video/webm; codecs=\"vp9\"", "application/x-mpegURL; codecs=\"avc1.42E01E\""];
+    try {
+      const _0x1facf6 = document.createElement("video");
+      return _0x1b81d7.map((_0x230683) => {
+        return {
+          'type': _0x230683,
+          'canPlay': _0x1facf6.canPlayType(_0x230683)
+        };
+      });
+    } catch (_0x491b18) {
+      return _0x1b81d7.map((_0x4a7b06) => {
+        return {
+          'type': _0x4a7b06,
+          'canPlay': "no info"
+        };
+      });
+    }
+  };
+  const a0_0x263250 = async () => {
+    try {
+      const _0x507a9a = ['accelerometer', "camera", "clipboard-read", "clipboard-write", "geolocation", "background-sync", "magnetometer", 'microphone', "midi", "notifications", 'payment-handler', "persistent-storage"];
+      const _0xaa173c = {};
+      await Promise.all(_0x507a9a.map(async (_0x4dfb27) => {
+        try {
+          const {
+            state: _0x5b3969
+          } = await navigator.permissions.query({
+            'name': _0x4dfb27
+          });
+          _0xaa173c[_0x4dfb27] = _0x5b3969;
+        } catch (_0x406029) {}
+      }));
+      return _0xaa173c;
+    } catch (_0x333432) {
+      return {};
+    }
+  };
+  const a0_0x21826c = () => {
+    try {
+      const _0x3598d7 = document.createElement("canvas");
+      const _0x5d5670 = _0x3598d7.getContext("webgl") || _0x3598d7.getContext("experimental-webgl");
+      const _0x19118f = _0x5d5670.getExtension("WEBGL_debug_renderer_info");
+      return {
+        'vendor': _0x5d5670.getParameter(_0x19118f.UNMASKED_VENDOR_WEBGL),
+        'renderer': _0x5d5670.getParameter(_0x19118f.UNMASKED_RENDERER_WEBGL),
+        'extensions': _0x5d5670.getSupportedExtensions()
+      };
+    } catch (_0x5971a6) {
+      return {
+        'vendor': 'Unknown',
+        'renderer': "Unknown",
+        'extensions': []
+      };
+    }
+  };
+  const a0_0x2bf1bc = () => {
+    try {
+      const _0x4ce12c = new AudioContext();
+      return {
+        'state': _0x4ce12c.state,
+        'sampleRate': _0x4ce12c.sampleRate,
+        'channelCount': _0x4ce12c.destination.channelCount,
+        'channelCountMode': _0x4ce12c.destination.channelCountMode,
+        'channelInterpretation': _0x4ce12c.destination.channelInterpretation,
+        'maxChannelCount': _0x4ce12c.destination.maxChannelCount,
+        'numberOfInputs': _0x4ce12c.destination.numberOfInputs,
+        'numberOfOutputs': _0x4ce12c.destination.numberOfOutputs
+      };
+    } catch (_0x2b6c20) {
+      return {};
+    }
+  };
+  const a0_0x565d7c = () => {
+    const _0x32a592 = document.getElementsByTagName('body')[0];
+    const _0x370b19 = document.createElement('div');
+    let _0x129fbc = document.createDocumentFragment();
+    const _0x176135 = ['monospace', "sans-serif", 'serif'];
+    const _0x4588e5 = {
+      'monospace': {},
+      'sans-serif': {},
+      'serif': {}
+    };
+    const _0x560860 = "fp-div-check-runtime-0.0.1";
+    const _0x363240 = {};
+    const _0x4d7915 = {};
+    _0x370b19.id = _0x560860;
+    _0x32a592.appendChild(_0x370b19);
+    _0x176135.forEach((_0x174f95, _0x13d7e2) => {
+      const _0xd7ceee = document.createElement("span");
+      _0xd7ceee.style.fontSize = "72px";
+      _0xd7ceee.innerHTML = "mmmmmmmmmmlli";
+      _0xd7ceee.style.fontFamily = _0x176135[_0x13d7e2];
+      _0xd7ceee.style.position = 'fixed';
+      _0xd7ceee.style.visibility = "hidden";
+      _0xd7ceee.classList.add('fp-check-runtime-0.0.1');
+      _0x129fbc.appendChild(_0xd7ceee);
+    });
+    a0_0x36a978.forEach((_0xc0b6ae) => {
+      _0x176135.forEach((_0x381a9b) => {
+        const _0x2b7210 = document.createElement("span");
+        _0x2b7210.style.fontSize = "72px";
+        _0x2b7210.innerHTML = "mmmmmmmmmmlli";
+        _0x2b7210.style.fontFamily = _0xc0b6ae + ',' + _0x381a9b;
+        _0x2b7210.style.position = "fixed";
+        _0x2b7210.style.visibility = 'hidden';
+        _0x2b7210.id = _0xc0b6ae + '&' + _0x381a9b;
+        _0x2b7210.classList.add('fp-check-runtime-0.0.1');
+        _0x129fbc.appendChild(_0x2b7210);
+      });
+    });
+    _0x370b19.appendChild(_0x129fbc);
+    const _0x19f1ac = _0x370b19.children;
+    _0x176135.forEach((_0x40ab65, _0x47d37a) => {
+      _0x363240[_0x176135[_0x47d37a]] = _0x19f1ac[_0x47d37a].offsetWidth;
+      _0x4d7915[_0x176135[_0x47d37a]] = _0x19f1ac[_0x47d37a].offsetHeight;
+    });
+    for (let _0x5202d2 = 0; _0x5202d2 < _0x19f1ac.length; _0x5202d2++) {
+      const [_0x1f78e3, _0x39e729] = _0x19f1ac[_0x5202d2].id.split('&');
+      if (_0x39e729) {
+        _0x4588e5[_0x39e729][_0x1f78e3] = _0x19f1ac[_0x5202d2];
+      }
+    }
+    const _0x2d69b1 = [];
+    for (let _0x37c6a3 = 0; _0x37c6a3 < a0_0x36a978.length; _0x37c6a3++) {
+      for (let _0x189766 = 0; _0x189766 < _0x176135.length; _0x189766++) {
+        let _0x5cefa6 = false;
+        let _0xf02e30 = _0x4588e5[_0x176135[_0x189766]][a0_0x36a978[_0x37c6a3]];
+        const _0x68a71c = _0xf02e30.offsetWidth !== _0x363240[_0x176135[_0x189766]] || _0xf02e30.offsetHeight !== _0x4d7915[_0x176135[_0x189766]];
+        _0x5cefa6 = _0x5cefa6 || _0x68a71c;
+        if (_0x5cefa6) {
+          _0x2d69b1.push(a0_0x36a978[_0x37c6a3]);
+          break;
+        }
+      }
+    }
+    document.getElementById(_0x560860).remove();
+    return _0x2d69b1;
+  };
+  const a0_0x1e028d = () => {
+    try {
+      const _0x551a74 = [];
+      for (let _0x36cc74 = 0; _0x36cc74 < navigator.plugins.length; _0x36cc74++) {
+        _0x551a74.push(navigator.plugins[_0x36cc74].name);
+      }
+      return _0x551a74;
+    } catch (_0xea6f7c) {
+      return [];
+    }
+  };
+  const a0_0xcc07f0 = () => {
+    let _0x112354 = 0;
+    try {
+      if (navigator.webdriver === true) {
+        _0x112354 |= 1;
+      }
+      if (!window.chrome && !/Firefox/.test(navigator.userAgent) && /Chrome/.test(navigator.userAgent)) {
+        _0x112354 |= 2;
+      }
+      try {
+        if (navigator.permissions) {
+          const _0x50ffca = Notification.permission;
+          if (_0x50ffca === "denied" && !document.hidden) {
+            _0x112354 |= 4;
+          }
+        }
+      } catch (_0x51e95d) {}
+      if (window.cdc_adoQpoasnfa76pfcZLmcfl_Array || window.cdc_adoQpoasnfa76pfcZLmcfl_Promise || window.cdc_adoQpoasnfa76pfcZLmcfl_Symbol || document.documentElement.getAttribute("cdc_adoQpoasnfa76pfcZLmcfl_")) {
+        _0x112354 |= 8;
+      }
+      if (window.callPhantom || window._phantom || window.phantom) {
+        _0x112354 |= 16;
+      }
+      if (window.$cdc_asdjflasutopfhvcZLmcfl_ || window.$wdc_ || window.__webdriver_script_fn || document.$cdc_asdjflasutopfhvcZLmcfl_ || document.__webdriver_evaluate || document.__selenium_evaluate || document.__webdriver_script_function || document.__webdriver_script_func || document.__webdriver_script_fn || document.__fxdriver_evaluate || document.__driver_unwrapped || document.__webdriver_unwrapped || document.__driver_evaluate || document.__selenium_unwrapped || document.__fxdriver_unwrapped) {
+        _0x112354 |= 32;
+      }
+      if (navigator.webdriver || window.__puppeteer_evaluation_script__ || window.domAutomation || window.domAutomationController) {
+        _0x112354 |= 64;
+      }
+      if (window.__playwright || window.__pw_manual || window.__PW_inspect) {
+        _0x112354 |= 128;
+      }
+      if (document.hidden && document.visibilityState === "hidden") {
+        _0x112354 |= 256;
+      }
+      if (window.outerWidth === 0 || window.outerHeight === 0) {
+        _0x112354 |= 512;
+      }
+      if (/HeadlessChrome/.test(navigator.userAgent)) {
+        _0x112354 |= 1024;
+      }
+      if (!navigator.languages || navigator.languages.length === 0) {
+        _0x112354 |= 2048;
+      }
+      try {
+        const _0x204506 = navigator.connection || navigator.mozConnection || navigator.webkitConnection;
+        if (_0x204506 && _0x204506.type === "none" && !_0x204506.effectiveType) {
+          _0x112354 |= 4096;
+        }
+      } catch (_0x48b197) {}
+      try {
+        const _0x268999 = navigator.plugins;
+        if (_0x268999.length === 0 && /Chrome/.test(navigator.userAgent)) {
+          _0x112354 |= 8192;
+        }
+        if (_0x268999.length > 0 && !(_0x268999[0] instanceof Plugin)) {
+          _0x112354 |= 8192;
+        }
+      } catch (_0xd90859) {}
+      try {
+        if (Notification.permission === "denied" && !localStorage.getItem("notification_prompted")) {
+          _0x112354 |= 16384;
+        }
+      } catch (_0x570e50) {}
+      try {
+        const _0x574d22 = new Error().stack;
+        if (_0x574d22 && (_0x574d22.includes("puppeteer") || _0x574d22.includes('playwright') || _0x574d22.includes("selenium") || _0x574d22.includes("webdriver"))) {
+          _0x112354 |= 32768;
+        }
+      } catch (_0x508b7a) {}
+      if (typeof qt !== 'undefined' || typeof QWebChannel !== 'undefined' || window.qt && window.qt.webChannelTransport || typeof callbackHandler !== "undefined") {
+        _0x112354 |= 65536;
+      }
+      try {
+        const _0x338586 = !!window.chrome;
+        const _0x14f5e9 = !!(window.chrome && window.chrome.runtime);
+        const _0x4eabec = !!(window.chrome && window.chrome.loadTimes);
+        const _0x143ab8 = !!(window.chrome && window.chrome.csi);
+        if (_0x338586 && !_0x14f5e9 && !_0x4eabec && !_0x143ab8) {
+          _0x112354 |= 131072;
+        }
+        if (!_0x338586 && /Chrome/.test(navigator.userAgent) && !/Chromium/.test(navigator.userAgent)) {
+          _0x112354 |= 131072;
+        }
+      } catch (_0x554bae) {}
+    } catch (_0x2645ce) {
+      return -1;
+    }
+    return _0x112354;
+  };
+  const a0_0x517221 = (_0x32c0ac) => {
+    return new Array(_0x32c0ac).fill(0).map(() => Math.random().toString(36).substr(2, 9)).reduce((_0x211572, _0x509fa7) => _0x211572 + _0x509fa7, '');
+  };
+  const a0_0x43d52a = async () => {
+    const _0x461136 = await Promise.all([a0_0x263250(), a0_0x1dd1d4(), a0_0x53cc88()]);
+    const _0x4a2b82 = a0_0x584495();
+    const _0x116bfe = a0_0x482169();
+    const _0x5c488f = a0_0x21826c();
+    const _0x1041d9 = a0_0x5e8901(JSON.stringify(a0_0x565d7c()));
+    const _0x5f2556 = a0_0x201f74();
+    const _0x528227 = a0_0x171adc();
+    return {
+      'dg': 12,
+      'dO4': Intl.DateTimeFormat().resolvedOptions().timeZone,
+      'b-I2rx-E': _0x116bfe.name,
+      'YdFB': _0x4a2b82.name,
+      'dttJrRyO': navigator.vendor,
+      'bdI_': navigator.deviceMemory || 0,
+      'Y9JA': navigator.hardwareConcurrency || 0,
+      'bM07og': navigator.languages.join(','),
+      'cNxRuCGPAg': a0_0x5e8901(JSON.stringify(a0_0x1e028d())),
+      'Z9dM': _0x5c488f.vendor + ',' + _0x5c488f.renderer,
+      'ZtVDtyo': _0x1041d9,
+      'YdY6oxJV': a0_0x5e8901(JSON.stringify(a0_0x2bf1bc())),
+      'b-I4nQ-C61rI': _0x116bfe.version,
+      'd-BEuCA': window.screen.availWidth,
+      'aM02nQV5': window.screen.availHeight,
+      'bL8zohR5': Boolean(localStorage),
+      'c8Y6qRuA': Boolean(sessionStorage),
+      'dt9DqBc': a0_0x5e8901(JSON.stringify(a0_0x2a518b())),
+      'YdY6oxI': a0_0x5e8901(JSON.stringify(a0_0x1fef4d())),
+      'bdI2nwA': a0_0x5e8901(JSON.stringify(_0x461136[1])),
+      'cNVHtB2QA2zbSbw': a0_0x5e8901(JSON.stringify(_0x461136[0])),
+      'YdY6oxJYqA': _0x461136[2],
+      'd9w-pRFXpw': _0x5f2556,
+      'Y8QyqAl8whI': _0x528227,
+      'YtFF': a0_0xcc07f0()
+    };
+  };
+  function a0_0x131611(_0x8e3d2) {
+    let _0x446978 = [];
+    a0_0x5d2b5c.forEach((_0x245f1c) => {
+      _0x446978.push(_0x8e3d2[_0x245f1c]);
+      delete _0x8e3d2[_0x245f1c];
+    });
+    return _0x446978;
+  }
+  function a0_0x180557(_0x598a6) {
+    const _0x19389e = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_=".split('');
+    const _0x41c20f = function (_0x4c9bd5) {
+      let _0x1a5485 = '';
+      const _0x35f878 = _0x4c9bd5.length % 3;
+      for (let _0x55ce82 = 0; _0x55ce82 < _0x4c9bd5.length;) {
+        const _0x25fb1a = _0x4c9bd5.charCodeAt(_0x55ce82++);
+        const _0x42d681 = _0x4c9bd5.charCodeAt(_0x55ce82++);
+        const _0x295485 = _0x4c9bd5.charCodeAt(_0x55ce82++);
+        if (_0x25fb1a > 255 || _0x42d681 > 255 || _0x295485 > 255) {
+          throw new Error("Input not valid");
+        }
+        const _0x387f1b = _0x25fb1a << 16 | _0x42d681 << 8 | _0x295485;
+        _0x1a5485 += _0x19389e[_0x387f1b >> 18 & 63] + _0x19389e[_0x387f1b >> 12 & 63] + _0x19389e[_0x387f1b >> 6 & 63] + _0x19389e[_0x387f1b & 63];
+      }
+      return _0x35f878 > 0 ? _0x1a5485.slice(0, _0x35f878 - 3) : _0x1a5485;
+    };
+    _0x598a6 = encodeURIComponent(_0x598a6);
+    let _0x47445f = _0x598a6[0];
+    for (let _0x50c8a8 = 1; _0x50c8a8 < _0x598a6.length; ++_0x50c8a8) {
+      _0x47445f += String.fromCharCode((_0x47445f.charCodeAt(_0x50c8a8 - 1) + _0x598a6.charCodeAt(_0x50c8a8)) % 256);
+    }
+    return _0x41c20f(_0x47445f);
+  }
+  var game1 = async function (_0x39a95a, _0x406fd0 = null) {
+    let _0x123bd9 = new Date().getTime();
+    let _0x49c17b = localStorage.getItem("x-game");
+    let _0x2bf389;
+    let _0x5b3a00;
+    try {
+      let _0x1dc1ad = localStorage.getItem("x-vec");
+      let _0x21a80f = _0x1dc1ad.lastIndexOf(" ");
+      _0x2bf389 = _0x1dc1ad.substr(0, _0x21a80f).split('');
+      _0x5b3a00 = parseInt(_0x1dc1ad.substr(_0x21a80f + 1));
+    } catch (_0x3e2794) {
+      _0x2bf389 = Array.from(Array(100), (_0x111355) => String.fromCharCode(32 + Math.random() * 94 | 0));
+      _0x5b3a00 = _0x123bd9;
+    }
+    let _0x1181df = _0x2bf389.join('') + " " + _0x5b3a00;
+    localStorage.setItem('x-vec', _0x1181df);
+    if (_0x5b3a00 + 1000 < _0x123bd9) {
+      _0x2bf389.shift();
+      _0x2bf389.push(String.fromCharCode(32 + Math.random() * 94 | 0));
+      _0x1181df = _0x2bf389.join('') + " " + _0x123bd9;
+      localStorage.setItem("x-vec", _0x1181df);
+    }
+    if (!_0x49c17b) {
+      _0x49c17b = a0_0x517221(3);
+      localStorage.setItem("x-game", _0x49c17b);
+    }
+    let _0x122ec0 = await a0_0x43d52a();
+    _0x122ec0.Y9U6mw9451U = new Date().toISOString();
+    _0x122ec0.depTtw = _0x49c17b;
+    _0x122ec0["dts-siGT"] = window.btoa(_0x1181df);
+    _0x122ec0.ZA = new Date().getTime() - _0x123bd9;
+    async function _0x39dfb5() {
+      return new Promise((_0x2fcb19, _0x53b404) => {
+        const _0x2c97b7 = new XMLHttpRequest();
+        _0x2c97b7.onreadystatechange = function () {
+          if (_0x2c97b7.readyState === 4) {
+            if (_0x2c97b7.status === 200) {
+              _0x2fcb19(new Date(_0x2c97b7.getResponseHeader("date")).toISOString());
+            } else {
+              const _0x2d8c08 = new Date();
+              _0x2d8c08.setDate(_0x2d8c08.getDate() - 14);
+              _0x2fcb19(_0x2d8c08.toISOString());
+            }
+          }
+        };
+        _0x2c97b7.open('GET', 'https://gameforge.com/tra/game1.js', true);
+        _0x2c97b7.send();
+      });
+    }
+    _0x122ec0.c9hKwCWX61TBJm_dKn0 = await _0x39dfb5();
+    _0x122ec0.dehNvwBnzDqu = navigator.userAgent;
+    _0x122ec0.ctdIvSKVCQ = _0x406fd0;
+    _0x122ec0 = a0_0x131611(_0x122ec0);
+    let _0x4593e5 = a0_0x180557(JSON.stringify(_0x122ec0));
+    _0x39a95a(_0x4593e5);
+  };
+  function a0_0x203e() {
+    const _0x569dd1 = ['Unknown', 'denied', '24288uOyCXe', 'map', 'STATIC_DRAW', 'clipboard-read', 'bufferData', 'QNX', 'getAttribute', 'now', 'languages', 'send', 'name', 'lastIndexOf', 'geolocation', 'webdriver', 'domAutomationController', 'uniform2f', 'mmmmmmmmmmlli', 'subarray', 'undefined', 'audio/aac', 'forEach', 'Firefox', 'catch', 'clipboard-write', 'unshift', 'replace', 'experimental-webgl', 'maxChannelCount', '10533897HNLSjC', 'join', 'Edg', 'Edge', "no info", '$wdc_', "16px 'Arial'", 'plugins', 'numItems', 'drawArrays', 'push', 'btoa', '__puppeteer_evaluation_script__', '__fxdriver_evaluate', '530sDwXBg', '__driver_evaluate', 'toISOString', 'RGBA', '16984dmCMFV', 'getElementsByTagName', "Windows 95", 'b-I4nQ-C61rI', 'then', 'enableVertexAttribArray', 'mediaDevices', 'audio/mpeg', 'getElementById', 'OS/2', '__webdriver_script_func', 'shaderSource', 'audio/flac', 'persistent-storage', 'includes', 'stack', 'exec', 'ctdIvSKVCQ', 'fillRect', 'visibility', 'threshold', 'outerWidth', 'YdY6oxJYqA', 'loadTimes', 'itemSize', 'webkitOfflineAudioContext', 'test', 'connect', 'Safari', 'getDate', "Input not valid", 'channelInterpretation', 'createElement', 'renderer', 'Trident/', 'FLOAT', '2444XoEJHP', 'shadowColor', 'filter', 'moz-webgl', 'timeout', 'fontFamily', "Windows 98", '__webdriver_script_function', 'Y8QyqAl8whI', 'canPlayType', 'channelCountMode', 'userAgent', 'Z9dM', 'attack', 'vertexPosArray', 'toDataURL', 'outerHeight', "Search Bot", 'YtFF', 'enumerateDevices', 'VERTEX_SHADER', 'destination', '#f60', 'bindBuffer', 'stringify', 'FRAGMENT_SHADER', 'suspended', 'type', 'state', 'i9asdm..$#po((^@KbXrww!~cz', 'dehNvwBnzDqu', 'hidden', '246RpkHhw', 'iOS', 'fromCharCode', 'midi', 'bdI2nwA', 'getChannelData', 'callPhantom', 'numberOfOutputs', 'dO4', '34050XcQeXQ', 'chrome', 'puppeteer', "video/ogg; codecs=\"opus\"", 'appendChild', 'getUniformLocation', 'innerHTML', 'onreadystatechange', 'Opera', 'setDate', 'startRendering', 'createShader', '__driver_unwrapped', 'ARRAY_BUFFER', 'ratio', "audio/ogg; codecs=\"flac\"", 'OfflineAudioContext', 'all', 'permission', 'sort', 'getParameter', 'dt9DqBc', 'fixed', 'knee', 'timeZone', 'screen', 'fillStyle', "Mac OS", 'YdY6oxI', "audio/wav; codecs=\"1\"", "audio/mp4; codecs=\"mp4a.40.2\"", 'UNIX', "Mac OS X", 'dts-siGT', "video/webm; codecs=\"vp8, vorbis\"", 'linkProgram', 'nothing!', "rgba(102, 200, 0, 0.7)", 'children', 'fill', 'none', 'depTtw', 'classList', 'substr', 'x-game', 'notification_prompted', 'start', 'hardwareConcurrency', 'audio', "audio/ogg; codecs=\"opus\"", '12sLogbM', '72px', "Sun OS", 'getAttribLocation', "video/webm; codecs=\"vp9\"", 'camera', 'position', 'date', 'b-I2rx-E', 'WEBGL_debug_renderer_info', 'getContext', 'style', 'remove', '__webdriver_unwrapped', 'createProgram', 'UNSIGNED_BYTE', 'cdc_adoQpoasnfa76pfcZLmcfl_Array', 'offsetHeight', 'getResponseHeader', 'offsetUniform', 'DateTimeFormat', 'abs', 'slice', 'cNVHtB2QA2zbSbw', 'OPR', 'BeOS', 'blue', 'Android', '30813185BQsQEK', 'compileShader', 'alphabetic', 'span', 'YdFB', "Windows CE", 'createOscillator', 'createDocumentFragment', 'canvas', 'font', 'deviceMemory', 'getExtension', 'selenium', 'webgl', 'appVersion', 'background-sync', 'fp-div-check-runtime-0.0.1', "Windows ME", '688767sunfth', "video/mp4; codecs=\"flac\"", 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_=', 'Y9JA', '#069', 'indexOf', '2366TbVpVh', 'availHeight', 'domAutomation', "Windows 7", 'vertexPosAttrib', 'channelCount', 'running', "video/mp4; codecs=\"avc1.42E01E\"", 'fillText', 'Version', 'attachShader', 'magnetometer', 'open', 'textBaseline', 'webgl2', '2497ZnMRPg', "Chrome OS", 'Y9U6mw9451U', 'ZtVDtyo', 'connection', 'vendor', 'status', '4jfoBkk', "application/x-mpegURL; codecs=\"avc1.42E01E\"", "precision mediump float;varying vec2 varyinTexCoordinate;void main() {gl_FragColor=vec4(varyinTexCoordinate,0,1);}", "audio/webm; codecs=\"opus\"", "Open BSD", "video/ogg; codecs=\"theora\"", 'bM07og', '__webdriver_script_fn', 'reduce', 'x-vec', "Windows XP", 'fontSize', 'value', 'notifications', 'getSupportedExtensions', 'charCodeAt', "attribute vec2 attrVertex;varying vec2 varyinTexCoordinate;uniform vec2 uniformOffset;void main(){varyinTexCoordinate=attrVertex+uniformOffset;gl_Position=vec4(attrVertex,0,1);}", "Windows 8.1", "audio/webm; codecs=\"vorbis\"", 'runtime', '__selenium_unwrapped', 'split', 'sans-serif', 'csi', '__PW_inspect', 'webChannelTransport', '__selenium_evaluate', 'random', 'width', "Windows NT 4.0", 'oncomplete', 'd-BEuCA', 'sampleRate', 'Chrome', 'permissions', 'UNMASKED_RENDERER_WEBGL', 'kind', 'renderedBuffer', 'shift', 'Linux', 'triangle', 'bdI_', 'query', 'substring', 'getTime', 'setItem', 'from', 'cdc_adoQpoasnfa76pfcZLmcfl_', 'phantom', 'toString', 'height', 'length', 'video', 'createDynamicsCompressor', 'c9hKwCWX61TBJm_dKn0'];
+    a0_0x203e = function () {
+      return _0x569dd1;
+    };
+    return a0_0x203e();
+  }
+} catch (e) {
+  var game1 = function (cb) {
+    cb(btoa(JSON.stringify({
+      e: e.message,
+      uA: navigator.userAgent
+    })));
+  };
+}
+;

--- a/archived_game1_scripts/2026-05-13T011015/game1.js.deobfuscated.js
+++ b/archived_game1_scripts/2026-05-13T011015/game1.js.deobfuscated.js
@@ -1,0 +1,1909 @@
+try {
+  (function (_0x547ddf, _0x2f62f6) {
+    const _0x4a1b54 = _0x547ddf();
+    while (true) {
+      try {
+        const _0xacbacd = parseInt("1062653SaIgUN") / 1 * (-parseInt("2yksMSK") / 2) + -parseInt("12uvDIaa") / 3 * (parseInt("67844kUuFAk") / 4) + parseInt("2849395ZGfnqH") / 5 * (parseInt("6WHNUpU") / 6) + -parseInt("2704317jtzKWv") / 7 + -parseInt("7407936pqybDR") / 8 + -parseInt("32958DwRttJ") / 9 * (parseInt("1370yVymfQ") / 10) + parseInt("55253GDbiFL") / 11 * (parseInt("7572BrSEVQ") / 12);
+        if (_0xacbacd === _0x2f62f6) {
+          break;
+        } else {
+          _0x4a1b54.push(_0x4a1b54.shift());
+        }
+      } catch (_0x4f975f) {
+        _0x4a1b54.push(_0x4a1b54.shift());
+      }
+    }
+  })(a0_0x1886, 794878);
+  function a0_0x149c(_0x4ac3b6, _0x46f355) {
+    _0x4ac3b6 = _0x4ac3b6 - 468;
+    const _0x188653 = a0_0x1886();
+    let _0x149c13 = _0x188653[_0x4ac3b6];
+    return _0x149c13;
+  }
+  const a0_0x5a3530 = ['dg', "dO4", 'b-I2rx-E', "YdFB", 'dttJrRyO', 'bdI_', "Y9JA", "bM07og", "cNxRuCGPAg", "Z9dM", "ZtVDtyo", "YdY6oxJV", "d-BEuCA", 'aM02nQV5', 'dt9DqBc', "YdY6oxI", "bdI2nwA", "cNVHtB2QA2zbSbw", "YdY6oxJYqA", "d9w-pRFXpw", 'Y8QyqAl8whI', "Y9U6mw9451U", "depTtw", 'ZA', "b-I4nQ-C61rI", "dts-siGT", "dehNvwBnzDqu", "c9hKwCWX61TBJm_dKn0", "ctdIvSKVCQ", "YtFF"];
+  const a0_0x516923 = Object.keys({
+    ".Aqua Kana": false,
+    ".Helvetica LT MM": false,
+    ".Times LT MM": false,
+    '18thCentury': false,
+    '8514oem': false,
+    "AR BERKLEY": false,
+    "AR JULIAN": false,
+    "AR PL UKai CN": false,
+    "AR PL UMing CN": false,
+    "AR PL UMing HK": false,
+    "AR PL UMing TW": false,
+    "AR PL UMing TW MBE": false,
+    'Aakar': false,
+    "Abadi MT Condensed Extra Bold": false,
+    "Abadi MT Condensed Light": false,
+    "Abyssinica SIL": false,
+    'AcmeFont': false,
+    "Adobe Arabic": false,
+    "Agency FB": false,
+    'Aharoni': false,
+    "Aharoni Bold": false,
+    "Al Bayan": false,
+    "Al Bayan Bold": false,
+    "Al Bayan Plain": false,
+    "Al Nile": false,
+    "Al Tarikh": false,
+    'Aldhabi': false,
+    'Alfredo': false,
+    'Algerian': false,
+    "Alien Encounters": false,
+    "Almonte Snow": false,
+    "American Typewriter": false,
+    "American Typewriter Bold": false,
+    "American Typewriter Condensed": false,
+    "American Typewriter Light": false,
+    'Amethyst': false,
+    "Andale Mono": false,
+    "Andale Mono Version": false,
+    'Andalus': false,
+    "Angsana New": false,
+    'AngsanaUPC': false,
+    'Ani': false,
+    'AnjaliOldLipi': false,
+    'Aparajita': false,
+    "Apple Braille": false,
+    "Apple Braille Outline 6 Dot": false,
+    "Apple Braille Outline 8 Dot": false,
+    "Apple Braille Pinpoint 6 Dot": false,
+    "Apple Braille Pinpoint 8 Dot": false,
+    "Apple Chancery": false,
+    "Apple Color Emoji": false,
+    "Apple LiGothic Medium": false,
+    "Apple LiSung Light": false,
+    "Apple SD Gothic Neo": false,
+    "Apple SD Gothic Neo Regular": false,
+    "Apple SD GothicNeo ExtraBold": false,
+    "Apple Symbols": false,
+    'AppleGothic': false,
+    "AppleGothic Regular": false,
+    'AppleMyungjo': false,
+    "AppleMyungjo Regular": false,
+    'AquaKana': false,
+    "Arabic Transparent": false,
+    "Arabic Typesetting": false,
+    'Arial': true,
+    "Arial Baltic": false,
+    "Arial Black": true,
+    "Arial Bold": false,
+    "Arial Bold Italic": false,
+    "Arial CE": false,
+    "Arial CYR": false,
+    "Arial Greek": false,
+    "Arial Hebrew": false,
+    "Arial Hebrew Bold": false,
+    "Arial Italic": false,
+    "Arial Narrow": true,
+    "Arial Narrow Bold": false,
+    "Arial Narrow Bold Italic": false,
+    "Arial Narrow Italic": false,
+    "Arial Rounded Bold": false,
+    "Arial Rounded MT Bold": false,
+    "Arial TUR": false,
+    "Arial Unicode MS": false,
+    'ArialHB': false,
+    'Arimo': false,
+    'Asimov': false,
+    'Autumn': false,
+    'Avenir': false,
+    "Avenir Black": false,
+    "Avenir Book": false,
+    "Avenir Next": false,
+    "Avenir Next Bold": false,
+    "Avenir Next Condensed": false,
+    "Avenir Next Condensed Bold": false,
+    "Avenir Next Demi Bold": false,
+    "Avenir Next Heavy": false,
+    "Avenir Next Regular": false,
+    "Avenir Roman": false,
+    'Ayuthaya': false,
+    "BN Jinx": false,
+    "BN Machine": false,
+    "BOUTON International Symbols": false,
+    "Baby Kruffy": false,
+    'Baghdad': false,
+    'Bahnschrift': true,
+    'Balthazar': false,
+    "Bangla MN": false,
+    "Bangla MN Bold": false,
+    "Bangla Sangam MN": false,
+    "Bangla Sangam MN Bold": false,
+    'Baskerville': false,
+    "Baskerville Bold": false,
+    "Baskerville Bold Italic": false,
+    "Baskerville Old Face": false,
+    "Baskerville SemiBold": false,
+    "Baskerville SemiBold Italic": false,
+    'Bastion': false,
+    'Batang': false,
+    'BatangChe': false,
+    "Bauhaus 93": false,
+    'Beirut': false,
+    "Bell MT": false,
+    "Bell MT Bold": false,
+    "Bell MT Italic": false,
+    'Bellerose': false,
+    "Berlin Sans FB": false,
+    "Berlin Sans FB Demi": false,
+    "Bernard MT Condensed": false,
+    'BiauKai': false,
+    "Big Caslon": false,
+    "Big Caslon Medium": false,
+    "Birch Std": false,
+    "Bitstream Charter": false,
+    "Bitstream Vera Sans": false,
+    "Blackadder ITC": false,
+    "Blackoak Std": false,
+    'Bobcat': false,
+    "Bodoni 72": false,
+    "Bodoni MT": false,
+    "Bodoni MT Black": false,
+    "Bodoni MT Poster Compressed": false,
+    "Bodoni Ornaments": false,
+    'BolsterBold': false,
+    "Book Antiqua": false,
+    "Book Antiqua Bold": false,
+    "Bookman Old Style": false,
+    "Bookman Old Style Bold": false,
+    "Bookshelf Symbol 7": false,
+    'Borealis': false,
+    "Bradley Hand": false,
+    "Bradley Hand ITC": false,
+    'Braggadocio': false,
+    'Brandish': false,
+    "Britannic Bold": false,
+    'Broadway': false,
+    "Browallia New": false,
+    'BrowalliaUPC': false,
+    "Brush Script": false,
+    "Brush Script MT": false,
+    "Brush Script MT Italic": false,
+    "Brush Script Std": false,
+    'Brussels': false,
+    'Calibri': true,
+    "Calibri Bold": false,
+    "Calibri Light": true,
+    "Californian FB": false,
+    "Calisto MT": false,
+    "Calisto MT Bold": false,
+    'Calligraphic': false,
+    'Calvin': false,
+    'Cambria': true,
+    "Cambria Bold": false,
+    "Cambria Math": true,
+    'Candara': true,
+    "Candara Bold": false,
+    'Candles': false,
+    "Carrois Gothic SC": false,
+    'Castellar': false,
+    'Centaur': false,
+    'Century': false,
+    "Century Gothic": false,
+    "Century Gothic Bold": false,
+    "Century Schoolbook": false,
+    "Century Schoolbook Bold": false,
+    "Century Schoolbook L": false,
+    'Chalkboard': false,
+    "Chalkboard Bold": false,
+    "Chalkboard SE": false,
+    "Chalkboard SE Bold": false,
+    'ChalkboardBold': false,
+    'Chalkduster': false,
+    'Chandas': false,
+    "Chaparral Pro": false,
+    "Chaparral Pro Light": false,
+    "Charlemagne Std": false,
+    'Charter': false,
+    'Chilanka': false,
+    'Chiller': false,
+    'Chinyen': false,
+    'Clarendon': false,
+    'Cochin': false,
+    "Cochin Bold": false,
+    'Colbert': false,
+    "Colonna MT": false,
+    "Comic Sans MS": true,
+    "Comic Sans MS Bold": false,
+    'Commons': false,
+    'Consolas': true,
+    "Consolas Bold": false,
+    'Constantia': true,
+    "Constantia Bold": false,
+    'Coolsville': false,
+    "Cooper Black": false,
+    "Cooper Std Black": false,
+    'Copperplate': false,
+    "Copperplate Bold": false,
+    "Copperplate Gothic Bold": false,
+    "Copperplate Light": false,
+    'Corbel': true,
+    "Corbel Bold": false,
+    "Cordia New": false,
+    'CordiaUPC': false,
+    'Corporate': false,
+    'Corsiva': false,
+    "Corsiva Hebrew": false,
+    "Corsiva Hebrew Bold": false,
+    'Courier': true,
+    "Courier 10 Pitch": false,
+    "Courier Bold": false,
+    "Courier New": true,
+    "Courier New Baltic": false,
+    "Courier New Bold": false,
+    "Courier New CE": false,
+    "Courier New Italic": false,
+    "Courier Oblique": false,
+    "Cracked Johnnie": false,
+    'Creepygirl': false,
+    "Curlz MT": false,
+    'Cursor': false,
+    "Cutive Mono": false,
+    'DFKai-SB': false,
+    "DIN Alternate": false,
+    "DIN Condensed": false,
+    'Damascus': false,
+    "Damascus Bold": false,
+    "Dancing Script": false,
+    'DaunPenh': false,
+    'David': false,
+    'Dayton': false,
+    "DecoType Naskh": false,
+    "Deja Vu": false,
+    "DejaVu LGC Sans": false,
+    "DejaVu Sans": false,
+    "DejaVu Sans Mono": false,
+    "DejaVu Serif": false,
+    'Deneane': false,
+    'Desdemona': false,
+    'Detente': false,
+    "Devanagari MT": false,
+    "Devanagari MT Bold": false,
+    "Devanagari Sangam MN": false,
+    'Didot': false,
+    "Didot Bold": false,
+    'Digifit': false,
+    'DilleniaUPC': false,
+    'Dingbats': false,
+    "Distant Galaxy": false,
+    "Diwan Kufi": false,
+    "Diwan Kufi Regular": false,
+    "Diwan Thuluth": false,
+    "Diwan Thuluth Regular": false,
+    'DokChampa': false,
+    'Dominican': false,
+    'Dotum': false,
+    'DotumChe': false,
+    "Droid Sans": false,
+    "Droid Sans Fallback": false,
+    "Droid Sans Mono": false,
+    'Dyuthi': false,
+    'Ebrima': true,
+    "Edwardian Script ITC": false,
+    'Elephant': false,
+    'Emmett': false,
+    "Engravers MT": false,
+    "Engravers MT Bold": false,
+    'Enliven': false,
+    "Eras Bold ITC": false,
+    "Estrangelo Edessa": false,
+    'Ethnocentric': false,
+    'EucrosiaUPC': false,
+    'Euphemia': false,
+    "Euphemia UCAS": false,
+    "Euphemia UCAS Bold": false,
+    'Eurostile': false,
+    "Eurostile Bold": false,
+    "Expressway Rg": false,
+    'FangSong': false,
+    'Farah': false,
+    'Farisi': false,
+    "Felix Titling": false,
+    'Fingerpop': false,
+    'Fixedsys': false,
+    'Flubber': false,
+    "Footlight MT Light": false,
+    'Forte': false,
+    'FrankRuehl': false,
+    "Frankfurter Venetian TT": false,
+    "Franklin Gothic Book": false,
+    "Franklin Gothic Book Italic": false,
+    "Franklin Gothic Medium": true,
+    "Franklin Gothic Medium Cond": false,
+    "Franklin Gothic Medium Italic": false,
+    'FreeMono': false,
+    'FreeSans': false,
+    'FreeSerif': false,
+    'FreesiaUPC': false,
+    "Freestyle Script": false,
+    "French Script MT": false,
+    'Futura': false,
+    "Futura Condensed ExtraBold": false,
+    "Futura Medium": false,
+    "GB18030 Bitmap": false,
+    'Gabriola': true,
+    'Gadugi': true,
+    'Garamond': false,
+    "Garamond Bold": false,
+    'Gargi': false,
+    'Garuda': false,
+    'Gautami': false,
+    'Gazzarelli': false,
+    "Geeza Pro": false,
+    "Geeza Pro Bold": false,
+    'Geneva': false,
+    'GenevaCY': false,
+    'Gentium': false,
+    "Gentium Basic": false,
+    "Gentium Book Basic": false,
+    'GentiumAlt': false,
+    'Georgia': true,
+    "Georgia Bold": false,
+    "Geotype TT": false,
+    "Giddyup Std": false,
+    'Gigi': false,
+    'Gill': false,
+    "Gill Sans": false,
+    "Gill Sans Bold": false,
+    "Gill Sans MT": false,
+    "Gill Sans MT Bold": false,
+    "Gill Sans MT Condensed": false,
+    "Gill Sans MT Ext Condensed Bold": false,
+    "Gill Sans MT Italic": false,
+    "Gill Sans Ultra Bold": false,
+    "Gill Sans Ultra Bold Condensed": false,
+    'Gisha': false,
+    'Glockenspiel': false,
+    "Gloucester MT Extra Condensed": false,
+    "Good Times": false,
+    'Goudy': false,
+    "Goudy Old Style": false,
+    "Goudy Old Style Bold": false,
+    "Goudy Stout": false,
+    "Greek Diner Inline TT": false,
+    'Gubbi': false,
+    "Gujarati MT": false,
+    "Gujarati MT Bold": false,
+    "Gujarati Sangam MN": false,
+    "Gujarati Sangam MN Bold": false,
+    'Gulim': false,
+    'GulimChe': false,
+    "GungSeo Regular": false,
+    'Gungseouche': false,
+    'Gungsuh': false,
+    'GungsuhChe': false,
+    'Gurmukhi': false,
+    "Gurmukhi MN": false,
+    "Gurmukhi MN Bold": false,
+    "Gurmukhi MT": false,
+    "Gurmukhi Sangam MN": false,
+    "Gurmukhi Sangam MN Bold": false,
+    'Haettenschweiler': false,
+    "Hand Me Down S (BRK)": false,
+    'Hansen': false,
+    "Harlow Solid Italic": false,
+    'Harrington': false,
+    'Harvest': false,
+    'HarvestItal': false,
+    "Haxton Logos TT": false,
+    "HeadLineA Regular": false,
+    'HeadlineA': false,
+    "Heavy Heap": false,
+    'Hei': false,
+    "Hei Regular": false,
+    "Heiti SC": false,
+    "Heiti SC Light": false,
+    "Heiti SC Medium": false,
+    "Heiti TC": false,
+    "Heiti TC Light": false,
+    "Heiti TC Medium": false,
+    'Helvetica': true,
+    "Helvetica Bold": false,
+    "Helvetica CY Bold": false,
+    "Helvetica CY Plain": false,
+    "Helvetica LT Std": false,
+    "Helvetica Light": false,
+    "Helvetica Neue": false,
+    "Helvetica Neue Bold": false,
+    "Helvetica Neue Medium": false,
+    "Helvetica Oblique": false,
+    'HelveticaCY': false,
+    "HelveticaNeueLT Com 107 XBlkCn": false,
+    'Herculanum': false,
+    "High Tower Text": false,
+    'Highboot': false,
+    "Hiragino Kaku Gothic Pro W3": false,
+    "Hiragino Kaku Gothic Pro W6": false,
+    "Hiragino Kaku Gothic ProN W3": false,
+    "Hiragino Kaku Gothic ProN W6": false,
+    "Hiragino Kaku Gothic Std W8": false,
+    "Hiragino Kaku Gothic StdN W8": false,
+    "Hiragino Maru Gothic Pro W4": false,
+    "Hiragino Maru Gothic ProN W4": false,
+    "Hiragino Mincho Pro W3": false,
+    "Hiragino Mincho Pro W6": false,
+    "Hiragino Mincho ProN W3": false,
+    "Hiragino Mincho ProN W6": false,
+    "Hiragino Sans GB W3": false,
+    "Hiragino Sans GB W6": false,
+    "Hiragino Sans W0": false,
+    "Hiragino Sans W1": false,
+    "Hiragino Sans W2": false,
+    "Hiragino Sans W3": false,
+    "Hiragino Sans W4": false,
+    "Hiragino Sans W5": false,
+    "Hiragino Sans W6": false,
+    "Hiragino Sans W7": false,
+    "Hiragino Sans W8": false,
+    "Hiragino Sans W9": false,
+    "Hobo Std": false,
+    "Hoefler Text": false,
+    "Hoefler Text Black": false,
+    "Hoefler Text Ornaments": false,
+    "Hollywood Hills": false,
+    'Hombre': false,
+    "Huxley Titling": false,
+    "ITC Stone Serif": false,
+    "ITF Devanagari": false,
+    "ITF Devanagari Marathi": false,
+    "ITF Devanagari Medium": false,
+    'Impact': true,
+    "Imprint MT Shadow": false,
+    'InaiMathi': false,
+    'Induction': false,
+    "Informal Roman": false,
+    "Ink Free": true,
+    'IrisUPC': false,
+    "Iskoola Pota": false,
+    'Italianate': false,
+    'Jamrul': false,
+    'JasmineUPC': false,
+    "Javanese Text": true,
+    'Jokerman': false,
+    "Juice ITC": false,
+    'KacstArt': false,
+    'KacstBook': false,
+    'KacstDecorative': false,
+    'KacstDigital': false,
+    'KacstFarsi': false,
+    'KacstLetter': false,
+    'KacstNaskh': false,
+    'KacstOffice': false,
+    'KacstOne': false,
+    'KacstPen': false,
+    'KacstPoster': false,
+    'KacstQurn': false,
+    'KacstScreen': false,
+    'KacstTitle': false,
+    'KacstTitleL': false,
+    'Kai': false,
+    "Kai Regular": false,
+    'KaiTi': false,
+    'Kailasa': false,
+    "Kailasa Regular": false,
+    "Kaiti SC": false,
+    "Kaiti SC Black": false,
+    'Kalapi': false,
+    'Kalimati': false,
+    'Kalinga': false,
+    "Kannada MN": false,
+    "Kannada MN Bold": false,
+    "Kannada Sangam MN": false,
+    "Kannada Sangam MN Bold": false,
+    'Kartika': false,
+    'Karumbi': false,
+    'Kedage': false,
+    'Kefa': false,
+    "Kefa Bold": false,
+    'Keraleeyam': false,
+    'Keyboard': false,
+    "Khmer MN": false,
+    "Khmer MN Bold": false,
+    "Khmer OS": false,
+    "Khmer OS System": false,
+    "Khmer Sangam MN": false,
+    "Khmer UI": false,
+    'Kinnari': false,
+    "Kino MT": false,
+    'KodchiangUPC': false,
+    "Kohinoor Bangla": false,
+    "Kohinoor Devanagari": false,
+    "Kohinoor Telugu": false,
+    'Kokila': false,
+    'Kokonor': false,
+    "Kokonor Regular": false,
+    "Kozuka Gothic Pr6N B": false,
+    "Kristen ITC": false,
+    'Krungthep': false,
+    'KufiStandardGK': false,
+    "KufiStandardGK Regular": false,
+    "Kunstler Script": false,
+    'Laksaman': false,
+    "Lao MN": false,
+    "Lao Sangam MN": false,
+    "Lao UI": false,
+    'LastResort': false,
+    'Latha': false,
+    'Leelawadee': false,
+    "Letter Gothic Std": false,
+    'LetterOMatic!': false,
+    "Levenim MT": false,
+    "LiHei Pro": false,
+    "LiSong Pro": false,
+    "Liberation Mono": false,
+    "Liberation Sans": false,
+    "Liberation Sans Narrow": false,
+    "Liberation Serif": false,
+    'Likhan': false,
+    'LilyUPC': false,
+    'Limousine': false,
+    "Lithos Pro Regular": false,
+    'LittleLordFontleroy': false,
+    "Lohit Assamese": false,
+    "Lohit Bengali": false,
+    "Lohit Devanagari": false,
+    "Lohit Gujarati": false,
+    "Lohit Gurmukhi": false,
+    "Lohit Hindi": false,
+    "Lohit Kannada": false,
+    "Lohit Malayalam": false,
+    "Lohit Odia": false,
+    "Lohit Punjabi": false,
+    "Lohit Tamil": false,
+    "Lohit Tamil Classical": false,
+    "Lohit Telugu": false,
+    'Loma': false,
+    "Lucida Blackletter": false,
+    "Lucida Bright": false,
+    "Lucida Bright Demibold": false,
+    "Lucida Bright Demibold Italic": false,
+    "Lucida Bright Italic": false,
+    "Lucida Calligraphy": false,
+    "Lucida Calligraphy Italic": false,
+    "Lucida Console": true,
+    "Lucida Fax": false,
+    "Lucida Fax Demibold": false,
+    "Lucida Fax Regular": false,
+    "Lucida Grande": false,
+    "Lucida Grande Bold": false,
+    "Lucida Handwriting": false,
+    "Lucida Handwriting Italic": false,
+    "Lucida Sans": false,
+    "Lucida Sans Demibold Italic": false,
+    "Lucida Sans Typewriter": false,
+    "Lucida Sans Typewriter Bold": false,
+    "Lucida Sans Unicode": true,
+    'Luminari': false,
+    "Luxi Mono": false,
+    "MS Gothic": true,
+    "MS Mincho": false,
+    "MS Outlook": false,
+    "MS PGothic": true,
+    "MS PMincho": false,
+    "MS Reference Sans Serif": false,
+    "MS Reference Specialty": false,
+    "MS Sans Serif": true,
+    "MS Serif": true,
+    "MS UI Gothic": true,
+    "MT Extra": false,
+    "MV Boli": true,
+    'Mael': false,
+    'Magneto': false,
+    "Maiandra GD": false,
+    "Malayalam MN": false,
+    "Malayalam MN Bold": false,
+    "Malayalam Sangam MN": false,
+    "Malayalam Sangam MN Bold": false,
+    "Malgun Gothic": true,
+    'Mallige': false,
+    'Mangal': false,
+    'Manorly': false,
+    'Marion': false,
+    "Marion Bold": false,
+    "Marker Felt": false,
+    "Marker Felt Thin": false,
+    'Marlett': true,
+    'Martina': false,
+    "Matura MT Script Capitals": false,
+    'Meera': false,
+    'Meiryo': false,
+    "Meiryo Bold": false,
+    "Meiryo UI": false,
+    'MelodBold': false,
+    'Menlo': false,
+    "Menlo Bold": false,
+    "Mesquite Std": false,
+    'Microsoft': false,
+    "Microsoft Himalaya": true,
+    "Microsoft JhengHei": true,
+    "Microsoft JhengHei UI": true,
+    "Microsoft New Tai Lue": true,
+    "Microsoft PhagsPa": true,
+    "Microsoft Sans Serif": true,
+    "Microsoft Tai Le": true,
+    "Microsoft Tai Le Bold": false,
+    "Microsoft Uighur": false,
+    "Microsoft YaHei": true,
+    "Microsoft YaHei UI": true,
+    "Microsoft Yi Baiti": true,
+    'Minerva': false,
+    'MingLiU': false,
+    'MingLiU-ExtB': true,
+    'MingLiU_HKSCS': false,
+    "Minion Pro": false,
+    'Miriam': false,
+    'Mishafi': false,
+    "Mishafi Gold": false,
+    'Mistral': false,
+    'Modern': false,
+    "Modern No. 20": false,
+    'Monaco': false,
+    "Mongolian Baiti": true,
+    'Monospace': false,
+    "Monotype Corsiva": false,
+    "Monotype Sorts": false,
+    'MoolBoran': false,
+    'Moonbeam': false,
+    'MotoyaLMaru': false,
+    'Mshtakan': false,
+    "Mshtakan Bold": false,
+    "Mukti Narrow": false,
+    'Muna': false,
+    "Myanmar MN": false,
+    "Myanmar MN Bold": false,
+    "Myanmar Sangam MN": false,
+    "Myanmar Text": true,
+    'Mycalc': false,
+    "Myriad Arabic": false,
+    "Myriad Hebrew": false,
+    "Myriad Pro": false,
+    'NISC18030': false,
+    'NSimSun': true,
+    'Nadeem': false,
+    "Nadeem Regular": false,
+    'Nakula': false,
+    "Nanum Barun Gothic": false,
+    "Nanum Gothic": false,
+    "Nanum Myeongjo": false,
+    'NanumBarunGothic': false,
+    'NanumGothic': false,
+    "NanumGothic Bold": false,
+    'NanumGothicCoding': false,
+    'NanumMyeongjo': false,
+    "NanumMyeongjo Bold": false,
+    'Narkisim': false,
+    'Nasalization': false,
+    'Navilu': false,
+    "Neon Lights": false,
+    "New Peninim MT": false,
+    "New Peninim MT Bold": false,
+    "News Gothic MT": false,
+    "News Gothic MT Bold": false,
+    "Niagara Engraved": false,
+    "Niagara Solid": false,
+    "Nimbus Mono L": false,
+    "Nimbus Roman No9 L": false,
+    "Nimbus Sans L": false,
+    "Nimbus Sans L Condensed": false,
+    'Nina': false,
+    "Nirmala UI": true,
+    'Nirmala.ttf': false,
+    'Norasi': false,
+    'Noteworthy': false,
+    "Noteworthy Bold": false,
+    "Noto Color Emoji": false,
+    "Noto Emoji": false,
+    "Noto Mono": false,
+    "Noto Naskh Arabic": false,
+    "Noto Nastaliq Urdu": false,
+    "Noto Sans": false,
+    "Noto Sans Armenian": false,
+    "Noto Sans Bengali": false,
+    "Noto Sans CJK": false,
+    "Noto Sans Canadian Aboriginal": false,
+    "Noto Sans Cherokee": false,
+    "Noto Sans Devanagari": false,
+    "Noto Sans Ethiopic": false,
+    "Noto Sans Georgian": false,
+    "Noto Sans Gujarati": false,
+    "Noto Sans Gurmukhi": false,
+    "Noto Sans Hebrew": false,
+    "Noto Sans JP": false,
+    "Noto Sans KR": false,
+    "Noto Sans Kannada": false,
+    "Noto Sans Khmer": false,
+    "Noto Sans Lao": false,
+    "Noto Sans Malayalam": false,
+    "Noto Sans Myanmar": false,
+    "Noto Sans Oriya": false,
+    "Noto Sans SC": false,
+    "Noto Sans Sinhala": false,
+    "Noto Sans Symbols": false,
+    "Noto Sans TC": false,
+    "Noto Sans Tamil": false,
+    "Noto Sans Telugu": false,
+    "Noto Sans Thai": false,
+    "Noto Sans Yi": false,
+    "Noto Serif": false,
+    'Notram': false,
+    'November': false,
+    "Nueva Std": false,
+    "Nueva Std Cond": false,
+    'Nyala': false,
+    "OCR A Extended": false,
+    "OCR A Std": false,
+    "Old English Text MT": false,
+    'OldeEnglish': false,
+    'Onyx': false,
+    'OpenSymbol': false,
+    'OpineHeavy': false,
+    'Optima': false,
+    "Optima Bold": false,
+    "Optima Regular": false,
+    "Orator Std": false,
+    "Oriya MN": false,
+    "Oriya MN Bold": false,
+    "Oriya Sangam MN": false,
+    "Oriya Sangam MN Bold": false,
+    'Osaka': false,
+    'Osaka-Mono': false,
+    'OsakaMono': false,
+    "PCMyungjo Regular": false,
+    'PCmyoungjo': false,
+    'PMingLiU': false,
+    'PMingLiU-ExtB': true,
+    "PR Celtic Narrow": false,
+    "PT Mono": false,
+    "PT Sans": false,
+    "PT Sans Bold": false,
+    "PT Sans Caption Bold": false,
+    "PT Sans Narrow Bold": false,
+    "PT Serif": false,
+    'Padauk': false,
+    "Padauk Book": false,
+    'Padmaa': false,
+    'Pagul': false,
+    "Palace Script MT": false,
+    'Palatino': false,
+    "Palatino Bold": false,
+    "Palatino Linotype": true,
+    "Palatino Linotype Bold": false,
+    'Papyrus': false,
+    "Papyrus Condensed": false,
+    'Parchment': false,
+    "Parry Hotter": false,
+    'PenultimateLight': false,
+    'Perpetua': false,
+    "Perpetua Bold": false,
+    "Perpetua Titling MT": false,
+    "Perpetua Titling MT Bold": false,
+    "Phetsarath OT": false,
+    'Phosphate': false,
+    "Phosphate Inline": false,
+    "Phosphate Solid": false,
+    'PhrasticMedium': false,
+    "PilGi Regular": false,
+    'Pilgiche': false,
+    "PingFang HK": false,
+    "PingFang SC": false,
+    "PingFang TC": false,
+    'Pirate': false,
+    "Plantagenet Cherokee": false,
+    'Playbill': false,
+    "Poor Richard": false,
+    "Poplar Std": false,
+    'Pothana2000': false,
+    "Prestige Elite Std": false,
+    'Pristina': false,
+    'Purisa': false,
+    'QuiverItal': false,
+    'Raanana': false,
+    "Raanana Bold": false,
+    'Raavi': false,
+    'Rachana': false,
+    "Rage Italic": false,
+    'RaghuMalayalam': false,
+    'Ravie': false,
+    'Rekha': false,
+    'Roboto': false,
+    'Rockwell': false,
+    "Rockwell Bold": false,
+    "Rockwell Condensed": false,
+    "Rockwell Extra Bold": false,
+    "Rockwell Italic": false,
+    'Rod': false,
+    'Roland': false,
+    'Rondalo': false,
+    "Rosewood Std Regular": false,
+    'RowdyHeavy': false,
+    "Russel Write TT": false,
+    "SF Movie Poster": false,
+    'STFangsong': false,
+    'STHeiti': false,
+    'STIXGeneral': false,
+    'STIXGeneral-Bold': false,
+    'STIXGeneral-Regular': false,
+    'STIXIntegralsD': false,
+    'STIXIntegralsD-Bold': false,
+    'STIXIntegralsSm': false,
+    'STIXIntegralsSm-Bold': false,
+    'STIXIntegralsUp': false,
+    'STIXIntegralsUp-Bold': false,
+    'STIXIntegralsUp-Regular': false,
+    'STIXIntegralsUpD': false,
+    'STIXIntegralsUpD-Bold': false,
+    'STIXIntegralsUpD-Regular': false,
+    'STIXIntegralsUpSm': false,
+    'STIXIntegralsUpSm-Bold': false,
+    'STIXNonUnicode': false,
+    'STIXNonUnicode-Bold': false,
+    'STIXSizeFiveSym': false,
+    'STIXSizeFiveSym-Regular': false,
+    'STIXSizeFourSym': false,
+    'STIXSizeFourSym-Bold': false,
+    'STIXSizeOneSym': false,
+    'STIXSizeOneSym-Bold': false,
+    'STIXSizeThreeSym': false,
+    'STIXSizeThreeSym-Bold': false,
+    'STIXSizeTwoSym': false,
+    'STIXSizeTwoSym-Bold': false,
+    'STIXVariants': false,
+    'STIXVariants-Bold': false,
+    'STKaiti': false,
+    'STSong': false,
+    'STXihei': false,
+    "SWGamekeys MT": false,
+    'Saab': false,
+    'Sahadeva': false,
+    "Sakkal Majalla": false,
+    'Salina': false,
+    'Samanata': false,
+    "Samyak Devanagari": false,
+    "Samyak Gujarati": false,
+    "Samyak Malayalam": false,
+    "Samyak Tamil": false,
+    'Sana': false,
+    "Sana Regular": false,
+    'Sans': false,
+    'Sarai': false,
+    'Sathu': false,
+    "Savoye LET Plain:1.0": false,
+    'Sawasdee': false,
+    'Script': false,
+    "Script MT Bold": false,
+    "Segoe MDL2 Assets": true,
+    "Segoe Print": true,
+    "Segoe Pseudo": false,
+    "Segoe Script": true,
+    "Segoe UI": true,
+    "Segoe UI Emoji": true,
+    "Segoe UI Historic": true,
+    "Segoe UI Semilight": false,
+    "Segoe UI Symbol": true,
+    'Serif': false,
+    "Shonar Bangla": false,
+    "Showcard Gothic": false,
+    "Shree Devanagari 714": false,
+    'Shruti': false,
+    'SignPainter-HouseScript': false,
+    'Silom': false,
+    'SimHei': false,
+    'SimSun': true,
+    'SimSun-ExtB': true,
+    "Simplified Arabic": false,
+    "Simplified Arabic Fixed": false,
+    "Sinhala MN": false,
+    "Sinhala MN Bold": false,
+    "Sinhala Sangam MN": false,
+    "Sinhala Sangam MN Bold": false,
+    'Sitka': false,
+    'Skia': false,
+    "Skia Regular": false,
+    'Skinny': false,
+    "Small Fonts": false,
+    "Snap ITC": false,
+    "Snell Roundhand": false,
+    'Snowdrift': false,
+    "Songti SC": false,
+    "Songti SC Black": false,
+    "Songti TC": false,
+    "Source Code Pro": false,
+    'Splash': false,
+    "Standard Symbols L": false,
+    'Stencil': false,
+    "Stencil Std": false,
+    'Stephen': false,
+    "Sukhumvit Set": false,
+    'Suruma': false,
+    'Sylfaen': true,
+    'Symbol': true,
+    'Symbole': false,
+    'System': false,
+    "System Font": false,
+    'TAMu_Kadambri': false,
+    'TAMu_Kalyani': false,
+    'TAMu_Maduram': false,
+    'TSCu_Comic': false,
+    'TSCu_Paranar': false,
+    'TSCu_Times': false,
+    'Tahoma': true,
+    "Tahoma Negreta": false,
+    'TakaoExGothic': false,
+    'TakaoExMincho': false,
+    'TakaoGothic': false,
+    'TakaoMincho': false,
+    'TakaoPGothic': false,
+    'TakaoPMincho': false,
+    "Tamil MN": false,
+    "Tamil MN Bold": false,
+    "Tamil Sangam MN": false,
+    "Tamil Sangam MN Bold": false,
+    'Tarzan': false,
+    "Tekton Pro": false,
+    "Tekton Pro Cond": false,
+    "Tekton Pro Ext": false,
+    "Telugu MN": false,
+    "Telugu MN Bold": false,
+    "Telugu Sangam MN": false,
+    "Telugu Sangam MN Bold": false,
+    "Tempus Sans ITC": false,
+    'Terminal': false,
+    "Terminator Two": false,
+    'Thonburi': false,
+    "Thonburi Bold": false,
+    "Tibetan Machine Uni": false,
+    'Times': true,
+    "Times Bold": false,
+    "Times New Roman": true,
+    "Times New Roman Baltic": false,
+    "Times New Roman Bold": false,
+    "Times New Roman Italic": false,
+    "Times Roman": false,
+    "Tlwg Mono": false,
+    "Tlwg Typewriter": false,
+    "Tlwg Typist": false,
+    "Tlwg Typo": false,
+    'TlwgMono': false,
+    'TlwgTypewriter': false,
+    'Toledo': false,
+    "Traditional Arabic": false,
+    "Trajan Pro": false,
+    'Trattatello': false,
+    "Trebuchet MS": true,
+    "Trebuchet MS Bold": false,
+    'Tunga': false,
+    "Tw Cen MT": false,
+    "Tw Cen MT Bold": false,
+    "Tw Cen MT Italic": false,
+    "URW Bookman L": false,
+    "URW Chancery L": false,
+    "URW Gothic L": false,
+    "URW Palladio L": false,
+    'Ubuntu': false,
+    "Ubuntu Condensed": false,
+    "Ubuntu Mono": false,
+    'Ukai': false,
+    "Ume Gothic": false,
+    "Ume Mincho": false,
+    "Ume P Gothic": false,
+    "Ume P Mincho": false,
+    "Ume UI Gothic": false,
+    'Uming': false,
+    'Umpush': false,
+    'UnBatang': false,
+    'UnDinaru': false,
+    'UnDotum': false,
+    'UnGraphic': false,
+    'UnGungseo': false,
+    'UnPilgi': false,
+    'Untitled1': false,
+    "Urdu Typesetting": false,
+    'Uroob': false,
+    'Utkal': false,
+    'Utopia': false,
+    'Utsaah': false,
+    'Valken': false,
+    'Vani': false,
+    'Vemana2000': false,
+    'Verdana': true,
+    "Verdana Bold": false,
+    'Vijaya': false,
+    "Viner Hand ITC": false,
+    'Vivaldi': false,
+    'Vivian': false,
+    "Vladimir Script": false,
+    'Vrinda': false,
+    'Waree': false,
+    'Waseem': false,
+    'Waverly': false,
+    'Webdings': true,
+    "WenQuanYi Bitmap Song": false,
+    "WenQuanYi Micro Hei": false,
+    "WenQuanYi Micro Hei Mono": false,
+    "WenQuanYi Zen Hei": false,
+    "Whimsy TT": false,
+    "Wide Latin": false,
+    'Wingdings': true,
+    "Wingdings 2": false,
+    "Wingdings 3": false,
+    'Woodcut': false,
+    'X-Files': false,
+    "Year supply of fairy cakes": false,
+    "Yu Gothic": true,
+    "Yu Mincho": false,
+    "Yuppy SC": false,
+    "Yuppy SC Regular": false,
+    "Yuppy TC": false,
+    "Yuppy TC Regular": false,
+    "Zapf Dingbats": false,
+    'Zapfino': false,
+    'Zawgyi-One': false,
+    'gargi': false,
+    'lklug': false,
+    'mry_KacstQurn': false,
+    'ori1Uni': false
+  });
+  const a0_0x2c3e19 = () => {
+    try {
+      const _0xfbb4dd = window.OfflineAudioContext || window.webkitOfflineAudioContext;
+      if (!_0xfbb4dd) {
+        return -2;
+      }
+      const _0x15023f = new _0xfbb4dd(1, 5000, 44100);
+      const _0x22ca1c = _0x15023f.createOscillator();
+      _0x22ca1c.type = "triangle";
+      _0x22ca1c.frequency.value = 10000;
+      const _0xb79e70 = _0x15023f.createDynamicsCompressor();
+      _0xb79e70.threshold.value = -50;
+      _0xb79e70.knee.value = 40;
+      _0xb79e70.ratio.value = 12;
+      _0xb79e70.attack.value = 0;
+      _0xb79e70.release.value = 0.25;
+      _0x22ca1c.connect(_0xb79e70);
+      _0xb79e70.connect(_0x15023f.destination);
+      _0x22ca1c.start(0);
+      const [_0x47f25f, _0x3e4f4e] = a0_0x287814(_0x15023f);
+      const _0x467fe1 = _0x47f25f.then((_0x26704e) => a0_0x3b9acd(_0x26704e.getChannelData(0).subarray(4500)), (_0x296517) => {
+        if (_0x296517.name === "timeout" || _0x296517.name === "suspended") {
+          return "timeout";
+        }
+        throw _0x296517;
+      });
+      _0x467fe1["catch"](() => undefined);
+      _0x3e4f4e();
+      return _0x467fe1;
+    } catch (_0x1f1ba8) {
+      return -1;
+    }
+  };
+  function a0_0x287814(_0x2c054f) {
+    let _0x54ba59 = () => undefined;
+    const _0x493e7 = new Promise((_0x212cb3, _0xc18f9f) => {
+      let _0x52c9c4 = false;
+      let _0x481d08 = 0;
+      let _0x52cacf = 0;
+      _0x2c054f.oncomplete = (_0xebe59a) => _0x212cb3(_0xebe59a.renderedBuffer);
+      const _0x9cd96d = () => {
+        setTimeout(() => _0xc18f9f(a0_0x4d44f3("timeout")), Math.min(500, _0x52cacf + 5000 - Date.now()));
+      };
+      const _0x165d8f = () => {
+        try {
+          _0x2c054f.startRendering();
+          switch (_0x2c054f.state) {
+            case "running":
+              _0x52cacf = Date.now();
+              if (_0x52c9c4) {
+                _0x9cd96d();
+              }
+              break;
+            case 'suspended':
+              if (!document.hidden) {
+                _0x481d08++;
+              }
+              if (_0x52c9c4 && _0x481d08 >= 3) {
+                _0xc18f9f(a0_0x4d44f3('suspended'));
+              } else {
+                setTimeout(_0x165d8f, 500);
+              }
+              break;
+          }
+        } catch (_0x49e512) {
+          _0xc18f9f(_0x49e512);
+        }
+      };
+      _0x165d8f();
+      _0x54ba59 = () => {
+        if (!_0x52c9c4) {
+          _0x52c9c4 = true;
+          if (_0x52cacf > 0) {
+            _0x9cd96d();
+          }
+        }
+      };
+    });
+    return [_0x493e7, _0x54ba59];
+  }
+  function a0_0x3b9acd(_0x48012e) {
+    let _0xf9755a = 0;
+    for (let _0x301c97 = 0; _0x301c97 < _0x48012e.length; ++_0x301c97) {
+      _0xf9755a += Math.abs(_0x48012e[_0x301c97]);
+    }
+    return _0xf9755a;
+  }
+  function a0_0x4d44f3(_0x347edf) {
+    const _0x4fc17d = new Error(_0x347edf);
+    _0x4fc17d.name = _0x347edf;
+    return _0x4fc17d;
+  }
+  const a0_0x3d0a5e = () => {
+    try {
+      const _0x15337c = [{
+        's': "Windows 10",
+        'r': /(Windows 10.0|Windows NT 10.0)/
+      }, {
+        's': "Windows 8.1",
+        'r': /(Windows 8.1|Windows NT 6.3)/
+      }, {
+        's': "Windows 8",
+        'r': /(Windows 8|Windows NT 6.2)/
+      }, {
+        's': "Windows 7",
+        'r': /(Windows 7|Windows NT 6.1)/
+      }, {
+        's': "Windows Vista",
+        'r': /Windows NT 6.0/
+      }, {
+        's': "Windows Server 2003",
+        'r': /Windows NT 5.2/
+      }, {
+        's': "Windows XP",
+        'r': /(Windows NT 5.1|Windows XP)/
+      }, {
+        's': "Windows 2000",
+        'r': /(Windows NT 5.0|Windows 2000)/
+      }, {
+        's': "Windows ME",
+        'r': /(Win 9x 4.90|Windows ME)/
+      }, {
+        's': "Windows 98",
+        'r': /(Windows 98|Win98)/
+      }, {
+        's': "Windows 95",
+        'r': /(Windows 95|Win95|Windows_95)/
+      }, {
+        's': "Windows NT 4.0",
+        'r': /(Windows NT 4.0|WinNT4.0|WinNT|Windows NT)/
+      }, {
+        's': "Windows CE",
+        'r': /Windows CE/
+      }, {
+        's': "Windows 3.11",
+        'r': /Win16/
+      }, {
+        's': "Android",
+        'r': /Android/
+      }, {
+        's': "Open BSD",
+        'r': /OpenBSD/
+      }, {
+        's': "Sun OS",
+        'r': /SunOS/
+      }, {
+        's': "Chrome OS",
+        'r': /CrOS/
+      }, {
+        's': "Linux",
+        'r': /(Linux|X11(?!.*CrOS))/
+      }, {
+        's': "iOS",
+        'r': /(iPhone|iPad|iPod)/
+      }, {
+        's': "Mac OS X",
+        'r': /Mac OS X/
+      }, {
+        's': "Mac OS",
+        'r': /(Mac OS|MacPPC|MacIntel|Mac_PowerPC|Macintosh)/
+      }, {
+        's': 'QNX',
+        'r': /QNX/
+      }, {
+        's': "UNIX",
+        'r': /UNIX/
+      }, {
+        's': "BeOS",
+        'r': /BeOS/
+      }, {
+        's': "OS/2",
+        'r': /OS\/2/
+      }, {
+        's': "Search Bot",
+        'r': /(nuhk|Googlebot|Yammybot|Openbot|Slurp|MSNBot|Ask Jeeves\/Teoma|ia_archiver)/
+      }];
+      let _0x110760;
+      let _0x5e4e14 = _0x15337c.filter((_0x4c3dad) => _0x4c3dad.r.test(navigator.userAgent))[0].s;
+      if (/Windows/.test(_0x5e4e14)) {
+        _0x110760 = /Windows (.*)/.exec(_0x5e4e14)[1];
+        _0x5e4e14 = "Windows";
+      }
+      switch (_0x5e4e14) {
+        case "Mac OS":
+        case "Mac OS X":
+        case 'Android':
+          _0x110760 = /(?:Android|Mac OS|Mac OS X|MacPPC|MacIntel|Mac_PowerPC|Macintosh) ([._\d]+)/.exec(navigator.userAgent)[1];
+          break;
+        case 'iOS':
+          _0x110760 = /OS (\d+)_(\d+)_?(\d+)?/.exec(navigator.appVersion);
+          _0x110760 = _0x110760[1] + '.' + _0x110760[2] + '.' + (_0x110760[3] | 0);
+          break;
+      }
+      return {
+        'name': _0x5e4e14,
+        'version': _0x110760
+      };
+    } catch (_0x57a836) {
+      return {
+        'name': "Unknown",
+        'version': 'Unknown'
+      };
+    }
+  };
+  const a0_0x477844 = () => {
+    try {
+      const _0x2ff8c6 = navigator.userAgent;
+      const _0x10077b = [{
+        'name': "Opera",
+        'getInfo': (_0x4b4acc) => {
+          if (_0x2ff8c6.indexOf("Version") !== -1) {
+            return {
+              'name': 'Opera',
+              'version': _0x2ff8c6.substring(_0x4b4acc + 8)
+            };
+          }
+          return {
+            'name': "Opera",
+            'version': _0x2ff8c6.substring(_0x4b4acc + 6)
+          };
+        }
+      }, {
+        'name': 'OPR',
+        'getInfo': (_0x16e06d) => {
+          return {
+            'name': 'Opera',
+            'version': _0x2ff8c6.substring(_0x16e06d + 4)
+          };
+        }
+      }, {
+        'name': "Edge",
+        'getInfo': (_0x15fbf8) => {
+          return {
+            'name': "Edge",
+            'version': _0x2ff8c6.substring(_0x15fbf8 + 5)
+          };
+        }
+      }, {
+        'name': 'Edg',
+        'getInfo': (_0xb3573c) => {
+          return {
+            'name': "Edge",
+            'version': _0x2ff8c6.substring(_0xb3573c + 4)
+          };
+        }
+      }, {
+        'name': "MSIE",
+        'getInfo': (_0x2dcec5) => {
+          return {
+            'name': "Internet Explorer",
+            'version': _0x2ff8c6.substring(_0x2dcec5 + 5)
+          };
+        }
+      }, {
+        'name': "Chrome",
+        'getInfo': (_0x50de01) => {
+          return {
+            'name': 'Chrome',
+            'version': _0x2ff8c6.substring(_0x50de01 + 7)
+          };
+        }
+      }, {
+        'name': 'Safari',
+        'getInfo': (_0x2afa69) => {
+          const _0x1fc36b = _0x2ff8c6.indexOf("Version");
+          if (_0x1fc36b !== -1) {
+            return {
+              'name': "Safari",
+              'version': _0x2ff8c6.substring(_0x2afa69 + 8)
+            };
+          }
+          return {
+            'name': "Safari",
+            'version': _0x2ff8c6.substring(_0x2afa69 + 7)
+          };
+        }
+      }, {
+        'name': "Firefox",
+        'getInfo': (_0x221e8) => {
+          return {
+            'name': "Firefox",
+            'version': _0x2ff8c6.substring(_0x221e8 + 8)
+          };
+        }
+      }, {
+        'name': 'Trident/',
+        'getInfo': () => {
+          return {
+            'name': "Internet Explorer",
+            'version': _0x2ff8c6.substring(_0x2ff8c6.indexOf("rv:") + 3)
+          };
+        }
+      }];
+      return _0x10077b.filter(({
+        name: _0x2e1afe
+      }) => _0x2ff8c6.indexOf(_0x2e1afe) !== -1).map(({
+        getInfo: _0x176b17,
+        name: _0x431d87
+      }) => _0x176b17(_0x2ff8c6.indexOf(_0x431d87)))[0];
+    } catch (_0x13ade1) {
+      return {
+        'name': "Unknown",
+        'version': 'Unknown'
+      };
+    }
+  };
+  const a0_0x4cc642 = () => {
+    try {
+      const _0x2a59d0 = document.createElement("canvas");
+      const _0x5c7cd3 = _0x2a59d0.getContext('2d');
+      const _0x1885a9 = "i9asdm..$#po((^@KbXrww!~cz";
+      _0x5c7cd3.textBaseline = 'top';
+      _0x5c7cd3.font = "16px 'Arial'";
+      _0x5c7cd3.textBaseline = 'alphabetic';
+      _0x5c7cd3.rotate(0.05);
+      _0x5c7cd3.fillStyle = "#f60";
+      _0x5c7cd3.fillRect(125, 1, 62, 20);
+      _0x5c7cd3.fillStyle = "#069";
+      _0x5c7cd3.fillText(_0x1885a9, 2, 15);
+      _0x5c7cd3.fillStyle = "rgba(102, 200, 0, 0.7)";
+      _0x5c7cd3.fillText(_0x1885a9, 4, 17);
+      _0x5c7cd3.shadowBlur = 10;
+      _0x5c7cd3.shadowColor = 'blue';
+      _0x5c7cd3.fillRect(-20, 10, 234, 5);
+      const _0x5a3a2b = _0x2a59d0.toDataURL();
+      let _0x475d03 = 0;
+      if (_0x5a3a2b.length === 0) {
+        return "nothing!";
+      }
+      for (let _0x49a437 = 0; _0x49a437 < _0x5a3a2b.length; _0x49a437++) {
+        const _0x27ce72 = _0x5a3a2b.charCodeAt(_0x49a437);
+        _0x475d03 = (_0x475d03 << 5) - _0x475d03 + _0x27ce72;
+        _0x475d03 = _0x475d03 & _0x475d03;
+      }
+      return _0x475d03;
+    } catch (_0x338ad6) {
+      return -1;
+    }
+  };
+  const a0_0x404bcb = () => {
+    try {
+      const _0x30a349 = document.createElement("canvas");
+      _0x30a349.width = 256;
+      _0x30a349.height = 128;
+      const _0x16f5f7 = _0x30a349.getContext('webgl2') || _0x30a349.getContext("experimental-webgl2") || _0x30a349.getContext("webgl") || _0x30a349.getContext("experimental-webgl") || _0x30a349.getContext("moz-webgl");
+      try {
+        const _0x3e4350 = "precision mediump float;varying vec2 varyinTexCoordinate;void main() {gl_FragColor=vec4(varyinTexCoordinate,0,1);}";
+        const _0x3fb92c = _0x16f5f7.createBuffer();
+        _0x16f5f7.bindBuffer(_0x16f5f7.ARRAY_BUFFER, _0x3fb92c);
+        const _0x56cc48 = new Float32Array([-0.2, -0.9, 0, 0.4, -0.26, 0, 0, 0.7321, 0]);
+        _0x16f5f7.bufferData(_0x16f5f7.ARRAY_BUFFER, _0x56cc48, _0x16f5f7.STATIC_DRAW);
+        _0x3fb92c.itemSize = 3;
+        _0x3fb92c.numItems = 3;
+        const _0x1184f5 = _0x16f5f7.createProgram();
+        const _0x22bdc0 = _0x16f5f7.createShader(_0x16f5f7.VERTEX_SHADER);
+        _0x16f5f7.shaderSource(_0x22bdc0, "attribute vec2 attrVertex;varying vec2 varyinTexCoordinate;uniform vec2 uniformOffset;void main(){varyinTexCoordinate=attrVertex+uniformOffset;gl_Position=vec4(attrVertex,0,1);}");
+        _0x16f5f7.compileShader(_0x22bdc0);
+        const _0x3ab624 = _0x16f5f7.createShader(_0x16f5f7.FRAGMENT_SHADER);
+        _0x16f5f7.shaderSource(_0x3ab624, _0x3e4350);
+        _0x16f5f7.compileShader(_0x3ab624);
+        _0x16f5f7.attachShader(_0x1184f5, _0x22bdc0);
+        _0x16f5f7.attachShader(_0x1184f5, _0x3ab624);
+        _0x16f5f7.linkProgram(_0x1184f5);
+        _0x16f5f7.useProgram(_0x1184f5);
+        _0x1184f5.vertexPosAttrib = _0x16f5f7.getAttribLocation(_0x1184f5, "attrVertex");
+        _0x1184f5.offsetUniform = _0x16f5f7.getUniformLocation(_0x1184f5, "uniformOffset");
+        _0x16f5f7.enableVertexAttribArray(_0x1184f5.vertexPosArray);
+        _0x16f5f7.vertexAttribPointer(_0x1184f5.vertexPosAttrib, _0x3fb92c.itemSize, _0x16f5f7.FLOAT, false, 0, 0);
+        _0x16f5f7.uniform2f(_0x1184f5.offsetUniform, 1, 1);
+        _0x16f5f7.drawArrays(_0x16f5f7.TRIANGLE_STRIP, 0, _0x3fb92c.numItems);
+      } catch (_0x1bab52) {}
+      const _0x36b95c = new Uint8Array(131072);
+      _0x16f5f7.readPixels(0, 0, 256, 128, _0x16f5f7.RGBA, _0x16f5f7.UNSIGNED_BYTE, _0x36b95c);
+      let _0x36a8c1 = JSON.stringify(_0x36b95c).replace(/,?"[0-9]+":/g, '');
+      return a0_0x1a3735(_0x36a8c1);
+    } catch (_0x40c53e) {
+      return '-1';
+    }
+  };
+  const a0_0x1a3735 = function () {
+    let _0x46736d = 1;
+    let _0x4b0efe;
+    let _0xf5404c = [];
+    let _0x55557b = [];
+    while (++_0x46736d < 18) {
+      for (_0x4b0efe = _0x46736d * _0x46736d; _0x4b0efe < 312; _0x4b0efe += _0x46736d) {
+        _0xf5404c[_0x4b0efe] = 1;
+      }
+    }
+    _0x46736d = 1;
+    for (_0x4b0efe = 0; _0x46736d < 313;) {
+      if (!_0xf5404c[++_0x46736d]) {
+        _0x55557b[_0x4b0efe] = Math.pow(_0x46736d, 0.5) % 1 * 0x100000000 | 0;
+        _0xf5404c[_0x4b0efe++] = Math.pow(_0x46736d, 0.3333333333333333) % 1 * 0x100000000 | 0;
+      }
+    }
+    function _0x4b8ded(_0x5be528) {
+      let _0x5f0bd8 = _0x55557b.slice(_0x46736d = 0);
+      let _0x230744 = unescape(encodeURI(_0x5be528));
+      let _0x3ac603 = [];
+      let _0x4747b4 = _0x230744.length;
+      let _0x448b6e = [];
+      let _0x5d549c;
+      let _0x2c015c;
+      let _0x29fab2;
+      for (; _0x46736d < _0x4747b4;) {
+        _0x448b6e[_0x46736d >> 2] |= (_0x230744.charCodeAt(_0x46736d) & 255) << 8 * (3 - _0x46736d++ % 4);
+      }
+      _0x4747b4 *= 8;
+      _0x448b6e[_0x4747b4 >> 5] |= 128 << 24 - _0x4747b4 % 32;
+      _0x448b6e[_0x29fab2 = _0x4747b4 + 64 >> 5 | 15] = _0x4747b4;
+      for (_0x46736d = 0; _0x46736d < _0x29fab2; _0x46736d += 16) {
+        _0x5d549c = _0x5f0bd8.slice(_0x4b0efe = 0, 8);
+        for (; _0x4b0efe < 64; _0x5d549c[4] += _0x2c015c) {
+          if (_0x4b0efe < 16) {
+            _0x3ac603[_0x4b0efe] = _0x448b6e[_0x4b0efe + _0x46736d];
+          } else {
+            _0x3ac603[_0x4b0efe] = (((_0x2c015c = _0x3ac603[_0x4b0efe - 2]) >>> 17 | (_0x2c015c = _0x3ac603[_0x4b0efe - 2]) << 15) ^ (_0x2c015c >>> 19 | _0x2c015c << 13) ^ _0x2c015c >>> 10) + (_0x3ac603[_0x4b0efe - 7] | 0) + (((_0x2c015c = _0x3ac603[_0x4b0efe - 15]) >>> 7 | (_0x2c015c = _0x3ac603[_0x4b0efe - 15]) << 25) ^ (_0x2c015c >>> 18 | _0x2c015c << 14) ^ _0x2c015c >>> 3) + (_0x3ac603[_0x4b0efe - 16] | 0);
+          }
+          _0x5d549c.unshift((_0x2c015c = (_0x5d549c.pop() + (((_0x5be528 = _0x5d549c[4]) >>> 6 | (_0x5be528 = _0x5d549c[4]) << 26) ^ (_0x5be528 >>> 11 | _0x5be528 << 21) ^ (_0x5be528 >>> 25 | _0x5be528 << 7)) + ((_0x5be528 & _0x5d549c[5] ^ ~_0x5be528 & _0x5d549c[6]) + _0xf5404c[_0x4b0efe]) | 0) + (_0x3ac603[_0x4b0efe++] | 0)) + (((_0x4747b4 = _0x5d549c[0]) >>> 2 | (_0x4747b4 = _0x5d549c[0]) << 30) ^ (_0x4747b4 >>> 13 | _0x4747b4 << 19) ^ (_0x4747b4 >>> 22 | _0x4747b4 << 10)) + (_0x4747b4 & _0x5d549c[1] ^ _0x5d549c[1] & _0x5d549c[2] ^ _0x5d549c[2] & _0x4747b4));
+        }
+        for (_0x4b0efe = 8; _0x4b0efe--;) {
+          _0x5f0bd8[_0x4b0efe] = _0x5d549c[_0x4b0efe] + _0x5f0bd8[_0x4b0efe];
+        }
+      }
+      for (_0x230744 = ''; _0x4b0efe < 63;) {
+        _0x230744 += (_0x5f0bd8[++_0x4b0efe >> 3] >> 4 * (7 - _0x4b0efe % 8) & 15).toString(16);
+      }
+      return _0x230744;
+    }
+    return _0x4b8ded;
+  }();
+  const a0_0x4c2340 = () => new Promise(async (_0x520020) => {
+    let _0x33407b = setTimeout(() => _0x520020([]), 200);
+    const _0x16c650 = await navigator.mediaDevices.enumerateDevices();
+    clearTimeout(_0x33407b);
+    let _0x391c1b = _0x16c650.map((_0x7f0daa) => _0x7f0daa.kind).sort();
+    _0x520020(_0x391c1b);
+  })["catch"]((_0x4a911b) => []);
+  const a0_0x35fabe = () => {
+    const _0x208c97 = ["audio/aac", 'audio/flac', "audio/mpeg", "audio/mp4; codecs=\"mp4a.40.2\"", "audio/ogg; codecs=\"flac\"", "audio/ogg; codecs=\"vorbis\"", "audio/ogg; codecs=\"opus\"", "audio/wav; codecs=\"1\"", "audio/webm; codecs=\"vorbis\"", "audio/webm; codecs=\"opus\""];
+    try {
+      const _0xe1b939 = document.createElement("audio");
+      return _0x208c97.map((_0x459d08) => {
+        return {
+          'type': _0x459d08,
+          'canPlay': _0xe1b939.canPlayType(_0x459d08)
+        };
+      });
+    } catch (_0x3c62b1) {
+      return _0x208c97.map((_0x2fd5fd) => {
+        return {
+          'type': _0x2fd5fd,
+          'canPlay': "no info"
+        };
+      });
+    }
+  };
+  const a0_0x58bea1 = () => {
+    const _0x142980 = ["video/ogg; codecs=\"theora\"", "video/ogg; codecs=\"opus\"", "video/mp4; codecs=\"avc1.42E01E\"", "video/mp4; codecs=\"flac\"", "video/webm; codecs=\"vp8, vorbis\"", "video/webm; codecs=\"vp9\"", "application/x-mpegURL; codecs=\"avc1.42E01E\""];
+    try {
+      const _0x4126ba = document.createElement("video");
+      return _0x142980.map((_0xdbd7f) => {
+        return {
+          'type': _0xdbd7f,
+          'canPlay': _0x4126ba.canPlayType(_0xdbd7f)
+        };
+      });
+    } catch (_0x4a4e2a) {
+      return _0x142980.map((_0x3670e5) => {
+        return {
+          'type': _0x3670e5,
+          'canPlay': "no info"
+        };
+      });
+    }
+  };
+  const a0_0x22a60d = async () => {
+    try {
+      const _0x17f797 = ["accelerometer", "camera", "clipboard-read", "clipboard-write", "geolocation", 'background-sync', "magnetometer", "microphone", "midi", "notifications", 'payment-handler', "persistent-storage"];
+      const _0x365e30 = {};
+      await Promise.all(_0x17f797.map(async (_0x3efe75) => {
+        try {
+          const {
+            state: _0x2e57ac
+          } = await navigator.permissions.query({
+            'name': _0x3efe75
+          });
+          _0x365e30[_0x3efe75] = _0x2e57ac;
+        } catch (_0x587137) {}
+      }));
+      return _0x365e30;
+    } catch (_0x68711c) {
+      return {};
+    }
+  };
+  const a0_0x4c6604 = () => {
+    try {
+      const _0x3822d8 = document.createElement("canvas");
+      const _0x303519 = _0x3822d8.getContext("webgl") || _0x3822d8.getContext("experimental-webgl");
+      const _0x5bd05d = _0x303519.getExtension('WEBGL_debug_renderer_info');
+      return {
+        'vendor': _0x303519.getParameter(_0x5bd05d.UNMASKED_VENDOR_WEBGL),
+        'renderer': _0x303519.getParameter(_0x5bd05d.UNMASKED_RENDERER_WEBGL),
+        'extensions': _0x303519.getSupportedExtensions()
+      };
+    } catch (_0x3d26a4) {
+      return {
+        'vendor': 'Unknown',
+        'renderer': "Unknown",
+        'extensions': []
+      };
+    }
+  };
+  const a0_0x4dfe89 = () => {
+    try {
+      const _0xfd4672 = new AudioContext();
+      return {
+        'state': _0xfd4672.state,
+        'sampleRate': _0xfd4672.sampleRate,
+        'channelCount': _0xfd4672.destination.channelCount,
+        'channelCountMode': _0xfd4672.destination.channelCountMode,
+        'channelInterpretation': _0xfd4672.destination.channelInterpretation,
+        'maxChannelCount': _0xfd4672.destination.maxChannelCount,
+        'numberOfInputs': _0xfd4672.destination.numberOfInputs,
+        'numberOfOutputs': _0xfd4672.destination.numberOfOutputs
+      };
+    } catch (_0x4a2f4e) {
+      return {};
+    }
+  };
+  const a0_0x25f0a8 = () => {
+    const _0x1f7d1e = document.getElementsByTagName('body')[0];
+    const _0x25909c = document.createElement('div');
+    let _0x2691c6 = document.createDocumentFragment();
+    const _0x2135a9 = ["monospace", "sans-serif", "serif"];
+    const _0x36ca6a = {
+      'monospace': {},
+      'sans-serif': {},
+      'serif': {}
+    };
+    const _0x1a70dd = "fp-check-runtime-0.0.1";
+    const _0x3c711f = {};
+    const _0x15a75b = {};
+    _0x25909c.id = 'fp-div-check-runtime-0.0.1';
+    _0x1f7d1e.appendChild(_0x25909c);
+    _0x2135a9.forEach((_0xe361f3, _0x2fc3e6) => {
+      const _0x6dd718 = document.createElement("span");
+      _0x6dd718.style.fontSize = '72px';
+      _0x6dd718.innerHTML = "mmmmmmmmmmlli";
+      _0x6dd718.style.fontFamily = _0x2135a9[_0x2fc3e6];
+      _0x6dd718.style.position = "fixed";
+      _0x6dd718.style.visibility = "hidden";
+      _0x6dd718.classList.add(_0x1a70dd);
+      _0x2691c6.appendChild(_0x6dd718);
+    });
+    a0_0x516923.forEach((_0x515743) => {
+      _0x2135a9.forEach((_0x2e383c) => {
+        const _0x1a4ba4 = document.createElement("span");
+        _0x1a4ba4.style.fontSize = "72px";
+        _0x1a4ba4.innerHTML = 'mmmmmmmmmmlli';
+        _0x1a4ba4.style.fontFamily = _0x515743 + ',' + _0x2e383c;
+        _0x1a4ba4.style.position = "fixed";
+        _0x1a4ba4.style.visibility = "hidden";
+        _0x1a4ba4.id = _0x515743 + '&' + _0x2e383c;
+        _0x1a4ba4.classList.add(_0x1a70dd);
+        _0x2691c6.appendChild(_0x1a4ba4);
+      });
+    });
+    _0x25909c.appendChild(_0x2691c6);
+    const _0x54d1be = _0x25909c.children;
+    _0x2135a9.forEach((_0x40a792, _0x41b91a) => {
+      _0x3c711f[_0x2135a9[_0x41b91a]] = _0x54d1be[_0x41b91a].offsetWidth;
+      _0x15a75b[_0x2135a9[_0x41b91a]] = _0x54d1be[_0x41b91a].offsetHeight;
+    });
+    for (let _0xd91c63 = 0; _0xd91c63 < _0x54d1be.length; _0xd91c63++) {
+      const [_0x4d7840, _0x49b88f] = _0x54d1be[_0xd91c63].id.split('&');
+      if (_0x49b88f) {
+        _0x36ca6a[_0x49b88f][_0x4d7840] = _0x54d1be[_0xd91c63];
+      }
+    }
+    const _0x11c201 = [];
+    for (let _0x44dc02 = 0; _0x44dc02 < a0_0x516923.length; _0x44dc02++) {
+      for (let _0x5a25a8 = 0; _0x5a25a8 < _0x2135a9.length; _0x5a25a8++) {
+        let _0x49f100 = false;
+        let _0xc5a73d = _0x36ca6a[_0x2135a9[_0x5a25a8]][a0_0x516923[_0x44dc02]];
+        const _0x3d633c = _0xc5a73d.offsetWidth !== _0x3c711f[_0x2135a9[_0x5a25a8]] || _0xc5a73d.offsetHeight !== _0x15a75b[_0x2135a9[_0x5a25a8]];
+        _0x49f100 = _0x49f100 || _0x3d633c;
+        if (_0x49f100) {
+          _0x11c201.push(a0_0x516923[_0x44dc02]);
+          break;
+        }
+      }
+    }
+    document.getElementById('fp-div-check-runtime-0.0.1').remove();
+    return _0x11c201;
+  };
+  const a0_0x594933 = () => {
+    try {
+      const _0x427e6f = [];
+      for (let _0x355b1b = 0; _0x355b1b < navigator.plugins.length; _0x355b1b++) {
+        _0x427e6f.push(navigator.plugins[_0x355b1b].name);
+      }
+      return _0x427e6f;
+    } catch (_0x4dff9d) {
+      return [];
+    }
+  };
+  const a0_0x8de54c = () => {
+    let _0x48a291 = 0;
+    try {
+      if (navigator.webdriver === true) {
+        _0x48a291 |= 1;
+      }
+      if (!window.chrome && !/Firefox/.test(navigator.userAgent) && /Chrome/.test(navigator.userAgent)) {
+        _0x48a291 |= 2;
+      }
+      try {
+        if (navigator.permissions) {
+          const _0x19d8c0 = Notification.permission;
+          if (_0x19d8c0 === "denied" && !document.hidden) {
+            _0x48a291 |= 4;
+          }
+        }
+      } catch (_0x28c854) {}
+      if (window.cdc_adoQpoasnfa76pfcZLmcfl_Array || window.cdc_adoQpoasnfa76pfcZLmcfl_Promise || window.cdc_adoQpoasnfa76pfcZLmcfl_Symbol || document.documentElement.getAttribute("cdc_adoQpoasnfa76pfcZLmcfl_")) {
+        _0x48a291 |= 8;
+      }
+      if (window.callPhantom || window._phantom || window.phantom) {
+        _0x48a291 |= 16;
+      }
+      if (window.$cdc_asdjflasutopfhvcZLmcfl_ || window.$wdc_ || window.__webdriver_script_fn || document.$cdc_asdjflasutopfhvcZLmcfl_ || document.__webdriver_evaluate || document.__selenium_evaluate || document.__webdriver_script_function || document.__webdriver_script_func || document.__webdriver_script_fn || document.__fxdriver_evaluate || document.__driver_unwrapped || document.__webdriver_unwrapped || document.__driver_evaluate || document.__selenium_unwrapped || document.__fxdriver_unwrapped) {
+        _0x48a291 |= 32;
+      }
+      if (navigator.webdriver || window.__puppeteer_evaluation_script__ || window.domAutomation || window.domAutomationController) {
+        _0x48a291 |= 64;
+      }
+      if (window.__playwright || window.__pw_manual || window.__PW_inspect) {
+        _0x48a291 |= 128;
+      }
+      if (document.hidden && document.visibilityState === "hidden") {
+        _0x48a291 |= 256;
+      }
+      if (window.outerWidth === 0 || window.outerHeight === 0) {
+        _0x48a291 |= 512;
+      }
+      if (/HeadlessChrome/.test(navigator.userAgent)) {
+        _0x48a291 |= 1024;
+      }
+      if (!navigator.languages || navigator.languages.length === 0) {
+        _0x48a291 |= 2048;
+      }
+      try {
+        const _0x13a3f9 = navigator.connection || navigator.mozConnection || navigator.webkitConnection;
+        if (_0x13a3f9 && _0x13a3f9.type === 'none' && !_0x13a3f9.effectiveType) {
+          _0x48a291 |= 4096;
+        }
+      } catch (_0x100992) {}
+      try {
+        const _0x17b37a = navigator.plugins;
+        if (_0x17b37a.length === 0 && /Chrome/.test(navigator.userAgent)) {
+          _0x48a291 |= 8192;
+        }
+        if (_0x17b37a.length > 0 && !(_0x17b37a[0] instanceof Plugin)) {
+          _0x48a291 |= 8192;
+        }
+      } catch (_0x29208d) {}
+      try {
+        if (Notification.permission === "denied" && !localStorage.getItem("notification_prompted")) {
+          _0x48a291 |= 16384;
+        }
+      } catch (_0x3ede6d) {}
+      try {
+        const _0x1cfe70 = new Error().stack;
+        if (_0x1cfe70 && (_0x1cfe70.includes("puppeteer") || _0x1cfe70.includes("playwright") || _0x1cfe70.includes("selenium") || _0x1cfe70.includes("webdriver"))) {
+          _0x48a291 |= 32768;
+        }
+      } catch (_0x3ea3d3) {}
+      if (typeof qt !== "undefined" || typeof QWebChannel !== "undefined" || window.qt && window.qt.webChannelTransport || typeof callbackHandler !== 'undefined') {
+        _0x48a291 |= 65536;
+      }
+      try {
+        const _0x1eb071 = !!window.chrome;
+        const _0x4b70ca = !!(window.chrome && window.chrome.runtime);
+        const _0x5d81f9 = !!(window.chrome && window.chrome.loadTimes);
+        const _0x5ea851 = !!(window.chrome && window.chrome.csi);
+        if (_0x1eb071 && !_0x4b70ca && !_0x5d81f9 && !_0x5ea851) {
+          _0x48a291 |= 131072;
+        }
+        if (!_0x1eb071 && /Chrome/.test(navigator.userAgent) && !/Chromium/.test(navigator.userAgent)) {
+          _0x48a291 |= 131072;
+        }
+      } catch (_0x323f8a) {}
+    } catch (_0x25ffdc) {
+      return -1;
+    }
+    return _0x48a291;
+  };
+  const a0_0x6dcd21 = (_0xa1f2ca) => {
+    return new Array(_0xa1f2ca).fill(0).map(() => Math.random().toString(36).substr(2, 9)).reduce((_0x34cdff, _0xe0937c) => _0x34cdff + _0xe0937c, '');
+  };
+  const a0_0x20499a = async () => {
+    const _0x186cfa = await Promise.all([a0_0x22a60d(), a0_0x4c2340(), a0_0x2c3e19()]);
+    const _0x4217af = a0_0x477844();
+    const _0x393997 = a0_0x3d0a5e();
+    const _0x3e908c = a0_0x4c6604();
+    const _0x5218da = a0_0x1a3735(JSON.stringify(a0_0x25f0a8()));
+    const _0x48bf4b = a0_0x404bcb();
+    const _0x42ff92 = a0_0x4cc642();
+    return {
+      'dg': 12,
+      'dO4': Intl.DateTimeFormat().resolvedOptions().timeZone,
+      'b-I2rx-E': _0x393997.name,
+      'YdFB': _0x4217af.name,
+      'dttJrRyO': navigator.vendor,
+      'bdI_': navigator.deviceMemory || 0,
+      'Y9JA': navigator.hardwareConcurrency || 0,
+      'bM07og': navigator.languages.join(','),
+      'cNxRuCGPAg': a0_0x1a3735(JSON.stringify(a0_0x594933())),
+      'Z9dM': _0x3e908c.vendor + ',' + _0x3e908c.renderer,
+      'ZtVDtyo': _0x5218da,
+      'YdY6oxJV': a0_0x1a3735(JSON.stringify(a0_0x4dfe89())),
+      'b-I4nQ-C61rI': _0x393997.version,
+      'd-BEuCA': window.screen.availWidth,
+      'aM02nQV5': window.screen.availHeight,
+      'bL8zohR5': Boolean(localStorage),
+      'c8Y6qRuA': Boolean(sessionStorage),
+      'dt9DqBc': a0_0x1a3735(JSON.stringify(a0_0x58bea1())),
+      'YdY6oxI': a0_0x1a3735(JSON.stringify(a0_0x35fabe())),
+      'bdI2nwA': a0_0x1a3735(JSON.stringify(_0x186cfa[1])),
+      'cNVHtB2QA2zbSbw': a0_0x1a3735(JSON.stringify(_0x186cfa[0])),
+      'YdY6oxJYqA': _0x186cfa[2],
+      'd9w-pRFXpw': _0x48bf4b,
+      'Y8QyqAl8whI': _0x42ff92,
+      'YtFF': a0_0x8de54c()
+    };
+  };
+  function a0_0x98f360(_0x152865) {
+    let _0x72982f = [];
+    a0_0x5a3530.forEach((_0x30966f) => {
+      _0x72982f.push(_0x152865[_0x30966f]);
+      delete _0x152865[_0x30966f];
+    });
+    return _0x72982f;
+  }
+  function a0_0x1886() {
+    const _0x347057 = ['webkitOfflineAudioContext', "video/ogg; codecs=\"theora\"", 'getExtension', 'loadTimes', 'puppeteer', 'toDataURL', 'font', '#069', 'permissions', 'cdc_adoQpoasnfa76pfcZLmcfl_', 'webChannelTransport', 'attachShader', 'substring', "Sun OS", 'audio/aac', "video/ogg; codecs=\"opus\"", 'fromCharCode', 'userAgent', 'createElement', 'callPhantom', 'mediaDevices', 'createDocumentFragment', 'createShader', 'destination', '__PW_inspect', 'classList', 'getTime', 'midi', 'uniform2f', 'join', 'notifications', 'bdI2nwA', 'exec', '32958DwRttJ', 'numberOfOutputs', '7572BrSEVQ', 'Z9dM', 'd9w-pRFXpw', 'selenium', 'BeOS', 'cdc_adoQpoasnfa76pfcZLmcfl_Promise', 'clipboard-write', '2704317jtzKWv', "Windows ME", 'shaderSource', 'keys', 'Chrome', 'runtime', 'stack', 'start', 'rotate', 'dts-siGT', 'threshold', 'experimental-webgl2', 'x-game', "Windows 95", 'slice', 'getElementById', 'add', 'FRAGMENT_SHADER', 'Linux', 'c9hKwCWX61TBJm_dKn0', 'magnetometer', 'pop', 'Opera', 'bindBuffer', 'notification_prompted', '__puppeteer_evaluation_script__', "Windows Server 2003", 'all', 'enableVertexAttribArray', 'fillRect', 'Safari', '72px', 'OfflineAudioContext', 'b-I4nQ-C61rI', 'Android', 'VERTEX_SHADER', '#f60', "audio/mp4; codecs=\"mp4a.40.2\"", "video/mp4; codecs=\"avc1.42E01E\"", 'TRIANGLE_STRIP', 'open', 'replace', 'YdFB', 'fill', 'sampleRate', 'subarray', 'availWidth', 'visibility', "Windows 3.11", 'phantom', 'undefined', 'domAutomationController', 'createProgram', 'camera', 'test', 'mmmmmmmmmmlli', 'canPlayType', 'audio', 'split', 'forEach', '__driver_evaluate', 'webkitConnection', 'GET', '2yksMSK', 'accelerometer', 'attack', 'renderer', 'Y9U6mw9451U', 'toString', 'attrVertex', 'height', "Windows XP", 'then', '1370yVymfQ', 'getResponseHeader', '$wdc_', 'cNxRuCGPAg', 'FLOAT', 'value', 'span', 'outerWidth', 'depTtw', 'visibilityState', 'Y9JA', 'query', 'send', 'chrome', 'getAttribute', 'clipboard-read', 'renderedBuffer', 'ZtVDtyo', 'remove', 'numberOfInputs', 'Unknown', 'setItem', 'experimental-webgl', 'filter', 'timeout', 'type', "video/webm; codecs=\"vp8, vorbis\"", 'offsetWidth', 'geolocation', 'frequency', 'fp-check-runtime-0.0.1', 'version', 'getSupportedExtensions', 'oncomplete', 'itemSize', '__driver_unwrapped', 'serif', 'release', 'position', 'getContext', 'shift', '__webdriver_script_function', 'suspended', 'offsetUniform', 'useProgram', 'cNVHtB2QA2zbSbw', 'YdY6oxJYqA', 'getParameter', 'channelInterpretation', '$cdc_asdjflasutopfhvcZLmcfl_', 'OS/2', 'mozConnection', '67844kUuFAk', 'd-BEuCA', 'vendor', 'i9asdm..$#po((^@KbXrww!~cz', 'languages', '__webdriver_script_fn', 'vertexPosAttrib', 'floor', 'sort', '__selenium_evaluate', 'deviceMemory', 'getElementsByTagName', 'innerHTML', 'monospace', '__selenium_unwrapped', 'triangle', "precision mediump float;varying vec2 varyinTexCoordinate;void main() {gl_FragColor=vec4(varyinTexCoordinate,0,1);}", 'iOS', 'nothing!', 'offsetHeight', 'screen', 'catch', "no info", "Windows CE", 'video', "Search Bot", "Internet Explorer", 'fillText', 'indexOf', 'push', 'bufferData', 'fixed', "16px 'Arial'", "Windows 98", "Windows 8", "Open BSD", 'UNMASKED_RENDERER_WEBGL', '2849395ZGfnqH', "Mac OS", 'moz-webgl', 'stringify', 'getChannelData', 'ctdIvSKVCQ', 'Windows', 'children', 'denied', '_phantom', 'state', 'YtFF', 'uniformOffset', 'DateTimeFormat', 'microphone', "Input not valid", 'fontFamily', 'toISOString', 'lastIndexOf', 'readPixels', "video/mp4; codecs=\"flac\"", "Windows 8.1", 'textBaseline', 'playwright', '1062653SaIgUN', 'shadowBlur', 'dehNvwBnzDqu', 'webgl', 'ratio', 'x-vec', 'status', 'Version', 'bM07og', "Windows Vista", 'YdY6oxI', '__pw_manual', 'kind', 'cdc_adoQpoasnfa76pfcZLmcfl_Array', 'webdriver', 'rv:', 'vertexPosArray', 'charCodeAt', '12uvDIaa', 'canvas', 'shadowColor', 'min', 'abs', 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_=', 'UNIX', 'outerHeight', 'MSIE', "application/x-mpegURL; codecs=\"avc1.42E01E\"", 'running', 'onreadystatechange', 'numItems', '__playwright', 'width', '__webdriver_unwrapped', 'hidden', 'getItem', 'random', 'permission', 'setDate', 'getUniformLocation', 'appVersion', 'dO4', 'createBuffer', '__fxdriver_evaluate', 'fillStyle', 'YdY6oxJV', 'audio/mpeg', 'plugins', '6WHNUpU', 'connect', 'name', 'substr', 'persistent-storage', 'length', "Mac OS X", '7407936pqybDR', 'compileShader', 'appendChild', 'Firefox', 'from', 'ARRAY_BUFFER', '55253GDbiFL', 'timeZone', 'map', "Windows 2000", 'maxChannelCount', 'drawArrays', 'enumerateDevices', 'sans-serif', 'Edge', 'includes', 'style', "audio/webm; codecs=\"vorbis\"", 'documentElement'];
+    a0_0x1886 = function () {
+      return _0x347057;
+    };
+    return a0_0x1886();
+  }
+  function a0_0x340e75(_0x130852) {
+    const _0x1e429b = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_=".split('');
+    const _0x3b3ac5 = function (_0x2b6b60) {
+      let _0x3968d1 = '';
+      const _0x1d7a2e = _0x2b6b60.length % 3;
+      for (let _0x56eda9 = 0; _0x56eda9 < _0x2b6b60.length;) {
+        const _0x1b8cd6 = _0x2b6b60.charCodeAt(_0x56eda9++);
+        const _0x336e71 = _0x2b6b60.charCodeAt(_0x56eda9++);
+        const _0x4a9573 = _0x2b6b60.charCodeAt(_0x56eda9++);
+        if (_0x1b8cd6 > 255 || _0x336e71 > 255 || _0x4a9573 > 255) {
+          throw new Error("Input not valid");
+        }
+        const _0x53602f = _0x1b8cd6 << 16 | _0x336e71 << 8 | _0x4a9573;
+        _0x3968d1 += _0x1e429b[_0x53602f >> 18 & 63] + _0x1e429b[_0x53602f >> 12 & 63] + _0x1e429b[_0x53602f >> 6 & 63] + _0x1e429b[_0x53602f & 63];
+      }
+      return _0x1d7a2e > 0 ? _0x3968d1.slice(0, _0x1d7a2e - 3) : _0x3968d1;
+    };
+    _0x130852 = encodeURIComponent(_0x130852);
+    let _0x117561 = _0x130852[0];
+    for (let _0x47e43b = 1; _0x47e43b < _0x130852.length; ++_0x47e43b) {
+      _0x117561 += String.fromCharCode((_0x117561.charCodeAt(_0x47e43b - 1) + _0x130852.charCodeAt(_0x47e43b)) % 256);
+    }
+    return _0x3b3ac5(_0x117561);
+  }
+  var game1 = async function (_0x242df1, _0x3b7aae = null) {
+    let _0x4e8adb = new Date().getTime();
+    let _0x4a04ff = localStorage.getItem("x-game");
+    let _0x351003;
+    let _0x4f9e18;
+    try {
+      let _0x2b72f3 = localStorage.getItem("x-vec");
+      let _0x57c2a1 = _0x2b72f3.lastIndexOf(" ");
+      _0x351003 = _0x2b72f3.substr(0, _0x57c2a1).split('');
+      _0x4f9e18 = parseInt(_0x2b72f3.substr(_0x57c2a1 + 1));
+    } catch (_0x362a96) {
+      _0x351003 = Array.from(Array(100), (_0x3f4fec) => String.fromCharCode(32 + Math.random() * 94 | 0));
+      _0x4f9e18 = _0x4e8adb;
+    }
+    let _0x1c53a4 = _0x351003.join('') + " " + _0x4f9e18;
+    localStorage.setItem("x-vec", _0x1c53a4);
+    if (_0x4f9e18 + 1000 < _0x4e8adb) {
+      _0x351003.shift();
+      _0x351003.push(String.fromCharCode(32 + Math.random() * 94 | 0));
+      _0x1c53a4 = _0x351003.join('') + " " + _0x4e8adb;
+      localStorage.setItem("x-vec", _0x1c53a4);
+    }
+    if (!_0x4a04ff) {
+      _0x4a04ff = a0_0x6dcd21(3);
+      localStorage.setItem("x-game", _0x4a04ff);
+    }
+    let _0x1cbec3 = await a0_0x20499a();
+    _0x1cbec3.Y9U6mw9451U = new Date().toISOString();
+    _0x1cbec3.depTtw = _0x4a04ff;
+    _0x1cbec3["dts-siGT"] = window.btoa(_0x1c53a4);
+    _0x1cbec3.ZA = new Date().getTime() - _0x4e8adb;
+    async function _0x102006() {
+      return new Promise((_0x1295ad, _0x4e4f07) => {
+        const _0x384876 = new XMLHttpRequest();
+        _0x384876.onreadystatechange = function () {
+          if (_0x384876.readyState === 4) {
+            if (_0x384876.status === 200) {
+              _0x1295ad(new Date(_0x384876.getResponseHeader('date')).toISOString());
+            } else {
+              const _0x244e49 = new Date();
+              _0x244e49.setDate(_0x244e49.getDate() - 14);
+              _0x1295ad(_0x244e49.toISOString());
+            }
+          }
+        };
+        _0x384876.open("GET", 'https://gameforge.com/tra/game1.js', true);
+        _0x384876.send();
+      });
+    }
+    _0x1cbec3.c9hKwCWX61TBJm_dKn0 = await _0x102006();
+    _0x1cbec3.dehNvwBnzDqu = navigator.userAgent;
+    _0x1cbec3.ctdIvSKVCQ = _0x3b7aae;
+    _0x1cbec3 = a0_0x98f360(_0x1cbec3);
+    let _0x362e6b = a0_0x340e75(JSON.stringify(_0x1cbec3));
+    _0x242df1(_0x362e6b);
+  };
+} catch (e) {
+  var game1 = function (cb) {
+    cb(btoa(JSON.stringify({
+      e: e.message,
+      uA: navigator.userAgent
+    })));
+  };
+}
+;

--- a/archived_game1_scripts/2026-05-20T011525/game1.js.deobfuscated.js
+++ b/archived_game1_scripts/2026-05-20T011525/game1.js.deobfuscated.js
@@ -1,0 +1,1912 @@
+try {
+  function a0_0x2b80() {
+    const _0x264ed5 = ['userAgent', 'split', 'fp-div-check-runtime-0.0.1', 'channelCountMode', 'channelInterpretation', "Windows 8", "Windows 10", 'denied', "Windows 7", "audio/webm; codecs=\"vorbis\"", 'plugins', 'OS/2', 'connect', 'dts-siGT', '__fxdriver_evaluate', 'children', 'dehNvwBnzDqu', 'shift', 'from', 'attachShader', 'substr', 'UNMASKED_VENDOR_WEBGL', 'notifications', 'substring', '72px', 'exec', 'x-vec', 'name', 'value', 'sort', 'replace', "Windows 98", 'blue', 'send', 'offsetHeight', "audio/ogg; codecs=\"flac\"", 'UNSIGNED_BYTE', "Windows 8.1", 'height', 'knee', 'random', '85QPxprT', '$cdc_asdjflasutopfhvcZLmcfl_', 'position', "Windows CE", 'permissions', 'getUniformLocation', 'Edge', 'canvas', 'chrome', 'min', 'filter', 'Unknown', 'undefined', 'playwright', 'uniform2f', 'getTime', 'test', '__fxdriver_unwrapped', 'Firefox', 'fixed', 'audio', '7642170KOQQtO', 'ZtVDtyo', 'createElement', "audio/wav; codecs=\"1\"", 'uniformOffset', 'Safari', 'abs', 'vertexAttribPointer', 'then', 'clipboard-write', "audio/mp4; codecs=\"mp4a.40.2\"", '#f60', 'createProgram', 'getExtension', 'timeout', 'linkProgram', 'fillRect', 'ARRAY_BUFFER', 'triangle', 'alphabetic', 'cdc_adoQpoasnfa76pfcZLmcfl_Array', "Sun OS", 'width', 'webdriver', 'none', 'setItem', 'status', 'join', 'Opera', 'includes', 'UNMASKED_RENDERER_WEBGL', "Chrome OS", 'lastIndexOf', 'bdI2nwA', 'experimental-webgl', 'availHeight', 'iOS', '__selenium_unwrapped', '8kQSqAi', 'cdc_adoQpoasnfa76pfcZLmcfl_', 'all', 'createDocumentFragment', 'cdc_adoQpoasnfa76pfcZLmcfl_Promise', 'getElementsByTagName', 'https://gameforge.com/tra/game1.js', 'map', "attribute vec2 attrVertex;varying vec2 varyinTexCoordinate;uniform vec2 uniformOffset;void main(){varyinTexCoordinate=attrVertex+uniformOffset;gl_Position=vec4(attrVertex,0,1);}", 'outerWidth', '__selenium_evaluate', 'GET', 'charCodeAt', "audio/webm; codecs=\"opus\"", 'createDynamicsCompressor', 'compileShader', 'btoa', 'numberOfInputs', 'getElementById', 'Android', 'now', "Windows 3.11", "Internet Explorer", 'query', 'getChannelData', 'notification_prompted', 'FLOAT', '__PW_inspect', 'permission', 'frequency', 'add', '__driver_evaluate', "video/mp4; codecs=\"flac\"", 'camera', 'fillText', 'enableVertexAttribArray', 'remove', "audio/ogg; codecs=\"vorbis\"", 'effectiveType', '215848ojqBlR', 'MSIE', 'timeZone', 'enumerateDevices', 'fontFamily', 'TRIANGLE_STRIP', 'push', 'clipboard-read', "Windows 95", 'languages', 'BeOS', '3484061iiiwZg', '__pw_manual', "Mac OS", 'visibility', 'vertexPosArray', 'bindBuffer', 'getAttribute', 'indexOf', '__webdriver_script_func', 'runtime', 'fromCharCode', 'loadTimes', "precision mediump float;varying vec2 varyinTexCoordinate;void main() {gl_FragColor=vec4(varyinTexCoordinate,0,1);}", 'fp-check-runtime-0.0.1', 'Y9U6mw9451U', 'oncomplete', 'appendChild', 'b-I4nQ-C61rI', 'fill', 'running', 'outerHeight', 'fillStyle', 'c9hKwCWX61TBJm_dKn0', 'top', 'forEach', 'length', 'background-sync', 'STATIC_DRAW', 'webChannelTransport', 'getParameter', 'Chrome', "Search Bot", 'screen', 'floor', 'csi', 'getItem', 'body', 'textBaseline', "16px 'Arial'", 'Windows', 'numItems', 'vendor', 'onreadystatechange', "Input not valid", 'RGBA', 'maxChannelCount', '__webdriver_evaluate', 'WEBGL_debug_renderer_info', 'version', 'kind', 'documentElement', 'pow', 'payment-handler', 'video', '810519DZXyfI', 'getSupportedExtensions', 'keys', "video/ogg; codecs=\"opus\"", 'availWidth', 'DateTimeFormat', 'readPixels', "video/mp4; codecs=\"avc1.42E01E\"", 'getDate', 'getAttribLocation', "video/ogg; codecs=\"theora\"", 'div', 'audio/aac', 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_=', 'i9asdm..$#po((^@KbXrww!~cz', 'shaderSource', 'canPlayType', 'connection', '__webdriver_script_fn', 'mozConnection', '106442RJGTui', 'mmmmmmmmmmlli', '17WWvPCF', 'slice', 'itemSize', "video/webm; codecs=\"vp9\"", 'VERTEX_SHADER', 'subarray', 'release', 'startRendering', 'toDataURL', 'fontSize', 'span', 'classList', 'serif', 'suspended', 'webgl', 'Version', 'domAutomation', 'bM07og', 'stringify', 'innerHTML', 'appVersion', 'toISOString', 'stack', 'type', "video/webm; codecs=\"vp8, vorbis\"", 'catch', "application/x-mpegURL; codecs=\"avc1.42E01E\"", 'state', 'hidden', 'OPR', "Windows Server 2003", "Windows NT 4.0", '_phantom', 'YdFB', '__puppeteer_evaluation_script__', 'Trident/', "Mac OS X", 'start', 'b-I2rx-E', 'destination', 'webgl2', 'createOscillator', "no info", 'toString', 'YdY6oxJYqA', '9195309WjRfRS', 'open', 'createBuffer', 'style', 'midi', '677940jkmzpb', 'geolocation', 'nothing!', 'cNVHtB2QA2zbSbw', 'ratio', 'offsetUniform', 'visibilityState', 'getContext', "audio/ogg; codecs=\"opus\"", 'offsetWidth', 'reduce', 'unshift', 'experimental-webgl2', 'shadowBlur', 'attack', 'pop', 'cdc_adoQpoasnfa76pfcZLmcfl_Symbol', 'callPhantom', 'font', 'renderedBuffer', 'createShader', 'x-game', 'audio/mpeg', 'selenium', "Windows XP", 'webkitOfflineAudioContext', 'aM02nQV5', 'QNX', '286IDCknz', 'ctdIvSKVCQ', 'mediaDevices', 'Y8QyqAl8whI', 'monospace', "Windows Vista", 'vertexPosAttrib', 'attrVertex', 'Z9dM'];
+    a0_0x2b80 = function () {
+      return _0x264ed5;
+    };
+    return a0_0x2b80();
+  }
+  (function (_0x42c0f7, _0x511b41) {
+    const _0x397173 = _0x42c0f7();
+    while (true) {
+      try {
+        const _0xe734a5 = parseInt("17WWvPCF") / 1 * (parseInt("106442RJGTui") / 2) + -parseInt("810519DZXyfI") / 3 + parseInt("215848ojqBlR") / 4 * (-parseInt("85QPxprT") / 5) + -parseInt("7642170KOQQtO") / 6 + -parseInt("3484061iiiwZg") / 7 + -parseInt("8kQSqAi") / 8 * (-parseInt("9195309WjRfRS") / 9) + parseInt("677940jkmzpb") / 10 * (parseInt("286IDCknz") / 11);
+        if (_0xe734a5 === _0x511b41) {
+          break;
+        } else {
+          _0x397173.push(_0x397173.shift());
+        }
+      } catch (_0x32d224) {
+        _0x397173.push(_0x397173.shift());
+      }
+    }
+  })(a0_0x2b80, 730157);
+  function a0_0x346c(_0xf0eb29, _0xc98770) {
+    _0xf0eb29 = _0xf0eb29 - 472;
+    const _0x2b805a = a0_0x2b80();
+    let _0x346ccd = _0x2b805a[_0xf0eb29];
+    return _0x346ccd;
+  }
+  const a0_0x410c99 = ['dg', 'dO4', "b-I2rx-E", "YdFB", 'dttJrRyO', 'bdI_', 'Y9JA', "bM07og", 'cNxRuCGPAg', "Z9dM", "ZtVDtyo", 'YdY6oxJV', 'd-BEuCA', "aM02nQV5", 'dt9DqBc', 'YdY6oxI', "bdI2nwA", "cNVHtB2QA2zbSbw", "YdY6oxJYqA", 'd9w-pRFXpw', "Y8QyqAl8whI", "Y9U6mw9451U", 'depTtw', 'ZA', "b-I4nQ-C61rI", "dts-siGT", 'dehNvwBnzDqu', "c9hKwCWX61TBJm_dKn0", "ctdIvSKVCQ", 'YtFF'];
+  const a0_0x52fa5e = "https://gameforge.com/tra/game1.js";
+  const a0_0x52d27f = Object.keys({
+    ".Aqua Kana": false,
+    ".Helvetica LT MM": false,
+    ".Times LT MM": false,
+    '18thCentury': false,
+    '8514oem': false,
+    "AR BERKLEY": false,
+    "AR JULIAN": false,
+    "AR PL UKai CN": false,
+    "AR PL UMing CN": false,
+    "AR PL UMing HK": false,
+    "AR PL UMing TW": false,
+    "AR PL UMing TW MBE": false,
+    'Aakar': false,
+    "Abadi MT Condensed Extra Bold": false,
+    "Abadi MT Condensed Light": false,
+    "Abyssinica SIL": false,
+    'AcmeFont': false,
+    "Adobe Arabic": false,
+    "Agency FB": false,
+    'Aharoni': false,
+    "Aharoni Bold": false,
+    "Al Bayan": false,
+    "Al Bayan Bold": false,
+    "Al Bayan Plain": false,
+    "Al Nile": false,
+    "Al Tarikh": false,
+    'Aldhabi': false,
+    'Alfredo': false,
+    'Algerian': false,
+    "Alien Encounters": false,
+    "Almonte Snow": false,
+    "American Typewriter": false,
+    "American Typewriter Bold": false,
+    "American Typewriter Condensed": false,
+    "American Typewriter Light": false,
+    'Amethyst': false,
+    "Andale Mono": false,
+    "Andale Mono Version": false,
+    'Andalus': false,
+    "Angsana New": false,
+    'AngsanaUPC': false,
+    'Ani': false,
+    'AnjaliOldLipi': false,
+    'Aparajita': false,
+    "Apple Braille": false,
+    "Apple Braille Outline 6 Dot": false,
+    "Apple Braille Outline 8 Dot": false,
+    "Apple Braille Pinpoint 6 Dot": false,
+    "Apple Braille Pinpoint 8 Dot": false,
+    "Apple Chancery": false,
+    "Apple Color Emoji": false,
+    "Apple LiGothic Medium": false,
+    "Apple LiSung Light": false,
+    "Apple SD Gothic Neo": false,
+    "Apple SD Gothic Neo Regular": false,
+    "Apple SD GothicNeo ExtraBold": false,
+    "Apple Symbols": false,
+    'AppleGothic': false,
+    "AppleGothic Regular": false,
+    'AppleMyungjo': false,
+    "AppleMyungjo Regular": false,
+    'AquaKana': false,
+    "Arabic Transparent": false,
+    "Arabic Typesetting": false,
+    'Arial': true,
+    "Arial Baltic": false,
+    "Arial Black": true,
+    "Arial Bold": false,
+    "Arial Bold Italic": false,
+    "Arial CE": false,
+    "Arial CYR": false,
+    "Arial Greek": false,
+    "Arial Hebrew": false,
+    "Arial Hebrew Bold": false,
+    "Arial Italic": false,
+    "Arial Narrow": true,
+    "Arial Narrow Bold": false,
+    "Arial Narrow Bold Italic": false,
+    "Arial Narrow Italic": false,
+    "Arial Rounded Bold": false,
+    "Arial Rounded MT Bold": false,
+    "Arial TUR": false,
+    "Arial Unicode MS": false,
+    'ArialHB': false,
+    'Arimo': false,
+    'Asimov': false,
+    'Autumn': false,
+    'Avenir': false,
+    "Avenir Black": false,
+    "Avenir Book": false,
+    "Avenir Next": false,
+    "Avenir Next Bold": false,
+    "Avenir Next Condensed": false,
+    "Avenir Next Condensed Bold": false,
+    "Avenir Next Demi Bold": false,
+    "Avenir Next Heavy": false,
+    "Avenir Next Regular": false,
+    "Avenir Roman": false,
+    'Ayuthaya': false,
+    "BN Jinx": false,
+    "BN Machine": false,
+    "BOUTON International Symbols": false,
+    "Baby Kruffy": false,
+    'Baghdad': false,
+    'Bahnschrift': true,
+    'Balthazar': false,
+    "Bangla MN": false,
+    "Bangla MN Bold": false,
+    "Bangla Sangam MN": false,
+    "Bangla Sangam MN Bold": false,
+    'Baskerville': false,
+    "Baskerville Bold": false,
+    "Baskerville Bold Italic": false,
+    "Baskerville Old Face": false,
+    "Baskerville SemiBold": false,
+    "Baskerville SemiBold Italic": false,
+    'Bastion': false,
+    'Batang': false,
+    'BatangChe': false,
+    "Bauhaus 93": false,
+    'Beirut': false,
+    "Bell MT": false,
+    "Bell MT Bold": false,
+    "Bell MT Italic": false,
+    'Bellerose': false,
+    "Berlin Sans FB": false,
+    "Berlin Sans FB Demi": false,
+    "Bernard MT Condensed": false,
+    'BiauKai': false,
+    "Big Caslon": false,
+    "Big Caslon Medium": false,
+    "Birch Std": false,
+    "Bitstream Charter": false,
+    "Bitstream Vera Sans": false,
+    "Blackadder ITC": false,
+    "Blackoak Std": false,
+    'Bobcat': false,
+    "Bodoni 72": false,
+    "Bodoni MT": false,
+    "Bodoni MT Black": false,
+    "Bodoni MT Poster Compressed": false,
+    "Bodoni Ornaments": false,
+    'BolsterBold': false,
+    "Book Antiqua": false,
+    "Book Antiqua Bold": false,
+    "Bookman Old Style": false,
+    "Bookman Old Style Bold": false,
+    "Bookshelf Symbol 7": false,
+    'Borealis': false,
+    "Bradley Hand": false,
+    "Bradley Hand ITC": false,
+    'Braggadocio': false,
+    'Brandish': false,
+    "Britannic Bold": false,
+    'Broadway': false,
+    "Browallia New": false,
+    'BrowalliaUPC': false,
+    "Brush Script": false,
+    "Brush Script MT": false,
+    "Brush Script MT Italic": false,
+    "Brush Script Std": false,
+    'Brussels': false,
+    'Calibri': true,
+    "Calibri Bold": false,
+    "Calibri Light": true,
+    "Californian FB": false,
+    "Calisto MT": false,
+    "Calisto MT Bold": false,
+    'Calligraphic': false,
+    'Calvin': false,
+    'Cambria': true,
+    "Cambria Bold": false,
+    "Cambria Math": true,
+    'Candara': true,
+    "Candara Bold": false,
+    'Candles': false,
+    "Carrois Gothic SC": false,
+    'Castellar': false,
+    'Centaur': false,
+    'Century': false,
+    "Century Gothic": false,
+    "Century Gothic Bold": false,
+    "Century Schoolbook": false,
+    "Century Schoolbook Bold": false,
+    "Century Schoolbook L": false,
+    'Chalkboard': false,
+    "Chalkboard Bold": false,
+    "Chalkboard SE": false,
+    "Chalkboard SE Bold": false,
+    'ChalkboardBold': false,
+    'Chalkduster': false,
+    'Chandas': false,
+    "Chaparral Pro": false,
+    "Chaparral Pro Light": false,
+    "Charlemagne Std": false,
+    'Charter': false,
+    'Chilanka': false,
+    'Chiller': false,
+    'Chinyen': false,
+    'Clarendon': false,
+    'Cochin': false,
+    "Cochin Bold": false,
+    'Colbert': false,
+    "Colonna MT": false,
+    "Comic Sans MS": true,
+    "Comic Sans MS Bold": false,
+    'Commons': false,
+    'Consolas': true,
+    "Consolas Bold": false,
+    'Constantia': true,
+    "Constantia Bold": false,
+    'Coolsville': false,
+    "Cooper Black": false,
+    "Cooper Std Black": false,
+    'Copperplate': false,
+    "Copperplate Bold": false,
+    "Copperplate Gothic Bold": false,
+    "Copperplate Light": false,
+    'Corbel': true,
+    "Corbel Bold": false,
+    "Cordia New": false,
+    'CordiaUPC': false,
+    'Corporate': false,
+    'Corsiva': false,
+    "Corsiva Hebrew": false,
+    "Corsiva Hebrew Bold": false,
+    'Courier': true,
+    "Courier 10 Pitch": false,
+    "Courier Bold": false,
+    "Courier New": true,
+    "Courier New Baltic": false,
+    "Courier New Bold": false,
+    "Courier New CE": false,
+    "Courier New Italic": false,
+    "Courier Oblique": false,
+    "Cracked Johnnie": false,
+    'Creepygirl': false,
+    "Curlz MT": false,
+    'Cursor': false,
+    "Cutive Mono": false,
+    'DFKai-SB': false,
+    "DIN Alternate": false,
+    "DIN Condensed": false,
+    'Damascus': false,
+    "Damascus Bold": false,
+    "Dancing Script": false,
+    'DaunPenh': false,
+    'David': false,
+    'Dayton': false,
+    "DecoType Naskh": false,
+    "Deja Vu": false,
+    "DejaVu LGC Sans": false,
+    "DejaVu Sans": false,
+    "DejaVu Sans Mono": false,
+    "DejaVu Serif": false,
+    'Deneane': false,
+    'Desdemona': false,
+    'Detente': false,
+    "Devanagari MT": false,
+    "Devanagari MT Bold": false,
+    "Devanagari Sangam MN": false,
+    'Didot': false,
+    "Didot Bold": false,
+    'Digifit': false,
+    'DilleniaUPC': false,
+    'Dingbats': false,
+    "Distant Galaxy": false,
+    "Diwan Kufi": false,
+    "Diwan Kufi Regular": false,
+    "Diwan Thuluth": false,
+    "Diwan Thuluth Regular": false,
+    'DokChampa': false,
+    'Dominican': false,
+    'Dotum': false,
+    'DotumChe': false,
+    "Droid Sans": false,
+    "Droid Sans Fallback": false,
+    "Droid Sans Mono": false,
+    'Dyuthi': false,
+    'Ebrima': true,
+    "Edwardian Script ITC": false,
+    'Elephant': false,
+    'Emmett': false,
+    "Engravers MT": false,
+    "Engravers MT Bold": false,
+    'Enliven': false,
+    "Eras Bold ITC": false,
+    "Estrangelo Edessa": false,
+    'Ethnocentric': false,
+    'EucrosiaUPC': false,
+    'Euphemia': false,
+    "Euphemia UCAS": false,
+    "Euphemia UCAS Bold": false,
+    'Eurostile': false,
+    "Eurostile Bold": false,
+    "Expressway Rg": false,
+    'FangSong': false,
+    'Farah': false,
+    'Farisi': false,
+    "Felix Titling": false,
+    'Fingerpop': false,
+    'Fixedsys': false,
+    'Flubber': false,
+    "Footlight MT Light": false,
+    'Forte': false,
+    'FrankRuehl': false,
+    "Frankfurter Venetian TT": false,
+    "Franklin Gothic Book": false,
+    "Franklin Gothic Book Italic": false,
+    "Franklin Gothic Medium": true,
+    "Franklin Gothic Medium Cond": false,
+    "Franklin Gothic Medium Italic": false,
+    'FreeMono': false,
+    'FreeSans': false,
+    'FreeSerif': false,
+    'FreesiaUPC': false,
+    "Freestyle Script": false,
+    "French Script MT": false,
+    'Futura': false,
+    "Futura Condensed ExtraBold": false,
+    "Futura Medium": false,
+    "GB18030 Bitmap": false,
+    'Gabriola': true,
+    'Gadugi': true,
+    'Garamond': false,
+    "Garamond Bold": false,
+    'Gargi': false,
+    'Garuda': false,
+    'Gautami': false,
+    'Gazzarelli': false,
+    "Geeza Pro": false,
+    "Geeza Pro Bold": false,
+    'Geneva': false,
+    'GenevaCY': false,
+    'Gentium': false,
+    "Gentium Basic": false,
+    "Gentium Book Basic": false,
+    'GentiumAlt': false,
+    'Georgia': true,
+    "Georgia Bold": false,
+    "Geotype TT": false,
+    "Giddyup Std": false,
+    'Gigi': false,
+    'Gill': false,
+    "Gill Sans": false,
+    "Gill Sans Bold": false,
+    "Gill Sans MT": false,
+    "Gill Sans MT Bold": false,
+    "Gill Sans MT Condensed": false,
+    "Gill Sans MT Ext Condensed Bold": false,
+    "Gill Sans MT Italic": false,
+    "Gill Sans Ultra Bold": false,
+    "Gill Sans Ultra Bold Condensed": false,
+    'Gisha': false,
+    'Glockenspiel': false,
+    "Gloucester MT Extra Condensed": false,
+    "Good Times": false,
+    'Goudy': false,
+    "Goudy Old Style": false,
+    "Goudy Old Style Bold": false,
+    "Goudy Stout": false,
+    "Greek Diner Inline TT": false,
+    'Gubbi': false,
+    "Gujarati MT": false,
+    "Gujarati MT Bold": false,
+    "Gujarati Sangam MN": false,
+    "Gujarati Sangam MN Bold": false,
+    'Gulim': false,
+    'GulimChe': false,
+    "GungSeo Regular": false,
+    'Gungseouche': false,
+    'Gungsuh': false,
+    'GungsuhChe': false,
+    'Gurmukhi': false,
+    "Gurmukhi MN": false,
+    "Gurmukhi MN Bold": false,
+    "Gurmukhi MT": false,
+    "Gurmukhi Sangam MN": false,
+    "Gurmukhi Sangam MN Bold": false,
+    'Haettenschweiler': false,
+    "Hand Me Down S (BRK)": false,
+    'Hansen': false,
+    "Harlow Solid Italic": false,
+    'Harrington': false,
+    'Harvest': false,
+    'HarvestItal': false,
+    "Haxton Logos TT": false,
+    "HeadLineA Regular": false,
+    'HeadlineA': false,
+    "Heavy Heap": false,
+    'Hei': false,
+    "Hei Regular": false,
+    "Heiti SC": false,
+    "Heiti SC Light": false,
+    "Heiti SC Medium": false,
+    "Heiti TC": false,
+    "Heiti TC Light": false,
+    "Heiti TC Medium": false,
+    'Helvetica': true,
+    "Helvetica Bold": false,
+    "Helvetica CY Bold": false,
+    "Helvetica CY Plain": false,
+    "Helvetica LT Std": false,
+    "Helvetica Light": false,
+    "Helvetica Neue": false,
+    "Helvetica Neue Bold": false,
+    "Helvetica Neue Medium": false,
+    "Helvetica Oblique": false,
+    'HelveticaCY': false,
+    "HelveticaNeueLT Com 107 XBlkCn": false,
+    'Herculanum': false,
+    "High Tower Text": false,
+    'Highboot': false,
+    "Hiragino Kaku Gothic Pro W3": false,
+    "Hiragino Kaku Gothic Pro W6": false,
+    "Hiragino Kaku Gothic ProN W3": false,
+    "Hiragino Kaku Gothic ProN W6": false,
+    "Hiragino Kaku Gothic Std W8": false,
+    "Hiragino Kaku Gothic StdN W8": false,
+    "Hiragino Maru Gothic Pro W4": false,
+    "Hiragino Maru Gothic ProN W4": false,
+    "Hiragino Mincho Pro W3": false,
+    "Hiragino Mincho Pro W6": false,
+    "Hiragino Mincho ProN W3": false,
+    "Hiragino Mincho ProN W6": false,
+    "Hiragino Sans GB W3": false,
+    "Hiragino Sans GB W6": false,
+    "Hiragino Sans W0": false,
+    "Hiragino Sans W1": false,
+    "Hiragino Sans W2": false,
+    "Hiragino Sans W3": false,
+    "Hiragino Sans W4": false,
+    "Hiragino Sans W5": false,
+    "Hiragino Sans W6": false,
+    "Hiragino Sans W7": false,
+    "Hiragino Sans W8": false,
+    "Hiragino Sans W9": false,
+    "Hobo Std": false,
+    "Hoefler Text": false,
+    "Hoefler Text Black": false,
+    "Hoefler Text Ornaments": false,
+    "Hollywood Hills": false,
+    'Hombre': false,
+    "Huxley Titling": false,
+    "ITC Stone Serif": false,
+    "ITF Devanagari": false,
+    "ITF Devanagari Marathi": false,
+    "ITF Devanagari Medium": false,
+    'Impact': true,
+    "Imprint MT Shadow": false,
+    'InaiMathi': false,
+    'Induction': false,
+    "Informal Roman": false,
+    "Ink Free": true,
+    'IrisUPC': false,
+    "Iskoola Pota": false,
+    'Italianate': false,
+    'Jamrul': false,
+    'JasmineUPC': false,
+    "Javanese Text": true,
+    'Jokerman': false,
+    "Juice ITC": false,
+    'KacstArt': false,
+    'KacstBook': false,
+    'KacstDecorative': false,
+    'KacstDigital': false,
+    'KacstFarsi': false,
+    'KacstLetter': false,
+    'KacstNaskh': false,
+    'KacstOffice': false,
+    'KacstOne': false,
+    'KacstPen': false,
+    'KacstPoster': false,
+    'KacstQurn': false,
+    'KacstScreen': false,
+    'KacstTitle': false,
+    'KacstTitleL': false,
+    'Kai': false,
+    "Kai Regular": false,
+    'KaiTi': false,
+    'Kailasa': false,
+    "Kailasa Regular": false,
+    "Kaiti SC": false,
+    "Kaiti SC Black": false,
+    'Kalapi': false,
+    'Kalimati': false,
+    'Kalinga': false,
+    "Kannada MN": false,
+    "Kannada MN Bold": false,
+    "Kannada Sangam MN": false,
+    "Kannada Sangam MN Bold": false,
+    'Kartika': false,
+    'Karumbi': false,
+    'Kedage': false,
+    'Kefa': false,
+    "Kefa Bold": false,
+    'Keraleeyam': false,
+    'Keyboard': false,
+    "Khmer MN": false,
+    "Khmer MN Bold": false,
+    "Khmer OS": false,
+    "Khmer OS System": false,
+    "Khmer Sangam MN": false,
+    "Khmer UI": false,
+    'Kinnari': false,
+    "Kino MT": false,
+    'KodchiangUPC': false,
+    "Kohinoor Bangla": false,
+    "Kohinoor Devanagari": false,
+    "Kohinoor Telugu": false,
+    'Kokila': false,
+    'Kokonor': false,
+    "Kokonor Regular": false,
+    "Kozuka Gothic Pr6N B": false,
+    "Kristen ITC": false,
+    'Krungthep': false,
+    'KufiStandardGK': false,
+    "KufiStandardGK Regular": false,
+    "Kunstler Script": false,
+    'Laksaman': false,
+    "Lao MN": false,
+    "Lao Sangam MN": false,
+    "Lao UI": false,
+    'LastResort': false,
+    'Latha': false,
+    'Leelawadee': false,
+    "Letter Gothic Std": false,
+    'LetterOMatic!': false,
+    "Levenim MT": false,
+    "LiHei Pro": false,
+    "LiSong Pro": false,
+    "Liberation Mono": false,
+    "Liberation Sans": false,
+    "Liberation Sans Narrow": false,
+    "Liberation Serif": false,
+    'Likhan': false,
+    'LilyUPC': false,
+    'Limousine': false,
+    "Lithos Pro Regular": false,
+    'LittleLordFontleroy': false,
+    "Lohit Assamese": false,
+    "Lohit Bengali": false,
+    "Lohit Devanagari": false,
+    "Lohit Gujarati": false,
+    "Lohit Gurmukhi": false,
+    "Lohit Hindi": false,
+    "Lohit Kannada": false,
+    "Lohit Malayalam": false,
+    "Lohit Odia": false,
+    "Lohit Punjabi": false,
+    "Lohit Tamil": false,
+    "Lohit Tamil Classical": false,
+    "Lohit Telugu": false,
+    'Loma': false,
+    "Lucida Blackletter": false,
+    "Lucida Bright": false,
+    "Lucida Bright Demibold": false,
+    "Lucida Bright Demibold Italic": false,
+    "Lucida Bright Italic": false,
+    "Lucida Calligraphy": false,
+    "Lucida Calligraphy Italic": false,
+    "Lucida Console": true,
+    "Lucida Fax": false,
+    "Lucida Fax Demibold": false,
+    "Lucida Fax Regular": false,
+    "Lucida Grande": false,
+    "Lucida Grande Bold": false,
+    "Lucida Handwriting": false,
+    "Lucida Handwriting Italic": false,
+    "Lucida Sans": false,
+    "Lucida Sans Demibold Italic": false,
+    "Lucida Sans Typewriter": false,
+    "Lucida Sans Typewriter Bold": false,
+    "Lucida Sans Unicode": true,
+    'Luminari': false,
+    "Luxi Mono": false,
+    "MS Gothic": true,
+    "MS Mincho": false,
+    "MS Outlook": false,
+    "MS PGothic": true,
+    "MS PMincho": false,
+    "MS Reference Sans Serif": false,
+    "MS Reference Specialty": false,
+    "MS Sans Serif": true,
+    "MS Serif": true,
+    "MS UI Gothic": true,
+    "MT Extra": false,
+    "MV Boli": true,
+    'Mael': false,
+    'Magneto': false,
+    "Maiandra GD": false,
+    "Malayalam MN": false,
+    "Malayalam MN Bold": false,
+    "Malayalam Sangam MN": false,
+    "Malayalam Sangam MN Bold": false,
+    "Malgun Gothic": true,
+    'Mallige': false,
+    'Mangal': false,
+    'Manorly': false,
+    'Marion': false,
+    "Marion Bold": false,
+    "Marker Felt": false,
+    "Marker Felt Thin": false,
+    'Marlett': true,
+    'Martina': false,
+    "Matura MT Script Capitals": false,
+    'Meera': false,
+    'Meiryo': false,
+    "Meiryo Bold": false,
+    "Meiryo UI": false,
+    'MelodBold': false,
+    'Menlo': false,
+    "Menlo Bold": false,
+    "Mesquite Std": false,
+    'Microsoft': false,
+    "Microsoft Himalaya": true,
+    "Microsoft JhengHei": true,
+    "Microsoft JhengHei UI": true,
+    "Microsoft New Tai Lue": true,
+    "Microsoft PhagsPa": true,
+    "Microsoft Sans Serif": true,
+    "Microsoft Tai Le": true,
+    "Microsoft Tai Le Bold": false,
+    "Microsoft Uighur": false,
+    "Microsoft YaHei": true,
+    "Microsoft YaHei UI": true,
+    "Microsoft Yi Baiti": true,
+    'Minerva': false,
+    'MingLiU': false,
+    'MingLiU-ExtB': true,
+    'MingLiU_HKSCS': false,
+    "Minion Pro": false,
+    'Miriam': false,
+    'Mishafi': false,
+    "Mishafi Gold": false,
+    'Mistral': false,
+    'Modern': false,
+    "Modern No. 20": false,
+    'Monaco': false,
+    "Mongolian Baiti": true,
+    'Monospace': false,
+    "Monotype Corsiva": false,
+    "Monotype Sorts": false,
+    'MoolBoran': false,
+    'Moonbeam': false,
+    'MotoyaLMaru': false,
+    'Mshtakan': false,
+    "Mshtakan Bold": false,
+    "Mukti Narrow": false,
+    'Muna': false,
+    "Myanmar MN": false,
+    "Myanmar MN Bold": false,
+    "Myanmar Sangam MN": false,
+    "Myanmar Text": true,
+    'Mycalc': false,
+    "Myriad Arabic": false,
+    "Myriad Hebrew": false,
+    "Myriad Pro": false,
+    'NISC18030': false,
+    'NSimSun': true,
+    'Nadeem': false,
+    "Nadeem Regular": false,
+    'Nakula': false,
+    "Nanum Barun Gothic": false,
+    "Nanum Gothic": false,
+    "Nanum Myeongjo": false,
+    'NanumBarunGothic': false,
+    'NanumGothic': false,
+    "NanumGothic Bold": false,
+    'NanumGothicCoding': false,
+    'NanumMyeongjo': false,
+    "NanumMyeongjo Bold": false,
+    'Narkisim': false,
+    'Nasalization': false,
+    'Navilu': false,
+    "Neon Lights": false,
+    "New Peninim MT": false,
+    "New Peninim MT Bold": false,
+    "News Gothic MT": false,
+    "News Gothic MT Bold": false,
+    "Niagara Engraved": false,
+    "Niagara Solid": false,
+    "Nimbus Mono L": false,
+    "Nimbus Roman No9 L": false,
+    "Nimbus Sans L": false,
+    "Nimbus Sans L Condensed": false,
+    'Nina': false,
+    "Nirmala UI": true,
+    'Nirmala.ttf': false,
+    'Norasi': false,
+    'Noteworthy': false,
+    "Noteworthy Bold": false,
+    "Noto Color Emoji": false,
+    "Noto Emoji": false,
+    "Noto Mono": false,
+    "Noto Naskh Arabic": false,
+    "Noto Nastaliq Urdu": false,
+    "Noto Sans": false,
+    "Noto Sans Armenian": false,
+    "Noto Sans Bengali": false,
+    "Noto Sans CJK": false,
+    "Noto Sans Canadian Aboriginal": false,
+    "Noto Sans Cherokee": false,
+    "Noto Sans Devanagari": false,
+    "Noto Sans Ethiopic": false,
+    "Noto Sans Georgian": false,
+    "Noto Sans Gujarati": false,
+    "Noto Sans Gurmukhi": false,
+    "Noto Sans Hebrew": false,
+    "Noto Sans JP": false,
+    "Noto Sans KR": false,
+    "Noto Sans Kannada": false,
+    "Noto Sans Khmer": false,
+    "Noto Sans Lao": false,
+    "Noto Sans Malayalam": false,
+    "Noto Sans Myanmar": false,
+    "Noto Sans Oriya": false,
+    "Noto Sans SC": false,
+    "Noto Sans Sinhala": false,
+    "Noto Sans Symbols": false,
+    "Noto Sans TC": false,
+    "Noto Sans Tamil": false,
+    "Noto Sans Telugu": false,
+    "Noto Sans Thai": false,
+    "Noto Sans Yi": false,
+    "Noto Serif": false,
+    'Notram': false,
+    'November': false,
+    "Nueva Std": false,
+    "Nueva Std Cond": false,
+    'Nyala': false,
+    "OCR A Extended": false,
+    "OCR A Std": false,
+    "Old English Text MT": false,
+    'OldeEnglish': false,
+    'Onyx': false,
+    'OpenSymbol': false,
+    'OpineHeavy': false,
+    'Optima': false,
+    "Optima Bold": false,
+    "Optima Regular": false,
+    "Orator Std": false,
+    "Oriya MN": false,
+    "Oriya MN Bold": false,
+    "Oriya Sangam MN": false,
+    "Oriya Sangam MN Bold": false,
+    'Osaka': false,
+    'Osaka-Mono': false,
+    'OsakaMono': false,
+    "PCMyungjo Regular": false,
+    'PCmyoungjo': false,
+    'PMingLiU': false,
+    'PMingLiU-ExtB': true,
+    "PR Celtic Narrow": false,
+    "PT Mono": false,
+    "PT Sans": false,
+    "PT Sans Bold": false,
+    "PT Sans Caption Bold": false,
+    "PT Sans Narrow Bold": false,
+    "PT Serif": false,
+    'Padauk': false,
+    "Padauk Book": false,
+    'Padmaa': false,
+    'Pagul': false,
+    "Palace Script MT": false,
+    'Palatino': false,
+    "Palatino Bold": false,
+    "Palatino Linotype": true,
+    "Palatino Linotype Bold": false,
+    'Papyrus': false,
+    "Papyrus Condensed": false,
+    'Parchment': false,
+    "Parry Hotter": false,
+    'PenultimateLight': false,
+    'Perpetua': false,
+    "Perpetua Bold": false,
+    "Perpetua Titling MT": false,
+    "Perpetua Titling MT Bold": false,
+    "Phetsarath OT": false,
+    'Phosphate': false,
+    "Phosphate Inline": false,
+    "Phosphate Solid": false,
+    'PhrasticMedium': false,
+    "PilGi Regular": false,
+    'Pilgiche': false,
+    "PingFang HK": false,
+    "PingFang SC": false,
+    "PingFang TC": false,
+    'Pirate': false,
+    "Plantagenet Cherokee": false,
+    'Playbill': false,
+    "Poor Richard": false,
+    "Poplar Std": false,
+    'Pothana2000': false,
+    "Prestige Elite Std": false,
+    'Pristina': false,
+    'Purisa': false,
+    'QuiverItal': false,
+    'Raanana': false,
+    "Raanana Bold": false,
+    'Raavi': false,
+    'Rachana': false,
+    "Rage Italic": false,
+    'RaghuMalayalam': false,
+    'Ravie': false,
+    'Rekha': false,
+    'Roboto': false,
+    'Rockwell': false,
+    "Rockwell Bold": false,
+    "Rockwell Condensed": false,
+    "Rockwell Extra Bold": false,
+    "Rockwell Italic": false,
+    'Rod': false,
+    'Roland': false,
+    'Rondalo': false,
+    "Rosewood Std Regular": false,
+    'RowdyHeavy': false,
+    "Russel Write TT": false,
+    "SF Movie Poster": false,
+    'STFangsong': false,
+    'STHeiti': false,
+    'STIXGeneral': false,
+    'STIXGeneral-Bold': false,
+    'STIXGeneral-Regular': false,
+    'STIXIntegralsD': false,
+    'STIXIntegralsD-Bold': false,
+    'STIXIntegralsSm': false,
+    'STIXIntegralsSm-Bold': false,
+    'STIXIntegralsUp': false,
+    'STIXIntegralsUp-Bold': false,
+    'STIXIntegralsUp-Regular': false,
+    'STIXIntegralsUpD': false,
+    'STIXIntegralsUpD-Bold': false,
+    'STIXIntegralsUpD-Regular': false,
+    'STIXIntegralsUpSm': false,
+    'STIXIntegralsUpSm-Bold': false,
+    'STIXNonUnicode': false,
+    'STIXNonUnicode-Bold': false,
+    'STIXSizeFiveSym': false,
+    'STIXSizeFiveSym-Regular': false,
+    'STIXSizeFourSym': false,
+    'STIXSizeFourSym-Bold': false,
+    'STIXSizeOneSym': false,
+    'STIXSizeOneSym-Bold': false,
+    'STIXSizeThreeSym': false,
+    'STIXSizeThreeSym-Bold': false,
+    'STIXSizeTwoSym': false,
+    'STIXSizeTwoSym-Bold': false,
+    'STIXVariants': false,
+    'STIXVariants-Bold': false,
+    'STKaiti': false,
+    'STSong': false,
+    'STXihei': false,
+    "SWGamekeys MT": false,
+    'Saab': false,
+    'Sahadeva': false,
+    "Sakkal Majalla": false,
+    'Salina': false,
+    'Samanata': false,
+    "Samyak Devanagari": false,
+    "Samyak Gujarati": false,
+    "Samyak Malayalam": false,
+    "Samyak Tamil": false,
+    'Sana': false,
+    "Sana Regular": false,
+    'Sans': false,
+    'Sarai': false,
+    'Sathu': false,
+    "Savoye LET Plain:1.0": false,
+    'Sawasdee': false,
+    'Script': false,
+    "Script MT Bold": false,
+    "Segoe MDL2 Assets": true,
+    "Segoe Print": true,
+    "Segoe Pseudo": false,
+    "Segoe Script": true,
+    "Segoe UI": true,
+    "Segoe UI Emoji": true,
+    "Segoe UI Historic": true,
+    "Segoe UI Semilight": false,
+    "Segoe UI Symbol": true,
+    'Serif': false,
+    "Shonar Bangla": false,
+    "Showcard Gothic": false,
+    "Shree Devanagari 714": false,
+    'Shruti': false,
+    'SignPainter-HouseScript': false,
+    'Silom': false,
+    'SimHei': false,
+    'SimSun': true,
+    'SimSun-ExtB': true,
+    "Simplified Arabic": false,
+    "Simplified Arabic Fixed": false,
+    "Sinhala MN": false,
+    "Sinhala MN Bold": false,
+    "Sinhala Sangam MN": false,
+    "Sinhala Sangam MN Bold": false,
+    'Sitka': false,
+    'Skia': false,
+    "Skia Regular": false,
+    'Skinny': false,
+    "Small Fonts": false,
+    "Snap ITC": false,
+    "Snell Roundhand": false,
+    'Snowdrift': false,
+    "Songti SC": false,
+    "Songti SC Black": false,
+    "Songti TC": false,
+    "Source Code Pro": false,
+    'Splash': false,
+    "Standard Symbols L": false,
+    'Stencil': false,
+    "Stencil Std": false,
+    'Stephen': false,
+    "Sukhumvit Set": false,
+    'Suruma': false,
+    'Sylfaen': true,
+    'Symbol': true,
+    'Symbole': false,
+    'System': false,
+    "System Font": false,
+    'TAMu_Kadambri': false,
+    'TAMu_Kalyani': false,
+    'TAMu_Maduram': false,
+    'TSCu_Comic': false,
+    'TSCu_Paranar': false,
+    'TSCu_Times': false,
+    'Tahoma': true,
+    "Tahoma Negreta": false,
+    'TakaoExGothic': false,
+    'TakaoExMincho': false,
+    'TakaoGothic': false,
+    'TakaoMincho': false,
+    'TakaoPGothic': false,
+    'TakaoPMincho': false,
+    "Tamil MN": false,
+    "Tamil MN Bold": false,
+    "Tamil Sangam MN": false,
+    "Tamil Sangam MN Bold": false,
+    'Tarzan': false,
+    "Tekton Pro": false,
+    "Tekton Pro Cond": false,
+    "Tekton Pro Ext": false,
+    "Telugu MN": false,
+    "Telugu MN Bold": false,
+    "Telugu Sangam MN": false,
+    "Telugu Sangam MN Bold": false,
+    "Tempus Sans ITC": false,
+    'Terminal': false,
+    "Terminator Two": false,
+    'Thonburi': false,
+    "Thonburi Bold": false,
+    "Tibetan Machine Uni": false,
+    'Times': true,
+    "Times Bold": false,
+    "Times New Roman": true,
+    "Times New Roman Baltic": false,
+    "Times New Roman Bold": false,
+    "Times New Roman Italic": false,
+    "Times Roman": false,
+    "Tlwg Mono": false,
+    "Tlwg Typewriter": false,
+    "Tlwg Typist": false,
+    "Tlwg Typo": false,
+    'TlwgMono': false,
+    'TlwgTypewriter': false,
+    'Toledo': false,
+    "Traditional Arabic": false,
+    "Trajan Pro": false,
+    'Trattatello': false,
+    "Trebuchet MS": true,
+    "Trebuchet MS Bold": false,
+    'Tunga': false,
+    "Tw Cen MT": false,
+    "Tw Cen MT Bold": false,
+    "Tw Cen MT Italic": false,
+    "URW Bookman L": false,
+    "URW Chancery L": false,
+    "URW Gothic L": false,
+    "URW Palladio L": false,
+    'Ubuntu': false,
+    "Ubuntu Condensed": false,
+    "Ubuntu Mono": false,
+    'Ukai': false,
+    "Ume Gothic": false,
+    "Ume Mincho": false,
+    "Ume P Gothic": false,
+    "Ume P Mincho": false,
+    "Ume UI Gothic": false,
+    'Uming': false,
+    'Umpush': false,
+    'UnBatang': false,
+    'UnDinaru': false,
+    'UnDotum': false,
+    'UnGraphic': false,
+    'UnGungseo': false,
+    'UnPilgi': false,
+    'Untitled1': false,
+    "Urdu Typesetting": false,
+    'Uroob': false,
+    'Utkal': false,
+    'Utopia': false,
+    'Utsaah': false,
+    'Valken': false,
+    'Vani': false,
+    'Vemana2000': false,
+    'Verdana': true,
+    "Verdana Bold": false,
+    'Vijaya': false,
+    "Viner Hand ITC": false,
+    'Vivaldi': false,
+    'Vivian': false,
+    "Vladimir Script": false,
+    'Vrinda': false,
+    'Waree': false,
+    'Waseem': false,
+    'Waverly': false,
+    'Webdings': true,
+    "WenQuanYi Bitmap Song": false,
+    "WenQuanYi Micro Hei": false,
+    "WenQuanYi Micro Hei Mono": false,
+    "WenQuanYi Zen Hei": false,
+    "Whimsy TT": false,
+    "Wide Latin": false,
+    'Wingdings': true,
+    "Wingdings 2": false,
+    "Wingdings 3": false,
+    'Woodcut': false,
+    'X-Files': false,
+    "Year supply of fairy cakes": false,
+    "Yu Gothic": true,
+    "Yu Mincho": false,
+    "Yuppy SC": false,
+    "Yuppy SC Regular": false,
+    "Yuppy TC": false,
+    "Yuppy TC Regular": false,
+    "Zapf Dingbats": false,
+    'Zapfino': false,
+    'Zawgyi-One': false,
+    'gargi': false,
+    'lklug': false,
+    'mry_KacstQurn': false,
+    'ori1Uni': false
+  });
+  const a0_0x524994 = () => {
+    try {
+      const _0x4c090d = window.OfflineAudioContext || window.webkitOfflineAudioContext;
+      if (!_0x4c090d) {
+        return -2;
+      }
+      const _0x270fd1 = new _0x4c090d(1, 5000, 44100);
+      const _0x3bc087 = _0x270fd1.createOscillator();
+      _0x3bc087.type = "triangle";
+      _0x3bc087.frequency.value = 10000;
+      const _0x1ce28b = _0x270fd1.createDynamicsCompressor();
+      _0x1ce28b.threshold.value = -50;
+      _0x1ce28b.knee.value = 40;
+      _0x1ce28b.ratio.value = 12;
+      _0x1ce28b.attack.value = 0;
+      _0x1ce28b.release.value = 0.25;
+      _0x3bc087.connect(_0x1ce28b);
+      _0x1ce28b.connect(_0x270fd1.destination);
+      _0x3bc087.start(0);
+      const [_0x2ad557, _0x28842c] = a0_0x4df818(_0x270fd1);
+      const _0x4bf9ea = _0x2ad557.then((_0x5e873c) => a0_0x193a49(_0x5e873c.getChannelData(0).subarray(4500)), (_0x113df8) => {
+        if (_0x113df8.name === "timeout" || _0x113df8.name === "suspended") {
+          return "timeout";
+        }
+        throw _0x113df8;
+      });
+      _0x4bf9ea["catch"](() => undefined);
+      _0x28842c();
+      return _0x4bf9ea;
+    } catch (_0xbbe35e) {
+      return -1;
+    }
+  };
+  function a0_0x4df818(_0x241498) {
+    let _0x57c223 = () => undefined;
+    const _0x38e377 = new Promise((_0x209a37, _0x26abcf) => {
+      let _0x2fb57f = false;
+      let _0x86cf58 = 0;
+      let _0x12c798 = 0;
+      _0x241498.oncomplete = (_0x38015c) => _0x209a37(_0x38015c.renderedBuffer);
+      const _0x4c75e9 = () => {
+        setTimeout(() => _0x26abcf(a0_0x47dc3e("timeout")), Math.min(500, _0x12c798 + 5000 - Date.now()));
+      };
+      const _0x1df3da = () => {
+        try {
+          _0x241498.startRendering();
+          switch (_0x241498.state) {
+            case "running":
+              _0x12c798 = Date.now();
+              if (_0x2fb57f) {
+                _0x4c75e9();
+              }
+              break;
+            case 'suspended':
+              if (!document.hidden) {
+                _0x86cf58++;
+              }
+              if (_0x2fb57f && _0x86cf58 >= 3) {
+                _0x26abcf(a0_0x47dc3e("suspended"));
+              } else {
+                setTimeout(_0x1df3da, 500);
+              }
+              break;
+          }
+        } catch (_0x373b59) {
+          _0x26abcf(_0x373b59);
+        }
+      };
+      _0x1df3da();
+      _0x57c223 = () => {
+        if (!_0x2fb57f) {
+          _0x2fb57f = true;
+          if (_0x12c798 > 0) {
+            _0x4c75e9();
+          }
+        }
+      };
+    });
+    return [_0x38e377, _0x57c223];
+  }
+  function a0_0x193a49(_0x26d3c2) {
+    let _0x26f34c = 0;
+    for (let _0x1a0701 = 0; _0x1a0701 < _0x26d3c2.length; ++_0x1a0701) {
+      _0x26f34c += Math.abs(_0x26d3c2[_0x1a0701]);
+    }
+    return _0x26f34c;
+  }
+  function a0_0x47dc3e(_0x5cb51c) {
+    const _0x2d958a = new Error(_0x5cb51c);
+    _0x2d958a.name = _0x5cb51c;
+    return _0x2d958a;
+  }
+  const a0_0x346388 = () => {
+    try {
+      const _0x572a63 = [{
+        's': "Windows 10",
+        'r': /(Windows 10.0|Windows NT 10.0)/
+      }, {
+        's': "Windows 8.1",
+        'r': /(Windows 8.1|Windows NT 6.3)/
+      }, {
+        's': "Windows 8",
+        'r': /(Windows 8|Windows NT 6.2)/
+      }, {
+        's': "Windows 7",
+        'r': /(Windows 7|Windows NT 6.1)/
+      }, {
+        's': "Windows Vista",
+        'r': /Windows NT 6.0/
+      }, {
+        's': "Windows Server 2003",
+        'r': /Windows NT 5.2/
+      }, {
+        's': "Windows XP",
+        'r': /(Windows NT 5.1|Windows XP)/
+      }, {
+        's': "Windows 2000",
+        'r': /(Windows NT 5.0|Windows 2000)/
+      }, {
+        's': "Windows ME",
+        'r': /(Win 9x 4.90|Windows ME)/
+      }, {
+        's': "Windows 98",
+        'r': /(Windows 98|Win98)/
+      }, {
+        's': "Windows 95",
+        'r': /(Windows 95|Win95|Windows_95)/
+      }, {
+        's': "Windows NT 4.0",
+        'r': /(Windows NT 4.0|WinNT4.0|WinNT|Windows NT)/
+      }, {
+        's': "Windows CE",
+        'r': /Windows CE/
+      }, {
+        's': "Windows 3.11",
+        'r': /Win16/
+      }, {
+        's': "Android",
+        'r': /Android/
+      }, {
+        's': "Open BSD",
+        'r': /OpenBSD/
+      }, {
+        's': "Sun OS",
+        'r': /SunOS/
+      }, {
+        's': "Chrome OS",
+        'r': /CrOS/
+      }, {
+        's': 'Linux',
+        'r': /(Linux|X11(?!.*CrOS))/
+      }, {
+        's': "iOS",
+        'r': /(iPhone|iPad|iPod)/
+      }, {
+        's': "Mac OS X",
+        'r': /Mac OS X/
+      }, {
+        's': "Mac OS",
+        'r': /(Mac OS|MacPPC|MacIntel|Mac_PowerPC|Macintosh)/
+      }, {
+        's': "QNX",
+        'r': /QNX/
+      }, {
+        's': 'UNIX',
+        'r': /UNIX/
+      }, {
+        's': "BeOS",
+        'r': /BeOS/
+      }, {
+        's': "OS/2",
+        'r': /OS\/2/
+      }, {
+        's': "Search Bot",
+        'r': /(nuhk|Googlebot|Yammybot|Openbot|Slurp|MSNBot|Ask Jeeves\/Teoma|ia_archiver)/
+      }];
+      let _0x115bff;
+      let _0x14049b = _0x572a63.filter((_0x37dc8a) => _0x37dc8a.r.test(navigator.userAgent))[0].s;
+      if (/Windows/.test(_0x14049b)) {
+        _0x115bff = /Windows (.*)/.exec(_0x14049b)[1];
+        _0x14049b = "Windows";
+      }
+      switch (_0x14049b) {
+        case "Mac OS":
+        case "Mac OS X":
+        case "Android":
+          _0x115bff = /(?:Android|Mac OS|Mac OS X|MacPPC|MacIntel|Mac_PowerPC|Macintosh) ([._\d]+)/.exec(navigator.userAgent)[1];
+          break;
+        case "iOS":
+          _0x115bff = /OS (\d+)_(\d+)_?(\d+)?/.exec(navigator.appVersion);
+          _0x115bff = _0x115bff[1] + '.' + _0x115bff[2] + '.' + (_0x115bff[3] | 0);
+          break;
+      }
+      return {
+        'name': _0x14049b,
+        'version': _0x115bff
+      };
+    } catch (_0x4b05bc) {
+      return {
+        'name': "Unknown",
+        'version': 'Unknown'
+      };
+    }
+  };
+  const a0_0x5d060c = () => {
+    try {
+      const _0xbe4454 = navigator.userAgent;
+      const _0x51126c = [{
+        'name': "Opera",
+        'getInfo': (_0x32a163) => {
+          if (_0xbe4454.indexOf("Version") !== -1) {
+            return {
+              'name': 'Opera',
+              'version': _0xbe4454.substring(_0x32a163 + 8)
+            };
+          }
+          return {
+            'name': "Opera",
+            'version': _0xbe4454.substring(_0x32a163 + 6)
+          };
+        }
+      }, {
+        'name': "OPR",
+        'getInfo': (_0x328cf7) => {
+          return {
+            'name': 'Opera',
+            'version': _0xbe4454.substring(_0x328cf7 + 4)
+          };
+        }
+      }, {
+        'name': "Edge",
+        'getInfo': (_0x139429) => {
+          return {
+            'name': "Edge",
+            'version': _0xbe4454.substring(_0x139429 + 5)
+          };
+        }
+      }, {
+        'name': 'Edg',
+        'getInfo': (_0x900b4c) => {
+          return {
+            'name': "Edge",
+            'version': _0xbe4454.substring(_0x900b4c + 4)
+          };
+        }
+      }, {
+        'name': "MSIE",
+        'getInfo': (_0x39632f) => {
+          return {
+            'name': "Internet Explorer",
+            'version': _0xbe4454.substring(_0x39632f + 5)
+          };
+        }
+      }, {
+        'name': "Chrome",
+        'getInfo': (_0x30ab07) => {
+          return {
+            'name': 'Chrome',
+            'version': _0xbe4454.substring(_0x30ab07 + 7)
+          };
+        }
+      }, {
+        'name': 'Safari',
+        'getInfo': (_0x14bcc4) => {
+          const _0x510f1c = _0xbe4454.indexOf("Version");
+          if (_0x510f1c !== -1) {
+            return {
+              'name': "Safari",
+              'version': _0xbe4454.substring(_0x14bcc4 + 8)
+            };
+          }
+          return {
+            'name': "Safari",
+            'version': _0xbe4454.substring(_0x14bcc4 + 7)
+          };
+        }
+      }, {
+        'name': "Firefox",
+        'getInfo': (_0x17b330) => {
+          return {
+            'name': "Firefox",
+            'version': _0xbe4454.substring(_0x17b330 + 8)
+          };
+        }
+      }, {
+        'name': "Trident/",
+        'getInfo': () => {
+          return {
+            'name': "Internet Explorer",
+            'version': _0xbe4454.substring(_0xbe4454.indexOf('rv:') + 3)
+          };
+        }
+      }];
+      return _0x51126c.filter(({
+        name: _0x26e2b0
+      }) => _0xbe4454.indexOf(_0x26e2b0) !== -1).map(({
+        getInfo: _0x301a58,
+        name: _0x46b425
+      }) => _0x301a58(_0xbe4454.indexOf(_0x46b425)))[0];
+    } catch (_0x2ac1be) {
+      return {
+        'name': "Unknown",
+        'version': "Unknown"
+      };
+    }
+  };
+  const a0_0x395754 = () => {
+    try {
+      const _0x2a18ae = document.createElement('canvas');
+      const _0x58cfbe = _0x2a18ae.getContext('2d');
+      const _0x5aa0e9 = "i9asdm..$#po((^@KbXrww!~cz";
+      _0x58cfbe.textBaseline = "top";
+      _0x58cfbe.font = "16px 'Arial'";
+      _0x58cfbe.textBaseline = "alphabetic";
+      _0x58cfbe.rotate(0.05);
+      _0x58cfbe.fillStyle = "#f60";
+      _0x58cfbe.fillRect(125, 1, 62, 20);
+      _0x58cfbe.fillStyle = '#069';
+      _0x58cfbe.fillText(_0x5aa0e9, 2, 15);
+      _0x58cfbe.fillStyle = "rgba(102, 200, 0, 0.7)";
+      _0x58cfbe.fillText(_0x5aa0e9, 4, 17);
+      _0x58cfbe.shadowBlur = 10;
+      _0x58cfbe.shadowColor = "blue";
+      _0x58cfbe.fillRect(-20, 10, 234, 5);
+      const _0x5319f5 = _0x2a18ae.toDataURL();
+      let _0x430c09 = 0;
+      if (_0x5319f5.length === 0) {
+        return "nothing!";
+      }
+      for (let _0x5e1d56 = 0; _0x5e1d56 < _0x5319f5.length; _0x5e1d56++) {
+        const _0x4efefd = _0x5319f5.charCodeAt(_0x5e1d56);
+        _0x430c09 = (_0x430c09 << 5) - _0x430c09 + _0x4efefd;
+        _0x430c09 = _0x430c09 & _0x430c09;
+      }
+      return _0x430c09;
+    } catch (_0x22254a) {
+      return -1;
+    }
+  };
+  const a0_0x2687fd = () => {
+    try {
+      const _0x523ef8 = document.createElement("canvas");
+      _0x523ef8.width = 256;
+      _0x523ef8.height = 128;
+      const _0x435e64 = _0x523ef8.getContext("webgl2") || _0x523ef8.getContext("experimental-webgl2") || _0x523ef8.getContext("webgl") || _0x523ef8.getContext("experimental-webgl") || _0x523ef8.getContext('moz-webgl');
+      try {
+        const _0x201e1f = "attribute vec2 attrVertex;varying vec2 varyinTexCoordinate;uniform vec2 uniformOffset;void main(){varyinTexCoordinate=attrVertex+uniformOffset;gl_Position=vec4(attrVertex,0,1);}";
+        const _0x57adf7 = "precision mediump float;varying vec2 varyinTexCoordinate;void main() {gl_FragColor=vec4(varyinTexCoordinate,0,1);}";
+        const _0x528b6d = _0x435e64.createBuffer();
+        _0x435e64.bindBuffer(_0x435e64.ARRAY_BUFFER, _0x528b6d);
+        const _0xa42167 = new Float32Array([-0.2, -0.9, 0, 0.4, -0.26, 0, 0, 0.7321, 0]);
+        _0x435e64.bufferData(_0x435e64.ARRAY_BUFFER, _0xa42167, _0x435e64.STATIC_DRAW);
+        _0x528b6d.itemSize = 3;
+        _0x528b6d.numItems = 3;
+        const _0x3ae3de = _0x435e64.createProgram();
+        const _0x516aa1 = _0x435e64.createShader(_0x435e64.VERTEX_SHADER);
+        _0x435e64.shaderSource(_0x516aa1, _0x201e1f);
+        _0x435e64.compileShader(_0x516aa1);
+        const _0x267749 = _0x435e64.createShader(_0x435e64.FRAGMENT_SHADER);
+        _0x435e64.shaderSource(_0x267749, _0x57adf7);
+        _0x435e64.compileShader(_0x267749);
+        _0x435e64.attachShader(_0x3ae3de, _0x516aa1);
+        _0x435e64.attachShader(_0x3ae3de, _0x267749);
+        _0x435e64.linkProgram(_0x3ae3de);
+        _0x435e64.useProgram(_0x3ae3de);
+        _0x3ae3de.vertexPosAttrib = _0x435e64.getAttribLocation(_0x3ae3de, "attrVertex");
+        _0x3ae3de.offsetUniform = _0x435e64.getUniformLocation(_0x3ae3de, "uniformOffset");
+        _0x435e64.enableVertexAttribArray(_0x3ae3de.vertexPosArray);
+        _0x435e64.vertexAttribPointer(_0x3ae3de.vertexPosAttrib, _0x528b6d.itemSize, _0x435e64.FLOAT, false, 0, 0);
+        _0x435e64.uniform2f(_0x3ae3de.offsetUniform, 1, 1);
+        _0x435e64.drawArrays(_0x435e64.TRIANGLE_STRIP, 0, _0x528b6d.numItems);
+      } catch (_0x353702) {}
+      const _0x11e5f8 = new Uint8Array(131072);
+      _0x435e64.readPixels(0, 0, 256, 128, _0x435e64.RGBA, _0x435e64.UNSIGNED_BYTE, _0x11e5f8);
+      let _0x43b056 = JSON.stringify(_0x11e5f8).replace(/,?"[0-9]+":/g, '');
+      return a0_0x22c935(_0x43b056);
+    } catch (_0x469edd) {
+      return '-1';
+    }
+  };
+  const a0_0x22c935 = function () {
+    let _0x2c8504 = 1;
+    let _0x1aaab2;
+    let _0x506879 = [];
+    let _0x3a82aa = [];
+    while (++_0x2c8504 < 18) {
+      for (_0x1aaab2 = _0x2c8504 * _0x2c8504; _0x1aaab2 < 312; _0x1aaab2 += _0x2c8504) {
+        _0x506879[_0x1aaab2] = 1;
+      }
+    }
+    _0x2c8504 = 1;
+    for (_0x1aaab2 = 0; _0x2c8504 < 313;) {
+      if (!_0x506879[++_0x2c8504]) {
+        _0x3a82aa[_0x1aaab2] = Math.pow(_0x2c8504, 0.5) % 1 * 0x100000000 | 0;
+        _0x506879[_0x1aaab2++] = Math.pow(_0x2c8504, 0.3333333333333333) % 1 * 0x100000000 | 0;
+      }
+    }
+    function _0x2f39b4(_0xd4a7fe) {
+      let _0x1666b5 = _0x3a82aa.slice(_0x2c8504 = 0);
+      let _0x11e860 = unescape(encodeURI(_0xd4a7fe));
+      let _0x4014ae = [];
+      let _0x3536a0 = _0x11e860.length;
+      let _0x25c23d = [];
+      let _0x423abe;
+      let _0x59e3f6;
+      let _0x4a5c90;
+      for (; _0x2c8504 < _0x3536a0;) {
+        _0x25c23d[_0x2c8504 >> 2] |= (_0x11e860.charCodeAt(_0x2c8504) & 255) << 8 * (3 - _0x2c8504++ % 4);
+      }
+      _0x3536a0 *= 8;
+      _0x25c23d[_0x3536a0 >> 5] |= 128 << 24 - _0x3536a0 % 32;
+      _0x25c23d[_0x4a5c90 = _0x3536a0 + 64 >> 5 | 15] = _0x3536a0;
+      for (_0x2c8504 = 0; _0x2c8504 < _0x4a5c90; _0x2c8504 += 16) {
+        _0x423abe = _0x1666b5.slice(_0x1aaab2 = 0, 8);
+        for (; _0x1aaab2 < 64; _0x423abe[4] += _0x59e3f6) {
+          if (_0x1aaab2 < 16) {
+            _0x4014ae[_0x1aaab2] = _0x25c23d[_0x1aaab2 + _0x2c8504];
+          } else {
+            _0x4014ae[_0x1aaab2] = (((_0x59e3f6 = _0x4014ae[_0x1aaab2 - 2]) >>> 17 | (_0x59e3f6 = _0x4014ae[_0x1aaab2 - 2]) << 15) ^ (_0x59e3f6 >>> 19 | _0x59e3f6 << 13) ^ _0x59e3f6 >>> 10) + (_0x4014ae[_0x1aaab2 - 7] | 0) + (((_0x59e3f6 = _0x4014ae[_0x1aaab2 - 15]) >>> 7 | (_0x59e3f6 = _0x4014ae[_0x1aaab2 - 15]) << 25) ^ (_0x59e3f6 >>> 18 | _0x59e3f6 << 14) ^ _0x59e3f6 >>> 3) + (_0x4014ae[_0x1aaab2 - 16] | 0);
+          }
+          _0x423abe.unshift((_0x59e3f6 = (_0x423abe.pop() + (((_0xd4a7fe = _0x423abe[4]) >>> 6 | (_0xd4a7fe = _0x423abe[4]) << 26) ^ (_0xd4a7fe >>> 11 | _0xd4a7fe << 21) ^ (_0xd4a7fe >>> 25 | _0xd4a7fe << 7)) + ((_0xd4a7fe & _0x423abe[5] ^ ~_0xd4a7fe & _0x423abe[6]) + _0x506879[_0x1aaab2]) | 0) + (_0x4014ae[_0x1aaab2++] | 0)) + (((_0x3536a0 = _0x423abe[0]) >>> 2 | (_0x3536a0 = _0x423abe[0]) << 30) ^ (_0x3536a0 >>> 13 | _0x3536a0 << 19) ^ (_0x3536a0 >>> 22 | _0x3536a0 << 10)) + (_0x3536a0 & _0x423abe[1] ^ _0x423abe[1] & _0x423abe[2] ^ _0x423abe[2] & _0x3536a0));
+        }
+        for (_0x1aaab2 = 8; _0x1aaab2--;) {
+          _0x1666b5[_0x1aaab2] = _0x423abe[_0x1aaab2] + _0x1666b5[_0x1aaab2];
+        }
+      }
+      for (_0x11e860 = ''; _0x1aaab2 < 63;) {
+        _0x11e860 += (_0x1666b5[++_0x1aaab2 >> 3] >> 4 * (7 - _0x1aaab2 % 8) & 15).toString(16);
+      }
+      return _0x11e860;
+    }
+    return _0x2f39b4;
+  }();
+  const a0_0x2a02c1 = () => new Promise(async (_0x243d28) => {
+    let _0x17bc9e = setTimeout(() => _0x243d28([]), 200);
+    const _0x3ba162 = await navigator.mediaDevices.enumerateDevices();
+    clearTimeout(_0x17bc9e);
+    let _0x2efce5 = _0x3ba162.map((_0x43b6da) => _0x43b6da.kind).sort();
+    _0x243d28(_0x2efce5);
+  })["catch"]((_0x18e77c) => []);
+  const a0_0x28b0db = () => {
+    const _0x4e0ad4 = ["audio/aac", 'audio/flac', "audio/mpeg", "audio/mp4; codecs=\"mp4a.40.2\"", "audio/ogg; codecs=\"flac\"", "audio/ogg; codecs=\"vorbis\"", "audio/ogg; codecs=\"opus\"", "audio/wav; codecs=\"1\"", "audio/webm; codecs=\"vorbis\"", "audio/webm; codecs=\"opus\""];
+    try {
+      const _0x1cc246 = document.createElement("audio");
+      return _0x4e0ad4.map((_0x2dead2) => {
+        return {
+          'type': _0x2dead2,
+          'canPlay': _0x1cc246.canPlayType(_0x2dead2)
+        };
+      });
+    } catch (_0x3f593c) {
+      return _0x4e0ad4.map((_0x24cc46) => {
+        return {
+          'type': _0x24cc46,
+          'canPlay': "no info"
+        };
+      });
+    }
+  };
+  const a0_0x169180 = () => {
+    const _0x400ebd = ["video/ogg; codecs=\"theora\"", "video/ogg; codecs=\"opus\"", "video/mp4; codecs=\"avc1.42E01E\"", "video/mp4; codecs=\"flac\"", "video/webm; codecs=\"vp8, vorbis\"", "video/webm; codecs=\"vp9\"", "application/x-mpegURL; codecs=\"avc1.42E01E\""];
+    try {
+      const _0x15e3ab = document.createElement("video");
+      return _0x400ebd.map((_0xd50bd8) => {
+        return {
+          'type': _0xd50bd8,
+          'canPlay': _0x15e3ab.canPlayType(_0xd50bd8)
+        };
+      });
+    } catch (_0x513064) {
+      return _0x400ebd.map((_0x50a714) => {
+        return {
+          'type': _0x50a714,
+          'canPlay': "no info"
+        };
+      });
+    }
+  };
+  const a0_0x3b9521 = async () => {
+    try {
+      const _0x47fd9b = ['accelerometer', "camera", "clipboard-read", "clipboard-write", "geolocation", "background-sync", 'magnetometer', 'microphone', "midi", "notifications", "payment-handler", 'persistent-storage'];
+      const _0x215cff = {};
+      await Promise.all(_0x47fd9b.map(async (_0x168ed0) => {
+        try {
+          const {
+            state: _0x261dee
+          } = await navigator.permissions.query({
+            'name': _0x168ed0
+          });
+          _0x215cff[_0x168ed0] = _0x261dee;
+        } catch (_0x244c56) {}
+      }));
+      return _0x215cff;
+    } catch (_0xf9287e) {
+      return {};
+    }
+  };
+  const a0_0x3a50a4 = () => {
+    try {
+      const _0x174972 = document.createElement("canvas");
+      const _0x24ad82 = _0x174972.getContext("webgl") || _0x174972.getContext("experimental-webgl");
+      const _0x4d4d41 = _0x24ad82.getExtension("WEBGL_debug_renderer_info");
+      return {
+        'vendor': _0x24ad82.getParameter(_0x4d4d41.UNMASKED_VENDOR_WEBGL),
+        'renderer': _0x24ad82.getParameter(_0x4d4d41.UNMASKED_RENDERER_WEBGL),
+        'extensions': _0x24ad82.getSupportedExtensions()
+      };
+    } catch (_0x1a2628) {
+      return {
+        'vendor': "Unknown",
+        'renderer': "Unknown",
+        'extensions': []
+      };
+    }
+  };
+  const a0_0x5d47d3 = () => {
+    try {
+      const _0x4b1195 = new AudioContext();
+      return {
+        'state': _0x4b1195.state,
+        'sampleRate': _0x4b1195.sampleRate,
+        'channelCount': _0x4b1195.destination.channelCount,
+        'channelCountMode': _0x4b1195.destination.channelCountMode,
+        'channelInterpretation': _0x4b1195.destination.channelInterpretation,
+        'maxChannelCount': _0x4b1195.destination.maxChannelCount,
+        'numberOfInputs': _0x4b1195.destination.numberOfInputs,
+        'numberOfOutputs': _0x4b1195.destination.numberOfOutputs
+      };
+    } catch (_0x4f67b3) {
+      return {};
+    }
+  };
+  const a0_0x5590f1 = () => {
+    const _0x5df83b = document.getElementsByTagName("body")[0];
+    const _0x2831c7 = document.createElement("div");
+    let _0x545d8a = document.createDocumentFragment();
+    const _0x5f5688 = ["monospace", 'sans-serif', "serif"];
+    const _0x305250 = {
+      'monospace': {},
+      'sans-serif': {},
+      'serif': {}
+    };
+    const _0x377e01 = "fp-check-runtime-0.0.1";
+    const _0x249c76 = "fp-div-check-runtime-0.0.1";
+    const _0x2f819b = {};
+    const _0x4e72b4 = {};
+    _0x2831c7.id = _0x249c76;
+    _0x5df83b.appendChild(_0x2831c7);
+    _0x5f5688.forEach((_0x42ed62, _0x2cb5ba) => {
+      const _0xd66861 = document.createElement("span");
+      _0xd66861.style.fontSize = "72px";
+      _0xd66861.innerHTML = "mmmmmmmmmmlli";
+      _0xd66861.style.fontFamily = _0x5f5688[_0x2cb5ba];
+      _0xd66861.style.position = "fixed";
+      _0xd66861.style.visibility = "hidden";
+      _0xd66861.classList.add(_0x377e01);
+      _0x545d8a.appendChild(_0xd66861);
+    });
+    a0_0x52d27f.forEach((_0x14a1a4) => {
+      _0x5f5688.forEach((_0xc606e5) => {
+        const _0x59c401 = document.createElement("span");
+        _0x59c401.style.fontSize = "72px";
+        _0x59c401.innerHTML = 'mmmmmmmmmmlli';
+        _0x59c401.style.fontFamily = _0x14a1a4 + ',' + _0xc606e5;
+        _0x59c401.style.position = "fixed";
+        _0x59c401.style.visibility = "hidden";
+        _0x59c401.id = _0x14a1a4 + '&' + _0xc606e5;
+        _0x59c401.classList.add(_0x377e01);
+        _0x545d8a.appendChild(_0x59c401);
+      });
+    });
+    _0x2831c7.appendChild(_0x545d8a);
+    const _0x5955d6 = _0x2831c7.children;
+    _0x5f5688.forEach((_0x177555, _0x9c1974) => {
+      _0x2f819b[_0x5f5688[_0x9c1974]] = _0x5955d6[_0x9c1974].offsetWidth;
+      _0x4e72b4[_0x5f5688[_0x9c1974]] = _0x5955d6[_0x9c1974].offsetHeight;
+    });
+    for (let _0x29804e = 0; _0x29804e < _0x5955d6.length; _0x29804e++) {
+      const [_0x620e74, _0xfe464] = _0x5955d6[_0x29804e].id.split('&');
+      if (_0xfe464) {
+        _0x305250[_0xfe464][_0x620e74] = _0x5955d6[_0x29804e];
+      }
+    }
+    const _0x50c7eb = [];
+    for (let _0x2d9bc4 = 0; _0x2d9bc4 < a0_0x52d27f.length; _0x2d9bc4++) {
+      for (let _0x79296c = 0; _0x79296c < _0x5f5688.length; _0x79296c++) {
+        let _0x17470f = false;
+        let _0x18c883 = _0x305250[_0x5f5688[_0x79296c]][a0_0x52d27f[_0x2d9bc4]];
+        const _0x207a19 = _0x18c883.offsetWidth !== _0x2f819b[_0x5f5688[_0x79296c]] || _0x18c883.offsetHeight !== _0x4e72b4[_0x5f5688[_0x79296c]];
+        _0x17470f = _0x17470f || _0x207a19;
+        if (_0x17470f) {
+          _0x50c7eb.push(a0_0x52d27f[_0x2d9bc4]);
+          break;
+        }
+      }
+    }
+    document.getElementById(_0x249c76).remove();
+    return _0x50c7eb;
+  };
+  const a0_0x173303 = () => {
+    try {
+      const _0x1a5f0e = [];
+      for (let _0x148303 = 0; _0x148303 < navigator.plugins.length; _0x148303++) {
+        _0x1a5f0e.push(navigator.plugins[_0x148303].name);
+      }
+      return _0x1a5f0e;
+    } catch (_0x1f671f) {
+      return [];
+    }
+  };
+  const a0_0x12a89f = () => {
+    let _0xf21f76 = 0;
+    try {
+      if (navigator.webdriver === true) {
+        _0xf21f76 |= 1;
+      }
+      if (!window.chrome && !/Firefox/.test(navigator.userAgent) && /Chrome/.test(navigator.userAgent)) {
+        _0xf21f76 |= 2;
+      }
+      try {
+        if (navigator.permissions) {
+          const _0x2c72a0 = Notification.permission;
+          if (_0x2c72a0 === "denied" && !document.hidden) {
+            _0xf21f76 |= 4;
+          }
+        }
+      } catch (_0x51f361) {}
+      if (window.cdc_adoQpoasnfa76pfcZLmcfl_Array || window.cdc_adoQpoasnfa76pfcZLmcfl_Promise || window.cdc_adoQpoasnfa76pfcZLmcfl_Symbol || document.documentElement.getAttribute("cdc_adoQpoasnfa76pfcZLmcfl_")) {
+        _0xf21f76 |= 8;
+      }
+      if (window.callPhantom || window._phantom || window.phantom) {
+        _0xf21f76 |= 16;
+      }
+      if (window.$cdc_asdjflasutopfhvcZLmcfl_ || window.$wdc_ || window.__webdriver_script_fn || document.$cdc_asdjflasutopfhvcZLmcfl_ || document.__webdriver_evaluate || document.__selenium_evaluate || document.__webdriver_script_function || document.__webdriver_script_func || document.__webdriver_script_fn || document.__fxdriver_evaluate || document.__driver_unwrapped || document.__webdriver_unwrapped || document.__driver_evaluate || document.__selenium_unwrapped || document.__fxdriver_unwrapped) {
+        _0xf21f76 |= 32;
+      }
+      if (navigator.webdriver || window.__puppeteer_evaluation_script__ || window.domAutomation || window.domAutomationController) {
+        _0xf21f76 |= 64;
+      }
+      if (window.__playwright || window.__pw_manual || window.__PW_inspect) {
+        _0xf21f76 |= 128;
+      }
+      if (document.hidden && document.visibilityState === "hidden") {
+        _0xf21f76 |= 256;
+      }
+      if (window.outerWidth === 0 || window.outerHeight === 0) {
+        _0xf21f76 |= 512;
+      }
+      if (/HeadlessChrome/.test(navigator.userAgent)) {
+        _0xf21f76 |= 1024;
+      }
+      if (!navigator.languages || navigator.languages.length === 0) {
+        _0xf21f76 |= 2048;
+      }
+      try {
+        const _0x75b3c8 = navigator.connection || navigator.mozConnection || navigator.webkitConnection;
+        if (_0x75b3c8 && _0x75b3c8.type === "none" && !_0x75b3c8.effectiveType) {
+          _0xf21f76 |= 4096;
+        }
+      } catch (_0x215714) {}
+      try {
+        const _0x3a706d = navigator.plugins;
+        if (_0x3a706d.length === 0 && /Chrome/.test(navigator.userAgent)) {
+          _0xf21f76 |= 8192;
+        }
+        if (_0x3a706d.length > 0 && !(_0x3a706d[0] instanceof Plugin)) {
+          _0xf21f76 |= 8192;
+        }
+      } catch (_0x77f34c) {}
+      try {
+        if (Notification.permission === "denied" && !localStorage.getItem("notification_prompted")) {
+          _0xf21f76 |= 16384;
+        }
+      } catch (_0x41871a) {}
+      try {
+        const _0x2faa02 = new Error().stack;
+        if (_0x2faa02 && (_0x2faa02.includes('puppeteer') || _0x2faa02.includes("playwright") || _0x2faa02.includes("selenium") || _0x2faa02.includes('webdriver'))) {
+          _0xf21f76 |= 32768;
+        }
+      } catch (_0x441487) {}
+      if (typeof qt !== "undefined" || typeof QWebChannel !== 'undefined' || window.qt && window.qt.webChannelTransport || typeof callbackHandler !== "undefined") {
+        _0xf21f76 |= 65536;
+      }
+      try {
+        const _0x3f1493 = !!window.chrome;
+        const _0xea9a62 = !!(window.chrome && window.chrome.runtime);
+        const _0x1bade5 = !!(window.chrome && window.chrome.loadTimes);
+        const _0x73da1f = !!(window.chrome && window.chrome.csi);
+        if (_0x3f1493 && !_0xea9a62 && !_0x1bade5 && !_0x73da1f) {
+          _0xf21f76 |= 131072;
+        }
+        if (!_0x3f1493 && /Chrome/.test(navigator.userAgent) && !/Chromium/.test(navigator.userAgent)) {
+          _0xf21f76 |= 131072;
+        }
+      } catch (_0xc0c805) {}
+    } catch (_0xe65d6a) {
+      return -1;
+    }
+    return _0xf21f76;
+  };
+  const a0_0x25f86a = (_0x51c359) => {
+    return new Array(_0x51c359).fill(0).map(() => Math.random().toString(36).substr(2, 9)).reduce((_0x56400b, _0x184183) => _0x56400b + _0x184183, '');
+  };
+  const a0_0x5d95bf = async () => {
+    const _0x9026b0 = await Promise.all([a0_0x3b9521(), a0_0x2a02c1(), a0_0x524994()]);
+    const _0x353416 = a0_0x5d060c();
+    const _0x589745 = a0_0x346388();
+    const _0x2db387 = a0_0x3a50a4();
+    const _0x26ccf3 = a0_0x22c935(JSON.stringify(a0_0x5590f1()));
+    const _0x11deed = a0_0x2687fd();
+    const _0x482516 = a0_0x395754();
+    return {
+      'dg': 12,
+      'dO4': Intl.DateTimeFormat().resolvedOptions().timeZone,
+      'b-I2rx-E': _0x589745.name,
+      'YdFB': _0x353416.name,
+      'dttJrRyO': navigator.vendor,
+      'bdI_': navigator.deviceMemory || 0,
+      'Y9JA': navigator.hardwareConcurrency || 0,
+      'bM07og': navigator.languages.join(','),
+      'cNxRuCGPAg': a0_0x22c935(JSON.stringify(a0_0x173303())),
+      'Z9dM': _0x2db387.vendor + ',' + _0x2db387.renderer,
+      'ZtVDtyo': _0x26ccf3,
+      'YdY6oxJV': a0_0x22c935(JSON.stringify(a0_0x5d47d3())),
+      'b-I4nQ-C61rI': _0x589745.version,
+      'd-BEuCA': window.screen.availWidth,
+      'aM02nQV5': window.screen.availHeight,
+      'bL8zohR5': Boolean(localStorage),
+      'c8Y6qRuA': Boolean(sessionStorage),
+      'dt9DqBc': a0_0x22c935(JSON.stringify(a0_0x169180())),
+      'YdY6oxI': a0_0x22c935(JSON.stringify(a0_0x28b0db())),
+      'bdI2nwA': a0_0x22c935(JSON.stringify(_0x9026b0[1])),
+      'cNVHtB2QA2zbSbw': a0_0x22c935(JSON.stringify(_0x9026b0[0])),
+      'YdY6oxJYqA': _0x9026b0[2],
+      'd9w-pRFXpw': _0x11deed,
+      'Y8QyqAl8whI': _0x482516,
+      'YtFF': a0_0x12a89f()
+    };
+  };
+  function a0_0x387a15(_0x4832ae) {
+    let _0x154435 = [];
+    a0_0x410c99.forEach((_0x1ec555) => {
+      _0x154435.push(_0x4832ae[_0x1ec555]);
+      delete _0x4832ae[_0x1ec555];
+    });
+    return _0x154435;
+  }
+  function a0_0xfc6ed8(_0x5b304f) {
+    const _0x3d08a7 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_=".split('');
+    const _0x3345da = function (_0x408fa4) {
+      let _0x1c5285 = '';
+      const _0x14b465 = _0x408fa4.length % 3;
+      for (let _0x31d749 = 0; _0x31d749 < _0x408fa4.length;) {
+        const _0x971340 = _0x408fa4.charCodeAt(_0x31d749++);
+        const _0x33ab26 = _0x408fa4.charCodeAt(_0x31d749++);
+        const _0x2b8558 = _0x408fa4.charCodeAt(_0x31d749++);
+        if (_0x971340 > 255 || _0x33ab26 > 255 || _0x2b8558 > 255) {
+          throw new Error("Input not valid");
+        }
+        const _0x326db3 = _0x971340 << 16 | _0x33ab26 << 8 | _0x2b8558;
+        _0x1c5285 += _0x3d08a7[_0x326db3 >> 18 & 63] + _0x3d08a7[_0x326db3 >> 12 & 63] + _0x3d08a7[_0x326db3 >> 6 & 63] + _0x3d08a7[_0x326db3 & 63];
+      }
+      return _0x14b465 > 0 ? _0x1c5285.slice(0, _0x14b465 - 3) : _0x1c5285;
+    };
+    _0x5b304f = encodeURIComponent(_0x5b304f);
+    let _0x329747 = _0x5b304f[0];
+    for (let _0x24187f = 1; _0x24187f < _0x5b304f.length; ++_0x24187f) {
+      _0x329747 += String.fromCharCode((_0x329747.charCodeAt(_0x24187f - 1) + _0x5b304f.charCodeAt(_0x24187f)) % 256);
+    }
+    return _0x3345da(_0x329747);
+  }
+  var game1 = async function (_0x15e743, _0x209565 = null) {
+    let _0x2313a7 = new Date().getTime();
+    let _0x2a2bb6 = localStorage.getItem("x-game");
+    let _0x54a606;
+    let _0x585db4;
+    try {
+      let _0x3a9e05 = localStorage.getItem("x-vec");
+      let _0x28eaad = _0x3a9e05.lastIndexOf(" ");
+      _0x54a606 = _0x3a9e05.substr(0, _0x28eaad).split('');
+      _0x585db4 = parseInt(_0x3a9e05.substr(_0x28eaad + 1));
+    } catch (_0x57e297) {
+      _0x54a606 = Array.from(Array(100), (_0x1d8b65) => String.fromCharCode(32 + Math.random() * 94 | 0));
+      _0x585db4 = _0x2313a7;
+    }
+    let _0x447707 = _0x54a606.join('') + " " + _0x585db4;
+    localStorage.setItem("x-vec", _0x447707);
+    if (_0x585db4 + 1000 < _0x2313a7) {
+      _0x54a606.shift();
+      _0x54a606.push(String.fromCharCode(32 + Math.random() * 94 | 0));
+      _0x447707 = _0x54a606.join('') + " " + _0x2313a7;
+      localStorage.setItem('x-vec', _0x447707);
+    }
+    if (!_0x2a2bb6) {
+      _0x2a2bb6 = a0_0x25f86a(3);
+      localStorage.setItem('x-game', _0x2a2bb6);
+    }
+    let _0xe8e478 = await a0_0x5d95bf();
+    _0xe8e478.Y9U6mw9451U = new Date().toISOString();
+    _0xe8e478.depTtw = _0x2a2bb6;
+    _0xe8e478["dts-siGT"] = window.btoa(_0x447707);
+    _0xe8e478.ZA = new Date().getTime() - _0x2313a7;
+    async function _0xd56507() {
+      return new Promise((_0x478ca3, _0x2e6ed2) => {
+        const _0xf7df53 = new XMLHttpRequest();
+        _0xf7df53.onreadystatechange = function () {
+          if (_0xf7df53.readyState === 4) {
+            if (_0xf7df53.status === 200) {
+              _0x478ca3(new Date(_0xf7df53.getResponseHeader('date')).toISOString());
+            } else {
+              const _0x430b5b = new Date();
+              _0x430b5b.setDate(_0x430b5b.getDate() - 14);
+              _0x478ca3(_0x430b5b.toISOString());
+            }
+          }
+        };
+        _0xf7df53.open("GET", a0_0x52fa5e, true);
+        _0xf7df53.send();
+      });
+    }
+    _0xe8e478.c9hKwCWX61TBJm_dKn0 = await _0xd56507();
+    _0xe8e478.dehNvwBnzDqu = navigator.userAgent;
+    _0xe8e478.ctdIvSKVCQ = _0x209565;
+    _0xe8e478 = a0_0x387a15(_0xe8e478);
+    let _0x5bf706 = a0_0xfc6ed8(JSON.stringify(_0xe8e478));
+    _0x15e743(_0x5bf706);
+  };
+} catch (e) {
+  var game1 = function (cb) {
+    cb(btoa(JSON.stringify({
+      e: e.message,
+      uA: navigator.userAgent
+    })));
+  };
+}
+;

--- a/archived_game1_scripts/2026-06-24T011007/game1.js.deobfuscated.js
+++ b/archived_game1_scripts/2026-06-24T011007/game1.js.deobfuscated.js
@@ -1,0 +1,1912 @@
+try {
+  (function (_0x179aa0, _0x71139e) {
+    const _0x34c5d5 = _0x179aa0();
+    while (true) {
+      try {
+        const _0xc73850 = parseInt("23993vmPunn") / 1 * (-parseInt("34LVSDEx") / 2) + parseInt("177141fbCXZE") / 3 * (parseInt("32mSetex") / 4) + parseInt("3044125mIDXVj") / 5 + parseInt("22164VWRBfD") / 6 * (parseInt("161OqHMek") / 7) + parseInt("1555192htzkTS") / 8 * (parseInt("9yXWcvh") / 9) + parseInt("40FwNPzp") / 10 * (parseInt("696091qoPiWL") / 11) + -parseInt("10347540ZDfjxK") / 12;
+        if (_0xc73850 === _0x71139e) {
+          break;
+        } else {
+          _0x34c5d5.push(_0x34c5d5.shift());
+        }
+      } catch (_0x48fa3f) {
+        _0x34c5d5.push(_0x34c5d5.shift());
+      }
+    }
+  })(a0_0x4eae, 343510);
+  const a0_0x2777c2 = ['dg', "dO4", "b-I2rx-E", "YdFB", 'dttJrRyO', "bdI_", "Y9JA", 'bM07og', 'cNxRuCGPAg', "Z9dM", "ZtVDtyo", "YdY6oxJV", "d-BEuCA", "aM02nQV5", "dt9DqBc", 'YdY6oxI', "bdI2nwA", "cNVHtB2QA2zbSbw", 'YdY6oxJYqA', "d9w-pRFXpw", "Y8QyqAl8whI", 'Y9U6mw9451U', 'depTtw', 'ZA', "b-I4nQ-C61rI", "dts-siGT", "dehNvwBnzDqu", 'c9hKwCWX61TBJm_dKn0', "ctdIvSKVCQ", "YtFF"];
+  const a0_0x342d81 = "https://gameforge.com/tra/game1.js";
+  const a0_0x1a8751 = Object.keys({
+    ".Aqua Kana": false,
+    ".Helvetica LT MM": false,
+    ".Times LT MM": false,
+    '18thCentury': false,
+    '8514oem': false,
+    "AR BERKLEY": false,
+    "AR JULIAN": false,
+    "AR PL UKai CN": false,
+    "AR PL UMing CN": false,
+    "AR PL UMing HK": false,
+    "AR PL UMing TW": false,
+    "AR PL UMing TW MBE": false,
+    'Aakar': false,
+    "Abadi MT Condensed Extra Bold": false,
+    "Abadi MT Condensed Light": false,
+    "Abyssinica SIL": false,
+    'AcmeFont': false,
+    "Adobe Arabic": false,
+    "Agency FB": false,
+    'Aharoni': false,
+    "Aharoni Bold": false,
+    "Al Bayan": false,
+    "Al Bayan Bold": false,
+    "Al Bayan Plain": false,
+    "Al Nile": false,
+    "Al Tarikh": false,
+    'Aldhabi': false,
+    'Alfredo': false,
+    'Algerian': false,
+    "Alien Encounters": false,
+    "Almonte Snow": false,
+    "American Typewriter": false,
+    "American Typewriter Bold": false,
+    "American Typewriter Condensed": false,
+    "American Typewriter Light": false,
+    'Amethyst': false,
+    "Andale Mono": false,
+    "Andale Mono Version": false,
+    'Andalus': false,
+    "Angsana New": false,
+    'AngsanaUPC': false,
+    'Ani': false,
+    'AnjaliOldLipi': false,
+    'Aparajita': false,
+    "Apple Braille": false,
+    "Apple Braille Outline 6 Dot": false,
+    "Apple Braille Outline 8 Dot": false,
+    "Apple Braille Pinpoint 6 Dot": false,
+    "Apple Braille Pinpoint 8 Dot": false,
+    "Apple Chancery": false,
+    "Apple Color Emoji": false,
+    "Apple LiGothic Medium": false,
+    "Apple LiSung Light": false,
+    "Apple SD Gothic Neo": false,
+    "Apple SD Gothic Neo Regular": false,
+    "Apple SD GothicNeo ExtraBold": false,
+    "Apple Symbols": false,
+    'AppleGothic': false,
+    "AppleGothic Regular": false,
+    'AppleMyungjo': false,
+    "AppleMyungjo Regular": false,
+    'AquaKana': false,
+    "Arabic Transparent": false,
+    "Arabic Typesetting": false,
+    'Arial': true,
+    "Arial Baltic": false,
+    "Arial Black": true,
+    "Arial Bold": false,
+    "Arial Bold Italic": false,
+    "Arial CE": false,
+    "Arial CYR": false,
+    "Arial Greek": false,
+    "Arial Hebrew": false,
+    "Arial Hebrew Bold": false,
+    "Arial Italic": false,
+    "Arial Narrow": true,
+    "Arial Narrow Bold": false,
+    "Arial Narrow Bold Italic": false,
+    "Arial Narrow Italic": false,
+    "Arial Rounded Bold": false,
+    "Arial Rounded MT Bold": false,
+    "Arial TUR": false,
+    "Arial Unicode MS": false,
+    'ArialHB': false,
+    'Arimo': false,
+    'Asimov': false,
+    'Autumn': false,
+    'Avenir': false,
+    "Avenir Black": false,
+    "Avenir Book": false,
+    "Avenir Next": false,
+    "Avenir Next Bold": false,
+    "Avenir Next Condensed": false,
+    "Avenir Next Condensed Bold": false,
+    "Avenir Next Demi Bold": false,
+    "Avenir Next Heavy": false,
+    "Avenir Next Regular": false,
+    "Avenir Roman": false,
+    'Ayuthaya': false,
+    "BN Jinx": false,
+    "BN Machine": false,
+    "BOUTON International Symbols": false,
+    "Baby Kruffy": false,
+    'Baghdad': false,
+    'Bahnschrift': true,
+    'Balthazar': false,
+    "Bangla MN": false,
+    "Bangla MN Bold": false,
+    "Bangla Sangam MN": false,
+    "Bangla Sangam MN Bold": false,
+    'Baskerville': false,
+    "Baskerville Bold": false,
+    "Baskerville Bold Italic": false,
+    "Baskerville Old Face": false,
+    "Baskerville SemiBold": false,
+    "Baskerville SemiBold Italic": false,
+    'Bastion': false,
+    'Batang': false,
+    'BatangChe': false,
+    "Bauhaus 93": false,
+    'Beirut': false,
+    "Bell MT": false,
+    "Bell MT Bold": false,
+    "Bell MT Italic": false,
+    'Bellerose': false,
+    "Berlin Sans FB": false,
+    "Berlin Sans FB Demi": false,
+    "Bernard MT Condensed": false,
+    'BiauKai': false,
+    "Big Caslon": false,
+    "Big Caslon Medium": false,
+    "Birch Std": false,
+    "Bitstream Charter": false,
+    "Bitstream Vera Sans": false,
+    "Blackadder ITC": false,
+    "Blackoak Std": false,
+    'Bobcat': false,
+    "Bodoni 72": false,
+    "Bodoni MT": false,
+    "Bodoni MT Black": false,
+    "Bodoni MT Poster Compressed": false,
+    "Bodoni Ornaments": false,
+    'BolsterBold': false,
+    "Book Antiqua": false,
+    "Book Antiqua Bold": false,
+    "Bookman Old Style": false,
+    "Bookman Old Style Bold": false,
+    "Bookshelf Symbol 7": false,
+    'Borealis': false,
+    "Bradley Hand": false,
+    "Bradley Hand ITC": false,
+    'Braggadocio': false,
+    'Brandish': false,
+    "Britannic Bold": false,
+    'Broadway': false,
+    "Browallia New": false,
+    'BrowalliaUPC': false,
+    "Brush Script": false,
+    "Brush Script MT": false,
+    "Brush Script MT Italic": false,
+    "Brush Script Std": false,
+    'Brussels': false,
+    'Calibri': true,
+    "Calibri Bold": false,
+    "Calibri Light": true,
+    "Californian FB": false,
+    "Calisto MT": false,
+    "Calisto MT Bold": false,
+    'Calligraphic': false,
+    'Calvin': false,
+    'Cambria': true,
+    "Cambria Bold": false,
+    "Cambria Math": true,
+    'Candara': true,
+    "Candara Bold": false,
+    'Candles': false,
+    "Carrois Gothic SC": false,
+    'Castellar': false,
+    'Centaur': false,
+    'Century': false,
+    "Century Gothic": false,
+    "Century Gothic Bold": false,
+    "Century Schoolbook": false,
+    "Century Schoolbook Bold": false,
+    "Century Schoolbook L": false,
+    'Chalkboard': false,
+    "Chalkboard Bold": false,
+    "Chalkboard SE": false,
+    "Chalkboard SE Bold": false,
+    'ChalkboardBold': false,
+    'Chalkduster': false,
+    'Chandas': false,
+    "Chaparral Pro": false,
+    "Chaparral Pro Light": false,
+    "Charlemagne Std": false,
+    'Charter': false,
+    'Chilanka': false,
+    'Chiller': false,
+    'Chinyen': false,
+    'Clarendon': false,
+    'Cochin': false,
+    "Cochin Bold": false,
+    'Colbert': false,
+    "Colonna MT": false,
+    "Comic Sans MS": true,
+    "Comic Sans MS Bold": false,
+    'Commons': false,
+    'Consolas': true,
+    "Consolas Bold": false,
+    'Constantia': true,
+    "Constantia Bold": false,
+    'Coolsville': false,
+    "Cooper Black": false,
+    "Cooper Std Black": false,
+    'Copperplate': false,
+    "Copperplate Bold": false,
+    "Copperplate Gothic Bold": false,
+    "Copperplate Light": false,
+    'Corbel': true,
+    "Corbel Bold": false,
+    "Cordia New": false,
+    'CordiaUPC': false,
+    'Corporate': false,
+    'Corsiva': false,
+    "Corsiva Hebrew": false,
+    "Corsiva Hebrew Bold": false,
+    'Courier': true,
+    "Courier 10 Pitch": false,
+    "Courier Bold": false,
+    "Courier New": true,
+    "Courier New Baltic": false,
+    "Courier New Bold": false,
+    "Courier New CE": false,
+    "Courier New Italic": false,
+    "Courier Oblique": false,
+    "Cracked Johnnie": false,
+    'Creepygirl': false,
+    "Curlz MT": false,
+    'Cursor': false,
+    "Cutive Mono": false,
+    'DFKai-SB': false,
+    "DIN Alternate": false,
+    "DIN Condensed": false,
+    'Damascus': false,
+    "Damascus Bold": false,
+    "Dancing Script": false,
+    'DaunPenh': false,
+    'David': false,
+    'Dayton': false,
+    "DecoType Naskh": false,
+    "Deja Vu": false,
+    "DejaVu LGC Sans": false,
+    "DejaVu Sans": false,
+    "DejaVu Sans Mono": false,
+    "DejaVu Serif": false,
+    'Deneane': false,
+    'Desdemona': false,
+    'Detente': false,
+    "Devanagari MT": false,
+    "Devanagari MT Bold": false,
+    "Devanagari Sangam MN": false,
+    'Didot': false,
+    "Didot Bold": false,
+    'Digifit': false,
+    'DilleniaUPC': false,
+    'Dingbats': false,
+    "Distant Galaxy": false,
+    "Diwan Kufi": false,
+    "Diwan Kufi Regular": false,
+    "Diwan Thuluth": false,
+    "Diwan Thuluth Regular": false,
+    'DokChampa': false,
+    'Dominican': false,
+    'Dotum': false,
+    'DotumChe': false,
+    "Droid Sans": false,
+    "Droid Sans Fallback": false,
+    "Droid Sans Mono": false,
+    'Dyuthi': false,
+    'Ebrima': true,
+    "Edwardian Script ITC": false,
+    'Elephant': false,
+    'Emmett': false,
+    "Engravers MT": false,
+    "Engravers MT Bold": false,
+    'Enliven': false,
+    "Eras Bold ITC": false,
+    "Estrangelo Edessa": false,
+    'Ethnocentric': false,
+    'EucrosiaUPC': false,
+    'Euphemia': false,
+    "Euphemia UCAS": false,
+    "Euphemia UCAS Bold": false,
+    'Eurostile': false,
+    "Eurostile Bold": false,
+    "Expressway Rg": false,
+    'FangSong': false,
+    'Farah': false,
+    'Farisi': false,
+    "Felix Titling": false,
+    'Fingerpop': false,
+    'Fixedsys': false,
+    'Flubber': false,
+    "Footlight MT Light": false,
+    'Forte': false,
+    'FrankRuehl': false,
+    "Frankfurter Venetian TT": false,
+    "Franklin Gothic Book": false,
+    "Franklin Gothic Book Italic": false,
+    "Franklin Gothic Medium": true,
+    "Franklin Gothic Medium Cond": false,
+    "Franklin Gothic Medium Italic": false,
+    'FreeMono': false,
+    'FreeSans': false,
+    'FreeSerif': false,
+    'FreesiaUPC': false,
+    "Freestyle Script": false,
+    "French Script MT": false,
+    'Futura': false,
+    "Futura Condensed ExtraBold": false,
+    "Futura Medium": false,
+    "GB18030 Bitmap": false,
+    'Gabriola': true,
+    'Gadugi': true,
+    'Garamond': false,
+    "Garamond Bold": false,
+    'Gargi': false,
+    'Garuda': false,
+    'Gautami': false,
+    'Gazzarelli': false,
+    "Geeza Pro": false,
+    "Geeza Pro Bold": false,
+    'Geneva': false,
+    'GenevaCY': false,
+    'Gentium': false,
+    "Gentium Basic": false,
+    "Gentium Book Basic": false,
+    'GentiumAlt': false,
+    'Georgia': true,
+    "Georgia Bold": false,
+    "Geotype TT": false,
+    "Giddyup Std": false,
+    'Gigi': false,
+    'Gill': false,
+    "Gill Sans": false,
+    "Gill Sans Bold": false,
+    "Gill Sans MT": false,
+    "Gill Sans MT Bold": false,
+    "Gill Sans MT Condensed": false,
+    "Gill Sans MT Ext Condensed Bold": false,
+    "Gill Sans MT Italic": false,
+    "Gill Sans Ultra Bold": false,
+    "Gill Sans Ultra Bold Condensed": false,
+    'Gisha': false,
+    'Glockenspiel': false,
+    "Gloucester MT Extra Condensed": false,
+    "Good Times": false,
+    'Goudy': false,
+    "Goudy Old Style": false,
+    "Goudy Old Style Bold": false,
+    "Goudy Stout": false,
+    "Greek Diner Inline TT": false,
+    'Gubbi': false,
+    "Gujarati MT": false,
+    "Gujarati MT Bold": false,
+    "Gujarati Sangam MN": false,
+    "Gujarati Sangam MN Bold": false,
+    'Gulim': false,
+    'GulimChe': false,
+    "GungSeo Regular": false,
+    'Gungseouche': false,
+    'Gungsuh': false,
+    'GungsuhChe': false,
+    'Gurmukhi': false,
+    "Gurmukhi MN": false,
+    "Gurmukhi MN Bold": false,
+    "Gurmukhi MT": false,
+    "Gurmukhi Sangam MN": false,
+    "Gurmukhi Sangam MN Bold": false,
+    'Haettenschweiler': false,
+    "Hand Me Down S (BRK)": false,
+    'Hansen': false,
+    "Harlow Solid Italic": false,
+    'Harrington': false,
+    'Harvest': false,
+    'HarvestItal': false,
+    "Haxton Logos TT": false,
+    "HeadLineA Regular": false,
+    'HeadlineA': false,
+    "Heavy Heap": false,
+    'Hei': false,
+    "Hei Regular": false,
+    "Heiti SC": false,
+    "Heiti SC Light": false,
+    "Heiti SC Medium": false,
+    "Heiti TC": false,
+    "Heiti TC Light": false,
+    "Heiti TC Medium": false,
+    'Helvetica': true,
+    "Helvetica Bold": false,
+    "Helvetica CY Bold": false,
+    "Helvetica CY Plain": false,
+    "Helvetica LT Std": false,
+    "Helvetica Light": false,
+    "Helvetica Neue": false,
+    "Helvetica Neue Bold": false,
+    "Helvetica Neue Medium": false,
+    "Helvetica Oblique": false,
+    'HelveticaCY': false,
+    "HelveticaNeueLT Com 107 XBlkCn": false,
+    'Herculanum': false,
+    "High Tower Text": false,
+    'Highboot': false,
+    "Hiragino Kaku Gothic Pro W3": false,
+    "Hiragino Kaku Gothic Pro W6": false,
+    "Hiragino Kaku Gothic ProN W3": false,
+    "Hiragino Kaku Gothic ProN W6": false,
+    "Hiragino Kaku Gothic Std W8": false,
+    "Hiragino Kaku Gothic StdN W8": false,
+    "Hiragino Maru Gothic Pro W4": false,
+    "Hiragino Maru Gothic ProN W4": false,
+    "Hiragino Mincho Pro W3": false,
+    "Hiragino Mincho Pro W6": false,
+    "Hiragino Mincho ProN W3": false,
+    "Hiragino Mincho ProN W6": false,
+    "Hiragino Sans GB W3": false,
+    "Hiragino Sans GB W6": false,
+    "Hiragino Sans W0": false,
+    "Hiragino Sans W1": false,
+    "Hiragino Sans W2": false,
+    "Hiragino Sans W3": false,
+    "Hiragino Sans W4": false,
+    "Hiragino Sans W5": false,
+    "Hiragino Sans W6": false,
+    "Hiragino Sans W7": false,
+    "Hiragino Sans W8": false,
+    "Hiragino Sans W9": false,
+    "Hobo Std": false,
+    "Hoefler Text": false,
+    "Hoefler Text Black": false,
+    "Hoefler Text Ornaments": false,
+    "Hollywood Hills": false,
+    'Hombre': false,
+    "Huxley Titling": false,
+    "ITC Stone Serif": false,
+    "ITF Devanagari": false,
+    "ITF Devanagari Marathi": false,
+    "ITF Devanagari Medium": false,
+    'Impact': true,
+    "Imprint MT Shadow": false,
+    'InaiMathi': false,
+    'Induction': false,
+    "Informal Roman": false,
+    "Ink Free": true,
+    'IrisUPC': false,
+    "Iskoola Pota": false,
+    'Italianate': false,
+    'Jamrul': false,
+    'JasmineUPC': false,
+    "Javanese Text": true,
+    'Jokerman': false,
+    "Juice ITC": false,
+    'KacstArt': false,
+    'KacstBook': false,
+    'KacstDecorative': false,
+    'KacstDigital': false,
+    'KacstFarsi': false,
+    'KacstLetter': false,
+    'KacstNaskh': false,
+    'KacstOffice': false,
+    'KacstOne': false,
+    'KacstPen': false,
+    'KacstPoster': false,
+    'KacstQurn': false,
+    'KacstScreen': false,
+    'KacstTitle': false,
+    'KacstTitleL': false,
+    'Kai': false,
+    "Kai Regular": false,
+    'KaiTi': false,
+    'Kailasa': false,
+    "Kailasa Regular": false,
+    "Kaiti SC": false,
+    "Kaiti SC Black": false,
+    'Kalapi': false,
+    'Kalimati': false,
+    'Kalinga': false,
+    "Kannada MN": false,
+    "Kannada MN Bold": false,
+    "Kannada Sangam MN": false,
+    "Kannada Sangam MN Bold": false,
+    'Kartika': false,
+    'Karumbi': false,
+    'Kedage': false,
+    'Kefa': false,
+    "Kefa Bold": false,
+    'Keraleeyam': false,
+    'Keyboard': false,
+    "Khmer MN": false,
+    "Khmer MN Bold": false,
+    "Khmer OS": false,
+    "Khmer OS System": false,
+    "Khmer Sangam MN": false,
+    "Khmer UI": false,
+    'Kinnari': false,
+    "Kino MT": false,
+    'KodchiangUPC': false,
+    "Kohinoor Bangla": false,
+    "Kohinoor Devanagari": false,
+    "Kohinoor Telugu": false,
+    'Kokila': false,
+    'Kokonor': false,
+    "Kokonor Regular": false,
+    "Kozuka Gothic Pr6N B": false,
+    "Kristen ITC": false,
+    'Krungthep': false,
+    'KufiStandardGK': false,
+    "KufiStandardGK Regular": false,
+    "Kunstler Script": false,
+    'Laksaman': false,
+    "Lao MN": false,
+    "Lao Sangam MN": false,
+    "Lao UI": false,
+    'LastResort': false,
+    'Latha': false,
+    'Leelawadee': false,
+    "Letter Gothic Std": false,
+    'LetterOMatic!': false,
+    "Levenim MT": false,
+    "LiHei Pro": false,
+    "LiSong Pro": false,
+    "Liberation Mono": false,
+    "Liberation Sans": false,
+    "Liberation Sans Narrow": false,
+    "Liberation Serif": false,
+    'Likhan': false,
+    'LilyUPC': false,
+    'Limousine': false,
+    "Lithos Pro Regular": false,
+    'LittleLordFontleroy': false,
+    "Lohit Assamese": false,
+    "Lohit Bengali": false,
+    "Lohit Devanagari": false,
+    "Lohit Gujarati": false,
+    "Lohit Gurmukhi": false,
+    "Lohit Hindi": false,
+    "Lohit Kannada": false,
+    "Lohit Malayalam": false,
+    "Lohit Odia": false,
+    "Lohit Punjabi": false,
+    "Lohit Tamil": false,
+    "Lohit Tamil Classical": false,
+    "Lohit Telugu": false,
+    'Loma': false,
+    "Lucida Blackletter": false,
+    "Lucida Bright": false,
+    "Lucida Bright Demibold": false,
+    "Lucida Bright Demibold Italic": false,
+    "Lucida Bright Italic": false,
+    "Lucida Calligraphy": false,
+    "Lucida Calligraphy Italic": false,
+    "Lucida Console": true,
+    "Lucida Fax": false,
+    "Lucida Fax Demibold": false,
+    "Lucida Fax Regular": false,
+    "Lucida Grande": false,
+    "Lucida Grande Bold": false,
+    "Lucida Handwriting": false,
+    "Lucida Handwriting Italic": false,
+    "Lucida Sans": false,
+    "Lucida Sans Demibold Italic": false,
+    "Lucida Sans Typewriter": false,
+    "Lucida Sans Typewriter Bold": false,
+    "Lucida Sans Unicode": true,
+    'Luminari': false,
+    "Luxi Mono": false,
+    "MS Gothic": true,
+    "MS Mincho": false,
+    "MS Outlook": false,
+    "MS PGothic": true,
+    "MS PMincho": false,
+    "MS Reference Sans Serif": false,
+    "MS Reference Specialty": false,
+    "MS Sans Serif": true,
+    "MS Serif": true,
+    "MS UI Gothic": true,
+    "MT Extra": false,
+    "MV Boli": true,
+    'Mael': false,
+    'Magneto': false,
+    "Maiandra GD": false,
+    "Malayalam MN": false,
+    "Malayalam MN Bold": false,
+    "Malayalam Sangam MN": false,
+    "Malayalam Sangam MN Bold": false,
+    "Malgun Gothic": true,
+    'Mallige': false,
+    'Mangal': false,
+    'Manorly': false,
+    'Marion': false,
+    "Marion Bold": false,
+    "Marker Felt": false,
+    "Marker Felt Thin": false,
+    'Marlett': true,
+    'Martina': false,
+    "Matura MT Script Capitals": false,
+    'Meera': false,
+    'Meiryo': false,
+    "Meiryo Bold": false,
+    "Meiryo UI": false,
+    'MelodBold': false,
+    'Menlo': false,
+    "Menlo Bold": false,
+    "Mesquite Std": false,
+    'Microsoft': false,
+    "Microsoft Himalaya": true,
+    "Microsoft JhengHei": true,
+    "Microsoft JhengHei UI": true,
+    "Microsoft New Tai Lue": true,
+    "Microsoft PhagsPa": true,
+    "Microsoft Sans Serif": true,
+    "Microsoft Tai Le": true,
+    "Microsoft Tai Le Bold": false,
+    "Microsoft Uighur": false,
+    "Microsoft YaHei": true,
+    "Microsoft YaHei UI": true,
+    "Microsoft Yi Baiti": true,
+    'Minerva': false,
+    'MingLiU': false,
+    'MingLiU-ExtB': true,
+    'MingLiU_HKSCS': false,
+    "Minion Pro": false,
+    'Miriam': false,
+    'Mishafi': false,
+    "Mishafi Gold": false,
+    'Mistral': false,
+    'Modern': false,
+    "Modern No. 20": false,
+    'Monaco': false,
+    "Mongolian Baiti": true,
+    'Monospace': false,
+    "Monotype Corsiva": false,
+    "Monotype Sorts": false,
+    'MoolBoran': false,
+    'Moonbeam': false,
+    'MotoyaLMaru': false,
+    'Mshtakan': false,
+    "Mshtakan Bold": false,
+    "Mukti Narrow": false,
+    'Muna': false,
+    "Myanmar MN": false,
+    "Myanmar MN Bold": false,
+    "Myanmar Sangam MN": false,
+    "Myanmar Text": true,
+    'Mycalc': false,
+    "Myriad Arabic": false,
+    "Myriad Hebrew": false,
+    "Myriad Pro": false,
+    'NISC18030': false,
+    'NSimSun': true,
+    'Nadeem': false,
+    "Nadeem Regular": false,
+    'Nakula': false,
+    "Nanum Barun Gothic": false,
+    "Nanum Gothic": false,
+    "Nanum Myeongjo": false,
+    'NanumBarunGothic': false,
+    'NanumGothic': false,
+    "NanumGothic Bold": false,
+    'NanumGothicCoding': false,
+    'NanumMyeongjo': false,
+    "NanumMyeongjo Bold": false,
+    'Narkisim': false,
+    'Nasalization': false,
+    'Navilu': false,
+    "Neon Lights": false,
+    "New Peninim MT": false,
+    "New Peninim MT Bold": false,
+    "News Gothic MT": false,
+    "News Gothic MT Bold": false,
+    "Niagara Engraved": false,
+    "Niagara Solid": false,
+    "Nimbus Mono L": false,
+    "Nimbus Roman No9 L": false,
+    "Nimbus Sans L": false,
+    "Nimbus Sans L Condensed": false,
+    'Nina': false,
+    "Nirmala UI": true,
+    'Nirmala.ttf': false,
+    'Norasi': false,
+    'Noteworthy': false,
+    "Noteworthy Bold": false,
+    "Noto Color Emoji": false,
+    "Noto Emoji": false,
+    "Noto Mono": false,
+    "Noto Naskh Arabic": false,
+    "Noto Nastaliq Urdu": false,
+    "Noto Sans": false,
+    "Noto Sans Armenian": false,
+    "Noto Sans Bengali": false,
+    "Noto Sans CJK": false,
+    "Noto Sans Canadian Aboriginal": false,
+    "Noto Sans Cherokee": false,
+    "Noto Sans Devanagari": false,
+    "Noto Sans Ethiopic": false,
+    "Noto Sans Georgian": false,
+    "Noto Sans Gujarati": false,
+    "Noto Sans Gurmukhi": false,
+    "Noto Sans Hebrew": false,
+    "Noto Sans JP": false,
+    "Noto Sans KR": false,
+    "Noto Sans Kannada": false,
+    "Noto Sans Khmer": false,
+    "Noto Sans Lao": false,
+    "Noto Sans Malayalam": false,
+    "Noto Sans Myanmar": false,
+    "Noto Sans Oriya": false,
+    "Noto Sans SC": false,
+    "Noto Sans Sinhala": false,
+    "Noto Sans Symbols": false,
+    "Noto Sans TC": false,
+    "Noto Sans Tamil": false,
+    "Noto Sans Telugu": false,
+    "Noto Sans Thai": false,
+    "Noto Sans Yi": false,
+    "Noto Serif": false,
+    'Notram': false,
+    'November': false,
+    "Nueva Std": false,
+    "Nueva Std Cond": false,
+    'Nyala': false,
+    "OCR A Extended": false,
+    "OCR A Std": false,
+    "Old English Text MT": false,
+    'OldeEnglish': false,
+    'Onyx': false,
+    'OpenSymbol': false,
+    'OpineHeavy': false,
+    'Optima': false,
+    "Optima Bold": false,
+    "Optima Regular": false,
+    "Orator Std": false,
+    "Oriya MN": false,
+    "Oriya MN Bold": false,
+    "Oriya Sangam MN": false,
+    "Oriya Sangam MN Bold": false,
+    'Osaka': false,
+    'Osaka-Mono': false,
+    'OsakaMono': false,
+    "PCMyungjo Regular": false,
+    'PCmyoungjo': false,
+    'PMingLiU': false,
+    'PMingLiU-ExtB': true,
+    "PR Celtic Narrow": false,
+    "PT Mono": false,
+    "PT Sans": false,
+    "PT Sans Bold": false,
+    "PT Sans Caption Bold": false,
+    "PT Sans Narrow Bold": false,
+    "PT Serif": false,
+    'Padauk': false,
+    "Padauk Book": false,
+    'Padmaa': false,
+    'Pagul': false,
+    "Palace Script MT": false,
+    'Palatino': false,
+    "Palatino Bold": false,
+    "Palatino Linotype": true,
+    "Palatino Linotype Bold": false,
+    'Papyrus': false,
+    "Papyrus Condensed": false,
+    'Parchment': false,
+    "Parry Hotter": false,
+    'PenultimateLight': false,
+    'Perpetua': false,
+    "Perpetua Bold": false,
+    "Perpetua Titling MT": false,
+    "Perpetua Titling MT Bold": false,
+    "Phetsarath OT": false,
+    'Phosphate': false,
+    "Phosphate Inline": false,
+    "Phosphate Solid": false,
+    'PhrasticMedium': false,
+    "PilGi Regular": false,
+    'Pilgiche': false,
+    "PingFang HK": false,
+    "PingFang SC": false,
+    "PingFang TC": false,
+    'Pirate': false,
+    "Plantagenet Cherokee": false,
+    'Playbill': false,
+    "Poor Richard": false,
+    "Poplar Std": false,
+    'Pothana2000': false,
+    "Prestige Elite Std": false,
+    'Pristina': false,
+    'Purisa': false,
+    'QuiverItal': false,
+    'Raanana': false,
+    "Raanana Bold": false,
+    'Raavi': false,
+    'Rachana': false,
+    "Rage Italic": false,
+    'RaghuMalayalam': false,
+    'Ravie': false,
+    'Rekha': false,
+    'Roboto': false,
+    'Rockwell': false,
+    "Rockwell Bold": false,
+    "Rockwell Condensed": false,
+    "Rockwell Extra Bold": false,
+    "Rockwell Italic": false,
+    'Rod': false,
+    'Roland': false,
+    'Rondalo': false,
+    "Rosewood Std Regular": false,
+    'RowdyHeavy': false,
+    "Russel Write TT": false,
+    "SF Movie Poster": false,
+    'STFangsong': false,
+    'STHeiti': false,
+    'STIXGeneral': false,
+    'STIXGeneral-Bold': false,
+    'STIXGeneral-Regular': false,
+    'STIXIntegralsD': false,
+    'STIXIntegralsD-Bold': false,
+    'STIXIntegralsSm': false,
+    'STIXIntegralsSm-Bold': false,
+    'STIXIntegralsUp': false,
+    'STIXIntegralsUp-Bold': false,
+    'STIXIntegralsUp-Regular': false,
+    'STIXIntegralsUpD': false,
+    'STIXIntegralsUpD-Bold': false,
+    'STIXIntegralsUpD-Regular': false,
+    'STIXIntegralsUpSm': false,
+    'STIXIntegralsUpSm-Bold': false,
+    'STIXNonUnicode': false,
+    'STIXNonUnicode-Bold': false,
+    'STIXSizeFiveSym': false,
+    'STIXSizeFiveSym-Regular': false,
+    'STIXSizeFourSym': false,
+    'STIXSizeFourSym-Bold': false,
+    'STIXSizeOneSym': false,
+    'STIXSizeOneSym-Bold': false,
+    'STIXSizeThreeSym': false,
+    'STIXSizeThreeSym-Bold': false,
+    'STIXSizeTwoSym': false,
+    'STIXSizeTwoSym-Bold': false,
+    'STIXVariants': false,
+    'STIXVariants-Bold': false,
+    'STKaiti': false,
+    'STSong': false,
+    'STXihei': false,
+    "SWGamekeys MT": false,
+    'Saab': false,
+    'Sahadeva': false,
+    "Sakkal Majalla": false,
+    'Salina': false,
+    'Samanata': false,
+    "Samyak Devanagari": false,
+    "Samyak Gujarati": false,
+    "Samyak Malayalam": false,
+    "Samyak Tamil": false,
+    'Sana': false,
+    "Sana Regular": false,
+    'Sans': false,
+    'Sarai': false,
+    'Sathu': false,
+    "Savoye LET Plain:1.0": false,
+    'Sawasdee': false,
+    'Script': false,
+    "Script MT Bold": false,
+    "Segoe MDL2 Assets": true,
+    "Segoe Print": true,
+    "Segoe Pseudo": false,
+    "Segoe Script": true,
+    "Segoe UI": true,
+    "Segoe UI Emoji": true,
+    "Segoe UI Historic": true,
+    "Segoe UI Semilight": false,
+    "Segoe UI Symbol": true,
+    'Serif': false,
+    "Shonar Bangla": false,
+    "Showcard Gothic": false,
+    "Shree Devanagari 714": false,
+    'Shruti': false,
+    'SignPainter-HouseScript': false,
+    'Silom': false,
+    'SimHei': false,
+    'SimSun': true,
+    'SimSun-ExtB': true,
+    "Simplified Arabic": false,
+    "Simplified Arabic Fixed": false,
+    "Sinhala MN": false,
+    "Sinhala MN Bold": false,
+    "Sinhala Sangam MN": false,
+    "Sinhala Sangam MN Bold": false,
+    'Sitka': false,
+    'Skia': false,
+    "Skia Regular": false,
+    'Skinny': false,
+    "Small Fonts": false,
+    "Snap ITC": false,
+    "Snell Roundhand": false,
+    'Snowdrift': false,
+    "Songti SC": false,
+    "Songti SC Black": false,
+    "Songti TC": false,
+    "Source Code Pro": false,
+    'Splash': false,
+    "Standard Symbols L": false,
+    'Stencil': false,
+    "Stencil Std": false,
+    'Stephen': false,
+    "Sukhumvit Set": false,
+    'Suruma': false,
+    'Sylfaen': true,
+    'Symbol': true,
+    'Symbole': false,
+    'System': false,
+    "System Font": false,
+    'TAMu_Kadambri': false,
+    'TAMu_Kalyani': false,
+    'TAMu_Maduram': false,
+    'TSCu_Comic': false,
+    'TSCu_Paranar': false,
+    'TSCu_Times': false,
+    'Tahoma': true,
+    "Tahoma Negreta": false,
+    'TakaoExGothic': false,
+    'TakaoExMincho': false,
+    'TakaoGothic': false,
+    'TakaoMincho': false,
+    'TakaoPGothic': false,
+    'TakaoPMincho': false,
+    "Tamil MN": false,
+    "Tamil MN Bold": false,
+    "Tamil Sangam MN": false,
+    "Tamil Sangam MN Bold": false,
+    'Tarzan': false,
+    "Tekton Pro": false,
+    "Tekton Pro Cond": false,
+    "Tekton Pro Ext": false,
+    "Telugu MN": false,
+    "Telugu MN Bold": false,
+    "Telugu Sangam MN": false,
+    "Telugu Sangam MN Bold": false,
+    "Tempus Sans ITC": false,
+    'Terminal': false,
+    "Terminator Two": false,
+    'Thonburi': false,
+    "Thonburi Bold": false,
+    "Tibetan Machine Uni": false,
+    'Times': true,
+    "Times Bold": false,
+    "Times New Roman": true,
+    "Times New Roman Baltic": false,
+    "Times New Roman Bold": false,
+    "Times New Roman Italic": false,
+    "Times Roman": false,
+    "Tlwg Mono": false,
+    "Tlwg Typewriter": false,
+    "Tlwg Typist": false,
+    "Tlwg Typo": false,
+    'TlwgMono': false,
+    'TlwgTypewriter': false,
+    'Toledo': false,
+    "Traditional Arabic": false,
+    "Trajan Pro": false,
+    'Trattatello': false,
+    "Trebuchet MS": true,
+    "Trebuchet MS Bold": false,
+    'Tunga': false,
+    "Tw Cen MT": false,
+    "Tw Cen MT Bold": false,
+    "Tw Cen MT Italic": false,
+    "URW Bookman L": false,
+    "URW Chancery L": false,
+    "URW Gothic L": false,
+    "URW Palladio L": false,
+    'Ubuntu': false,
+    "Ubuntu Condensed": false,
+    "Ubuntu Mono": false,
+    'Ukai': false,
+    "Ume Gothic": false,
+    "Ume Mincho": false,
+    "Ume P Gothic": false,
+    "Ume P Mincho": false,
+    "Ume UI Gothic": false,
+    'Uming': false,
+    'Umpush': false,
+    'UnBatang': false,
+    'UnDinaru': false,
+    'UnDotum': false,
+    'UnGraphic': false,
+    'UnGungseo': false,
+    'UnPilgi': false,
+    'Untitled1': false,
+    "Urdu Typesetting": false,
+    'Uroob': false,
+    'Utkal': false,
+    'Utopia': false,
+    'Utsaah': false,
+    'Valken': false,
+    'Vani': false,
+    'Vemana2000': false,
+    'Verdana': true,
+    "Verdana Bold": false,
+    'Vijaya': false,
+    "Viner Hand ITC": false,
+    'Vivaldi': false,
+    'Vivian': false,
+    "Vladimir Script": false,
+    'Vrinda': false,
+    'Waree': false,
+    'Waseem': false,
+    'Waverly': false,
+    'Webdings': true,
+    "WenQuanYi Bitmap Song": false,
+    "WenQuanYi Micro Hei": false,
+    "WenQuanYi Micro Hei Mono": false,
+    "WenQuanYi Zen Hei": false,
+    "Whimsy TT": false,
+    "Wide Latin": false,
+    'Wingdings': true,
+    "Wingdings 2": false,
+    "Wingdings 3": false,
+    'Woodcut': false,
+    'X-Files': false,
+    "Year supply of fairy cakes": false,
+    "Yu Gothic": true,
+    "Yu Mincho": false,
+    "Yuppy SC": false,
+    "Yuppy SC Regular": false,
+    "Yuppy TC": false,
+    "Yuppy TC Regular": false,
+    "Zapf Dingbats": false,
+    'Zapfino': false,
+    'Zawgyi-One': false,
+    'gargi': false,
+    'lklug': false,
+    'mry_KacstQurn': false,
+    'ori1Uni': false
+  });
+  const a0_0x478bd5 = () => {
+    try {
+      const _0x4ab3f2 = window.OfflineAudioContext || window.webkitOfflineAudioContext;
+      if (!_0x4ab3f2) {
+        return -2;
+      }
+      const _0x41ef0d = new _0x4ab3f2(1, 5000, 44100);
+      const _0x346aba = _0x41ef0d.createOscillator();
+      _0x346aba.type = "triangle";
+      _0x346aba.frequency.value = 10000;
+      const _0x47974a = _0x41ef0d.createDynamicsCompressor();
+      _0x47974a.threshold.value = -50;
+      _0x47974a.knee.value = 40;
+      _0x47974a.ratio.value = 12;
+      _0x47974a.attack.value = 0;
+      _0x47974a.release.value = 0.25;
+      _0x346aba.connect(_0x47974a);
+      _0x47974a.connect(_0x41ef0d.destination);
+      _0x346aba.start(0);
+      const [_0x2703df, _0x93f29f] = a0_0x5dd036(_0x41ef0d);
+      const _0x55e006 = _0x2703df.then((_0x13e625) => a0_0x2d1f13(_0x13e625.getChannelData(0).subarray(4500)), (_0x27df73) => {
+        if (_0x27df73.name === "timeout" || _0x27df73.name === 'suspended') {
+          return "timeout";
+        }
+        throw _0x27df73;
+      });
+      _0x55e006['catch'](() => undefined);
+      _0x93f29f();
+      return _0x55e006;
+    } catch (_0x1cba12) {
+      return -1;
+    }
+  };
+  function a0_0x4081(_0x1b4f79, _0x82c738) {
+    _0x1b4f79 = _0x1b4f79 - 356;
+    const _0x4eaea4 = a0_0x4eae();
+    let _0x408180 = _0x4eaea4[_0x1b4f79];
+    return _0x408180;
+  }
+  function a0_0x5dd036(_0x2d842f) {
+    let _0x5659b4 = () => undefined;
+    const _0x3724ee = new Promise((_0x51b03d, _0x40424c) => {
+      let _0x566eea = false;
+      let _0x4548ca = 0;
+      let _0x4f44d4 = 0;
+      _0x2d842f.oncomplete = (_0x3efecc) => _0x51b03d(_0x3efecc.renderedBuffer);
+      const _0x2cb730 = () => {
+        setTimeout(() => _0x40424c(a0_0x26fbd7("timeout")), Math.min(500, _0x4f44d4 + 5000 - Date.now()));
+      };
+      const _0x5aee26 = () => {
+        try {
+          _0x2d842f.startRendering();
+          switch (_0x2d842f.state) {
+            case "running":
+              _0x4f44d4 = Date.now();
+              if (_0x566eea) {
+                _0x2cb730();
+              }
+              break;
+            case "suspended":
+              if (!document.hidden) {
+                _0x4548ca++;
+              }
+              if (_0x566eea && _0x4548ca >= 3) {
+                _0x40424c(a0_0x26fbd7("suspended"));
+              } else {
+                setTimeout(_0x5aee26, 500);
+              }
+              break;
+          }
+        } catch (_0x5ae754) {
+          _0x40424c(_0x5ae754);
+        }
+      };
+      _0x5aee26();
+      _0x5659b4 = () => {
+        if (!_0x566eea) {
+          _0x566eea = true;
+          if (_0x4f44d4 > 0) {
+            _0x2cb730();
+          }
+        }
+      };
+    });
+    return [_0x3724ee, _0x5659b4];
+  }
+  function a0_0x2d1f13(_0x1bfaaa) {
+    let _0x18331c = 0;
+    for (let _0x5e37ee = 0; _0x5e37ee < _0x1bfaaa.length; ++_0x5e37ee) {
+      _0x18331c += Math.abs(_0x1bfaaa[_0x5e37ee]);
+    }
+    return _0x18331c;
+  }
+  function a0_0x26fbd7(_0xcf80b3) {
+    const _0x4d1550 = new Error(_0xcf80b3);
+    _0x4d1550.name = _0xcf80b3;
+    return _0x4d1550;
+  }
+  const a0_0x458a71 = () => {
+    try {
+      const _0x2f3943 = [{
+        's': "Windows 10",
+        'r': /(Windows 10.0|Windows NT 10.0)/
+      }, {
+        's': "Windows 8.1",
+        'r': /(Windows 8.1|Windows NT 6.3)/
+      }, {
+        's': "Windows 8",
+        'r': /(Windows 8|Windows NT 6.2)/
+      }, {
+        's': "Windows 7",
+        'r': /(Windows 7|Windows NT 6.1)/
+      }, {
+        's': "Windows Vista",
+        'r': /Windows NT 6.0/
+      }, {
+        's': "Windows Server 2003",
+        'r': /Windows NT 5.2/
+      }, {
+        's': "Windows XP",
+        'r': /(Windows NT 5.1|Windows XP)/
+      }, {
+        's': "Windows 2000",
+        'r': /(Windows NT 5.0|Windows 2000)/
+      }, {
+        's': "Windows ME",
+        'r': /(Win 9x 4.90|Windows ME)/
+      }, {
+        's': "Windows 98",
+        'r': /(Windows 98|Win98)/
+      }, {
+        's': "Windows 95",
+        'r': /(Windows 95|Win95|Windows_95)/
+      }, {
+        's': "Windows NT 4.0",
+        'r': /(Windows NT 4.0|WinNT4.0|WinNT|Windows NT)/
+      }, {
+        's': "Windows CE",
+        'r': /Windows CE/
+      }, {
+        's': "Windows 3.11",
+        'r': /Win16/
+      }, {
+        's': "Android",
+        'r': /Android/
+      }, {
+        's': "Open BSD",
+        'r': /OpenBSD/
+      }, {
+        's': "Sun OS",
+        'r': /SunOS/
+      }, {
+        's': "Chrome OS",
+        'r': /CrOS/
+      }, {
+        's': "Linux",
+        'r': /(Linux|X11(?!.*CrOS))/
+      }, {
+        's': "iOS",
+        'r': /(iPhone|iPad|iPod)/
+      }, {
+        's': "Mac OS X",
+        'r': /Mac OS X/
+      }, {
+        's': "Mac OS",
+        'r': /(Mac OS|MacPPC|MacIntel|Mac_PowerPC|Macintosh)/
+      }, {
+        's': "QNX",
+        'r': /QNX/
+      }, {
+        's': 'UNIX',
+        'r': /UNIX/
+      }, {
+        's': "BeOS",
+        'r': /BeOS/
+      }, {
+        's': "OS/2",
+        'r': /OS\/2/
+      }, {
+        's': "Search Bot",
+        'r': /(nuhk|Googlebot|Yammybot|Openbot|Slurp|MSNBot|Ask Jeeves\/Teoma|ia_archiver)/
+      }];
+      let _0x1c078c;
+      let _0x54ebe0 = _0x2f3943.filter((_0x1cf863) => _0x1cf863.r.test(navigator.userAgent))[0].s;
+      if (/Windows/.test(_0x54ebe0)) {
+        _0x1c078c = /Windows (.*)/.exec(_0x54ebe0)[1];
+        _0x54ebe0 = "Windows";
+      }
+      switch (_0x54ebe0) {
+        case "Mac OS":
+        case "Mac OS X":
+        case "Android":
+          _0x1c078c = /(?:Android|Mac OS|Mac OS X|MacPPC|MacIntel|Mac_PowerPC|Macintosh) ([._\d]+)/.exec(navigator.userAgent)[1];
+          break;
+        case "iOS":
+          _0x1c078c = /OS (\d+)_(\d+)_?(\d+)?/.exec(navigator.appVersion);
+          _0x1c078c = _0x1c078c[1] + '.' + _0x1c078c[2] + '.' + (_0x1c078c[3] | 0);
+          break;
+      }
+      return {
+        'name': _0x54ebe0,
+        'version': _0x1c078c
+      };
+    } catch (_0xb888d1) {
+      return {
+        'name': "Unknown",
+        'version': "Unknown"
+      };
+    }
+  };
+  const a0_0x1f5f95 = () => {
+    try {
+      const _0x232318 = navigator.userAgent;
+      const _0x4b6ccf = [{
+        'name': "Opera",
+        'getInfo': (_0x94ab38) => {
+          if (_0x232318.indexOf("Version") !== -1) {
+            return {
+              'name': "Opera",
+              'version': _0x232318.substring(_0x94ab38 + 8)
+            };
+          }
+          return {
+            'name': "Opera",
+            'version': _0x232318.substring(_0x94ab38 + 6)
+          };
+        }
+      }, {
+        'name': "OPR",
+        'getInfo': (_0x52cfae) => {
+          return {
+            'name': "Opera",
+            'version': _0x232318.substring(_0x52cfae + 4)
+          };
+        }
+      }, {
+        'name': "Edge",
+        'getInfo': (_0x3c4d54) => {
+          return {
+            'name': "Edge",
+            'version': _0x232318.substring(_0x3c4d54 + 5)
+          };
+        }
+      }, {
+        'name': "Edg",
+        'getInfo': (_0x4675f2) => {
+          return {
+            'name': "Edge",
+            'version': _0x232318.substring(_0x4675f2 + 4)
+          };
+        }
+      }, {
+        'name': "MSIE",
+        'getInfo': (_0x16618e) => {
+          return {
+            'name': "Internet Explorer",
+            'version': _0x232318.substring(_0x16618e + 5)
+          };
+        }
+      }, {
+        'name': 'Chrome',
+        'getInfo': (_0x4074b0) => {
+          return {
+            'name': 'Chrome',
+            'version': _0x232318.substring(_0x4074b0 + 7)
+          };
+        }
+      }, {
+        'name': "Safari",
+        'getInfo': (_0x668941) => {
+          const _0x1f7774 = _0x232318.indexOf("Version");
+          if (_0x1f7774 !== -1) {
+            return {
+              'name': "Safari",
+              'version': _0x232318.substring(_0x668941 + 8)
+            };
+          }
+          return {
+            'name': 'Safari',
+            'version': _0x232318.substring(_0x668941 + 7)
+          };
+        }
+      }, {
+        'name': "Firefox",
+        'getInfo': (_0x5e6920) => {
+          return {
+            'name': "Firefox",
+            'version': _0x232318.substring(_0x5e6920 + 8)
+          };
+        }
+      }, {
+        'name': "Trident/",
+        'getInfo': () => {
+          return {
+            'name': "Internet Explorer",
+            'version': _0x232318.substring(_0x232318.indexOf("rv:") + 3)
+          };
+        }
+      }];
+      return _0x4b6ccf.filter(({
+        name: _0x374a0b
+      }) => _0x232318.indexOf(_0x374a0b) !== -1).map(({
+        getInfo: _0x128979,
+        name: _0x57a2fc
+      }) => _0x128979(_0x232318.indexOf(_0x57a2fc)))[0];
+    } catch (_0x1ad3e1) {
+      return {
+        'name': "Unknown",
+        'version': 'Unknown'
+      };
+    }
+  };
+  const a0_0x3d703d = () => {
+    try {
+      const _0x5571bf = document.createElement("canvas");
+      const _0x3e66f3 = _0x5571bf.getContext('2d');
+      const _0xeadc0d = "i9asdm..$#po((^@KbXrww!~cz";
+      _0x3e66f3.textBaseline = "top";
+      _0x3e66f3.font = "16px 'Arial'";
+      _0x3e66f3.textBaseline = "alphabetic";
+      _0x3e66f3.rotate(0.05);
+      _0x3e66f3.fillStyle = "#f60";
+      _0x3e66f3.fillRect(125, 1, 62, 20);
+      _0x3e66f3.fillStyle = "#069";
+      _0x3e66f3.fillText(_0xeadc0d, 2, 15);
+      _0x3e66f3.fillStyle = "rgba(102, 200, 0, 0.7)";
+      _0x3e66f3.fillText(_0xeadc0d, 4, 17);
+      _0x3e66f3.shadowBlur = 10;
+      _0x3e66f3.shadowColor = "blue";
+      _0x3e66f3.fillRect(-20, 10, 234, 5);
+      const _0x48a096 = _0x5571bf.toDataURL();
+      let _0x27a7fa = 0;
+      if (_0x48a096.length === 0) {
+        return "nothing!";
+      }
+      for (let _0xd6d998 = 0; _0xd6d998 < _0x48a096.length; _0xd6d998++) {
+        const _0x81f945 = _0x48a096.charCodeAt(_0xd6d998);
+        _0x27a7fa = (_0x27a7fa << 5) - _0x27a7fa + _0x81f945;
+        _0x27a7fa = _0x27a7fa & _0x27a7fa;
+      }
+      return _0x27a7fa;
+    } catch (_0x5f4b15) {
+      return -1;
+    }
+  };
+  const a0_0x21bdcc = () => {
+    try {
+      const _0x4566e9 = document.createElement("canvas");
+      _0x4566e9.width = 256;
+      _0x4566e9.height = 128;
+      const _0x1a0787 = _0x4566e9.getContext("webgl2") || _0x4566e9.getContext("experimental-webgl2") || _0x4566e9.getContext("webgl") || _0x4566e9.getContext('experimental-webgl') || _0x4566e9.getContext("moz-webgl");
+      try {
+        const _0x26cec6 = "attribute vec2 attrVertex;varying vec2 varyinTexCoordinate;uniform vec2 uniformOffset;void main(){varyinTexCoordinate=attrVertex+uniformOffset;gl_Position=vec4(attrVertex,0,1);}";
+        const _0x2b2510 = "precision mediump float;varying vec2 varyinTexCoordinate;void main() {gl_FragColor=vec4(varyinTexCoordinate,0,1);}";
+        const _0x20c0de = _0x1a0787.createBuffer();
+        _0x1a0787.bindBuffer(_0x1a0787.ARRAY_BUFFER, _0x20c0de);
+        const _0x314d22 = new Float32Array([-0.2, -0.9, 0, 0.4, -0.26, 0, 0, 0.7321, 0]);
+        _0x1a0787.bufferData(_0x1a0787.ARRAY_BUFFER, _0x314d22, _0x1a0787.STATIC_DRAW);
+        _0x20c0de.itemSize = 3;
+        _0x20c0de.numItems = 3;
+        const _0x401797 = _0x1a0787.createProgram();
+        const _0x5a558b = _0x1a0787.createShader(_0x1a0787.VERTEX_SHADER);
+        _0x1a0787.shaderSource(_0x5a558b, _0x26cec6);
+        _0x1a0787.compileShader(_0x5a558b);
+        const _0x1f9690 = _0x1a0787.createShader(_0x1a0787.FRAGMENT_SHADER);
+        _0x1a0787.shaderSource(_0x1f9690, _0x2b2510);
+        _0x1a0787.compileShader(_0x1f9690);
+        _0x1a0787.attachShader(_0x401797, _0x5a558b);
+        _0x1a0787.attachShader(_0x401797, _0x1f9690);
+        _0x1a0787.linkProgram(_0x401797);
+        _0x1a0787.useProgram(_0x401797);
+        _0x401797.vertexPosAttrib = _0x1a0787.getAttribLocation(_0x401797, "attrVertex");
+        _0x401797.offsetUniform = _0x1a0787.getUniformLocation(_0x401797, 'uniformOffset');
+        _0x1a0787.enableVertexAttribArray(_0x401797.vertexPosArray);
+        _0x1a0787.vertexAttribPointer(_0x401797.vertexPosAttrib, _0x20c0de.itemSize, _0x1a0787.FLOAT, false, 0, 0);
+        _0x1a0787.uniform2f(_0x401797.offsetUniform, 1, 1);
+        _0x1a0787.drawArrays(_0x1a0787.TRIANGLE_STRIP, 0, _0x20c0de.numItems);
+      } catch (_0x2d06f6) {}
+      const _0x36de5a = new Uint8Array(131072);
+      _0x1a0787.readPixels(0, 0, 256, 128, _0x1a0787.RGBA, _0x1a0787.UNSIGNED_BYTE, _0x36de5a);
+      let _0x406419 = JSON.stringify(_0x36de5a).replace(/,?"[0-9]+":/g, '');
+      return a0_0x41c694(_0x406419);
+    } catch (_0x5b02e6) {
+      return '-1';
+    }
+  };
+  const a0_0x41c694 = function () {
+    let _0x5637ca = 1;
+    let _0x38104d;
+    let _0x167dbc = [];
+    let _0x48f4c9 = [];
+    while (++_0x5637ca < 18) {
+      for (_0x38104d = _0x5637ca * _0x5637ca; _0x38104d < 312; _0x38104d += _0x5637ca) {
+        _0x167dbc[_0x38104d] = 1;
+      }
+    }
+    _0x5637ca = 1;
+    for (_0x38104d = 0; _0x5637ca < 313;) {
+      if (!_0x167dbc[++_0x5637ca]) {
+        _0x48f4c9[_0x38104d] = Math.pow(_0x5637ca, 0.5) % 1 * 0x100000000 | 0;
+        _0x167dbc[_0x38104d++] = Math.pow(_0x5637ca, 0.3333333333333333) % 1 * 0x100000000 | 0;
+      }
+    }
+    function _0x4e2c29(_0x4dc31c) {
+      let _0x577c57 = _0x48f4c9.slice(_0x5637ca = 0);
+      let _0x112237 = unescape(encodeURI(_0x4dc31c));
+      let _0x154596 = [];
+      let _0x5cd821 = _0x112237.length;
+      let _0x41e6fc = [];
+      let _0x11060f;
+      let _0x139ca4;
+      let _0x55e242;
+      for (; _0x5637ca < _0x5cd821;) {
+        _0x41e6fc[_0x5637ca >> 2] |= (_0x112237.charCodeAt(_0x5637ca) & 255) << 8 * (3 - _0x5637ca++ % 4);
+      }
+      _0x5cd821 *= 8;
+      _0x41e6fc[_0x5cd821 >> 5] |= 128 << 24 - _0x5cd821 % 32;
+      _0x41e6fc[_0x55e242 = _0x5cd821 + 64 >> 5 | 15] = _0x5cd821;
+      for (_0x5637ca = 0; _0x5637ca < _0x55e242; _0x5637ca += 16) {
+        _0x11060f = _0x577c57.slice(_0x38104d = 0, 8);
+        for (; _0x38104d < 64; _0x11060f[4] += _0x139ca4) {
+          if (_0x38104d < 16) {
+            _0x154596[_0x38104d] = _0x41e6fc[_0x38104d + _0x5637ca];
+          } else {
+            _0x154596[_0x38104d] = (((_0x139ca4 = _0x154596[_0x38104d - 2]) >>> 17 | (_0x139ca4 = _0x154596[_0x38104d - 2]) << 15) ^ (_0x139ca4 >>> 19 | _0x139ca4 << 13) ^ _0x139ca4 >>> 10) + (_0x154596[_0x38104d - 7] | 0) + (((_0x139ca4 = _0x154596[_0x38104d - 15]) >>> 7 | (_0x139ca4 = _0x154596[_0x38104d - 15]) << 25) ^ (_0x139ca4 >>> 18 | _0x139ca4 << 14) ^ _0x139ca4 >>> 3) + (_0x154596[_0x38104d - 16] | 0);
+          }
+          _0x11060f.unshift((_0x139ca4 = (_0x11060f.pop() + (((_0x4dc31c = _0x11060f[4]) >>> 6 | (_0x4dc31c = _0x11060f[4]) << 26) ^ (_0x4dc31c >>> 11 | _0x4dc31c << 21) ^ (_0x4dc31c >>> 25 | _0x4dc31c << 7)) + ((_0x4dc31c & _0x11060f[5] ^ ~_0x4dc31c & _0x11060f[6]) + _0x167dbc[_0x38104d]) | 0) + (_0x154596[_0x38104d++] | 0)) + (((_0x5cd821 = _0x11060f[0]) >>> 2 | (_0x5cd821 = _0x11060f[0]) << 30) ^ (_0x5cd821 >>> 13 | _0x5cd821 << 19) ^ (_0x5cd821 >>> 22 | _0x5cd821 << 10)) + (_0x5cd821 & _0x11060f[1] ^ _0x11060f[1] & _0x11060f[2] ^ _0x11060f[2] & _0x5cd821));
+        }
+        for (_0x38104d = 8; _0x38104d--;) {
+          _0x577c57[_0x38104d] = _0x11060f[_0x38104d] + _0x577c57[_0x38104d];
+        }
+      }
+      for (_0x112237 = ''; _0x38104d < 63;) {
+        _0x112237 += (_0x577c57[++_0x38104d >> 3] >> 4 * (7 - _0x38104d % 8) & 15).toString(16);
+      }
+      return _0x112237;
+    }
+    return _0x4e2c29;
+  }();
+  const a0_0x3cec7b = () => new Promise(async (_0x181283) => {
+    let _0x4066ae = setTimeout(() => _0x181283([]), 200);
+    const _0x35dfbd = await navigator.mediaDevices.enumerateDevices();
+    clearTimeout(_0x4066ae);
+    let _0x48e36c = _0x35dfbd.map((_0x5477be) => _0x5477be.kind).sort();
+    _0x181283(_0x48e36c);
+  })["catch"]((_0x1d8b60) => []);
+  const a0_0x6bb321 = () => {
+    const _0xe32672 = ["audio/aac", 'audio/flac', "audio/mpeg", "audio/mp4; codecs=\"mp4a.40.2\"", "audio/ogg; codecs=\"flac\"", "audio/ogg; codecs=\"vorbis\"", "audio/ogg; codecs=\"opus\"", "audio/wav; codecs=\"1\"", "audio/webm; codecs=\"vorbis\"", "audio/webm; codecs=\"opus\""];
+    try {
+      const _0x25b069 = document.createElement("audio");
+      return _0xe32672.map((_0x510a32) => {
+        return {
+          'type': _0x510a32,
+          'canPlay': _0x25b069.canPlayType(_0x510a32)
+        };
+      });
+    } catch (_0x17d5ba) {
+      return _0xe32672.map((_0x1f0c43) => {
+        return {
+          'type': _0x1f0c43,
+          'canPlay': "no info"
+        };
+      });
+    }
+  };
+  const a0_0x184563 = () => {
+    const _0x4b9fac = ["video/ogg; codecs=\"theora\"", "video/ogg; codecs=\"opus\"", "video/mp4; codecs=\"avc1.42E01E\"", "video/mp4; codecs=\"flac\"", "video/webm; codecs=\"vp8, vorbis\"", "video/webm; codecs=\"vp9\"", "application/x-mpegURL; codecs=\"avc1.42E01E\""];
+    try {
+      const _0x292089 = document.createElement("video");
+      return _0x4b9fac.map((_0x2810d3) => {
+        return {
+          'type': _0x2810d3,
+          'canPlay': _0x292089.canPlayType(_0x2810d3)
+        };
+      });
+    } catch (_0x1232bd) {
+      return _0x4b9fac.map((_0x410007) => {
+        return {
+          'type': _0x410007,
+          'canPlay': "no info"
+        };
+      });
+    }
+  };
+  const a0_0x4938ec = async () => {
+    try {
+      const _0x9d122 = ["accelerometer", "camera", "clipboard-read", "clipboard-write", "geolocation", "background-sync", "magnetometer", "microphone", "midi", 'notifications', 'payment-handler', "persistent-storage"];
+      const _0x22f907 = {};
+      await Promise.all(_0x9d122.map(async (_0x43c03b) => {
+        try {
+          const {
+            state: _0x9c6f95
+          } = await navigator.permissions.query({
+            'name': _0x43c03b
+          });
+          _0x22f907[_0x43c03b] = _0x9c6f95;
+        } catch (_0xeaf5bb) {}
+      }));
+      return _0x22f907;
+    } catch (_0x46d6dc) {
+      return {};
+    }
+  };
+  const a0_0x7c3c35 = () => {
+    try {
+      const _0x46acee = document.createElement("canvas");
+      const _0x305b36 = _0x46acee.getContext("webgl") || _0x46acee.getContext("experimental-webgl");
+      const _0x7e84a8 = _0x305b36.getExtension("WEBGL_debug_renderer_info");
+      return {
+        'vendor': _0x305b36.getParameter(_0x7e84a8.UNMASKED_VENDOR_WEBGL),
+        'renderer': _0x305b36.getParameter(_0x7e84a8.UNMASKED_RENDERER_WEBGL),
+        'extensions': _0x305b36.getSupportedExtensions()
+      };
+    } catch (_0x5df0a1) {
+      return {
+        'vendor': "Unknown",
+        'renderer': "Unknown",
+        'extensions': []
+      };
+    }
+  };
+  const a0_0x2f1071 = () => {
+    try {
+      const _0xe4d96 = new AudioContext();
+      return {
+        'state': _0xe4d96.state,
+        'sampleRate': _0xe4d96.sampleRate,
+        'channelCount': _0xe4d96.destination.channelCount,
+        'channelCountMode': _0xe4d96.destination.channelCountMode,
+        'channelInterpretation': _0xe4d96.destination.channelInterpretation,
+        'maxChannelCount': _0xe4d96.destination.maxChannelCount,
+        'numberOfInputs': _0xe4d96.destination.numberOfInputs,
+        'numberOfOutputs': _0xe4d96.destination.numberOfOutputs
+      };
+    } catch (_0x135683) {
+      return {};
+    }
+  };
+  const a0_0x28f00c = () => {
+    const _0x1a75a5 = document.getElementsByTagName("body")[0];
+    const _0x58b268 = document.createElement("div");
+    let _0x119490 = document.createDocumentFragment();
+    const _0x3a0372 = ["monospace", "sans-serif", "serif"];
+    const _0x7d2c98 = {
+      'monospace': {},
+      'sans-serif': {},
+      'serif': {}
+    };
+    const _0x595a22 = "fp-check-runtime-0.0.1";
+    const _0x1f049a = "fp-div-check-runtime-0.0.1";
+    const _0x1d5bf4 = {};
+    const _0x2ee6f0 = {};
+    _0x58b268.id = _0x1f049a;
+    _0x1a75a5.appendChild(_0x58b268);
+    _0x3a0372.forEach((_0x125579, _0x482858) => {
+      const _0x5b1672 = document.createElement("span");
+      _0x5b1672.style.fontSize = "72px";
+      _0x5b1672.innerHTML = "mmmmmmmmmmlli";
+      _0x5b1672.style.fontFamily = _0x3a0372[_0x482858];
+      _0x5b1672.style.position = "fixed";
+      _0x5b1672.style.visibility = 'hidden';
+      _0x5b1672.classList.add(_0x595a22);
+      _0x119490.appendChild(_0x5b1672);
+    });
+    a0_0x1a8751.forEach((_0x412705) => {
+      _0x3a0372.forEach((_0x224980) => {
+        const _0x43b55b = document.createElement("span");
+        _0x43b55b.style.fontSize = '72px';
+        _0x43b55b.innerHTML = "mmmmmmmmmmlli";
+        _0x43b55b.style.fontFamily = _0x412705 + ',' + _0x224980;
+        _0x43b55b.style.position = "fixed";
+        _0x43b55b.style.visibility = "hidden";
+        _0x43b55b.id = _0x412705 + '&' + _0x224980;
+        _0x43b55b.classList.add(_0x595a22);
+        _0x119490.appendChild(_0x43b55b);
+      });
+    });
+    _0x58b268.appendChild(_0x119490);
+    const _0x32fcce = _0x58b268.children;
+    _0x3a0372.forEach((_0x38667b, _0x430aae) => {
+      _0x1d5bf4[_0x3a0372[_0x430aae]] = _0x32fcce[_0x430aae].offsetWidth;
+      _0x2ee6f0[_0x3a0372[_0x430aae]] = _0x32fcce[_0x430aae].offsetHeight;
+    });
+    for (let _0xffc768 = 0; _0xffc768 < _0x32fcce.length; _0xffc768++) {
+      const [_0xb9811f, _0x3da754] = _0x32fcce[_0xffc768].id.split('&');
+      if (_0x3da754) {
+        _0x7d2c98[_0x3da754][_0xb9811f] = _0x32fcce[_0xffc768];
+      }
+    }
+    const _0x1d1365 = [];
+    for (let _0x5ec410 = 0; _0x5ec410 < a0_0x1a8751.length; _0x5ec410++) {
+      for (let _0x14687f = 0; _0x14687f < _0x3a0372.length; _0x14687f++) {
+        let _0x47353f = false;
+        let _0x4b16f1 = _0x7d2c98[_0x3a0372[_0x14687f]][a0_0x1a8751[_0x5ec410]];
+        const _0x5f4ed0 = _0x4b16f1.offsetWidth !== _0x1d5bf4[_0x3a0372[_0x14687f]] || _0x4b16f1.offsetHeight !== _0x2ee6f0[_0x3a0372[_0x14687f]];
+        _0x47353f = _0x47353f || _0x5f4ed0;
+        if (_0x47353f) {
+          _0x1d1365.push(a0_0x1a8751[_0x5ec410]);
+          break;
+        }
+      }
+    }
+    document.getElementById(_0x1f049a).remove();
+    return _0x1d1365;
+  };
+  const a0_0x487f36 = () => {
+    try {
+      const _0x457f89 = [];
+      for (let _0x15890d = 0; _0x15890d < navigator.plugins.length; _0x15890d++) {
+        _0x457f89.push(navigator.plugins[_0x15890d].name);
+      }
+      return _0x457f89;
+    } catch (_0x44f5fb) {
+      return [];
+    }
+  };
+  const a0_0x338f77 = () => {
+    let _0x16dbda = 0;
+    try {
+      if (navigator.webdriver === true) {
+        _0x16dbda |= 1;
+      }
+      if (!window.chrome && !/Firefox/.test(navigator.userAgent) && /Chrome/.test(navigator.userAgent)) {
+        _0x16dbda |= 2;
+      }
+      try {
+        if (navigator.permissions) {
+          const _0x4a2cad = Notification.permission;
+          if (_0x4a2cad === "denied" && !document.hidden) {
+            _0x16dbda |= 4;
+          }
+        }
+      } catch (_0x15a518) {}
+      if (window.cdc_adoQpoasnfa76pfcZLmcfl_Array || window.cdc_adoQpoasnfa76pfcZLmcfl_Promise || window.cdc_adoQpoasnfa76pfcZLmcfl_Symbol || document.documentElement.getAttribute('cdc_adoQpoasnfa76pfcZLmcfl_')) {
+        _0x16dbda |= 8;
+      }
+      if (window.callPhantom || window._phantom || window.phantom) {
+        _0x16dbda |= 16;
+      }
+      if (window.$cdc_asdjflasutopfhvcZLmcfl_ || window.$wdc_ || window.__webdriver_script_fn || document.$cdc_asdjflasutopfhvcZLmcfl_ || document.__webdriver_evaluate || document.__selenium_evaluate || document.__webdriver_script_function || document.__webdriver_script_func || document.__webdriver_script_fn || document.__fxdriver_evaluate || document.__driver_unwrapped || document.__webdriver_unwrapped || document.__driver_evaluate || document.__selenium_unwrapped || document.__fxdriver_unwrapped) {
+        _0x16dbda |= 32;
+      }
+      if (navigator.webdriver || window.__puppeteer_evaluation_script__ || window.domAutomation || window.domAutomationController) {
+        _0x16dbda |= 64;
+      }
+      if (window.__playwright || window.__pw_manual || window.__PW_inspect) {
+        _0x16dbda |= 128;
+      }
+      if (document.hidden && document.visibilityState === "hidden") {
+        _0x16dbda |= 256;
+      }
+      if (window.outerWidth === 0 || window.outerHeight === 0) {
+        _0x16dbda |= 512;
+      }
+      if (/HeadlessChrome/.test(navigator.userAgent)) {
+        _0x16dbda |= 1024;
+      }
+      if (!navigator.languages || navigator.languages.length === 0) {
+        _0x16dbda |= 2048;
+      }
+      try {
+        const _0x782930 = navigator.connection || navigator.mozConnection || navigator.webkitConnection;
+        if (_0x782930 && _0x782930.type === 'none' && !_0x782930.effectiveType) {
+          _0x16dbda |= 4096;
+        }
+      } catch (_0x476f7b) {}
+      try {
+        const _0x44213a = navigator.plugins;
+        if (_0x44213a.length === 0 && /Chrome/.test(navigator.userAgent)) {
+          _0x16dbda |= 8192;
+        }
+        if (_0x44213a.length > 0 && !(_0x44213a[0] instanceof Plugin)) {
+          _0x16dbda |= 8192;
+        }
+      } catch (_0x46b1d5) {}
+      try {
+        if (Notification.permission === "denied" && !localStorage.getItem('notification_prompted')) {
+          _0x16dbda |= 16384;
+        }
+      } catch (_0x80a043) {}
+      try {
+        const _0x5f30c1 = new Error().stack;
+        if (_0x5f30c1 && (_0x5f30c1.includes("puppeteer") || _0x5f30c1.includes("playwright") || _0x5f30c1.includes("selenium") || _0x5f30c1.includes("webdriver"))) {
+          _0x16dbda |= 32768;
+        }
+      } catch (_0xdf3408) {}
+      if (typeof qt !== "undefined" || typeof QWebChannel !== 'undefined' || window.qt && window.qt.webChannelTransport || typeof callbackHandler !== "undefined") {
+        _0x16dbda |= 65536;
+      }
+      try {
+        const _0x5e25c1 = !!window.chrome;
+        const _0xed0290 = !!(window.chrome && window.chrome.runtime);
+        const _0x12c952 = !!(window.chrome && window.chrome.loadTimes);
+        const _0x4ed1f1 = !!(window.chrome && window.chrome.csi);
+        if (_0x5e25c1 && !_0xed0290 && !_0x12c952 && !_0x4ed1f1) {
+          _0x16dbda |= 131072;
+        }
+        if (!_0x5e25c1 && /Chrome/.test(navigator.userAgent) && !/Chromium/.test(navigator.userAgent)) {
+          _0x16dbda |= 131072;
+        }
+      } catch (_0x463898) {}
+    } catch (_0x47f0ea) {
+      return -1;
+    }
+    return _0x16dbda;
+  };
+  const a0_0x4ab8a9 = (_0x1394ba) => {
+    return new Array(_0x1394ba).fill(0).map(() => Math.random().toString(36).substr(2, 9)).reduce((_0x1c56b2, _0x4de8c6) => _0x1c56b2 + _0x4de8c6, '');
+  };
+  const a0_0x1874d0 = async () => {
+    const _0x53b35a = await Promise.all([a0_0x4938ec(), a0_0x3cec7b(), a0_0x478bd5()]);
+    const _0x581e12 = a0_0x1f5f95();
+    const _0x37547e = a0_0x458a71();
+    const _0x2e1dd8 = a0_0x7c3c35();
+    const _0x22c36c = a0_0x41c694(JSON.stringify(a0_0x28f00c()));
+    const _0x61bd34 = a0_0x21bdcc();
+    const _0x18d1ea = a0_0x3d703d();
+    return {
+      'dg': 12,
+      'dO4': Intl.DateTimeFormat().resolvedOptions().timeZone,
+      'b-I2rx-E': _0x37547e.name,
+      'YdFB': _0x581e12.name,
+      'dttJrRyO': navigator.vendor,
+      'bdI_': navigator.deviceMemory || 0,
+      'Y9JA': navigator.hardwareConcurrency || 0,
+      'bM07og': navigator.languages.join(','),
+      'cNxRuCGPAg': a0_0x41c694(JSON.stringify(a0_0x487f36())),
+      'Z9dM': _0x2e1dd8.vendor + ',' + _0x2e1dd8.renderer,
+      'ZtVDtyo': _0x22c36c,
+      'YdY6oxJV': a0_0x41c694(JSON.stringify(a0_0x2f1071())),
+      'b-I4nQ-C61rI': _0x37547e.version,
+      'd-BEuCA': window.screen.availWidth,
+      'aM02nQV5': window.screen.availHeight,
+      'bL8zohR5': Boolean(localStorage),
+      'c8Y6qRuA': Boolean(sessionStorage),
+      'dt9DqBc': a0_0x41c694(JSON.stringify(a0_0x184563())),
+      'YdY6oxI': a0_0x41c694(JSON.stringify(a0_0x6bb321())),
+      'bdI2nwA': a0_0x41c694(JSON.stringify(_0x53b35a[1])),
+      'cNVHtB2QA2zbSbw': a0_0x41c694(JSON.stringify(_0x53b35a[0])),
+      'YdY6oxJYqA': _0x53b35a[2],
+      'd9w-pRFXpw': _0x61bd34,
+      'Y8QyqAl8whI': _0x18d1ea,
+      'YtFF': a0_0x338f77()
+    };
+  };
+  function a0_0x5d8cc5(_0x41764b) {
+    let _0x311489 = [];
+    a0_0x2777c2.forEach((_0x110355) => {
+      _0x311489.push(_0x41764b[_0x110355]);
+      delete _0x41764b[_0x110355];
+    });
+    return _0x311489;
+  }
+  function a0_0x348f4b(_0x3a8de5) {
+    const _0x38ff7a = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_='.split('');
+    const _0x32d470 = function (_0x81c9d7) {
+      let _0x5c76bc = '';
+      const _0x2d112d = _0x81c9d7.length % 3;
+      for (let _0x4b603b = 0; _0x4b603b < _0x81c9d7.length;) {
+        const _0x2cb402 = _0x81c9d7.charCodeAt(_0x4b603b++);
+        const _0x90cf70 = _0x81c9d7.charCodeAt(_0x4b603b++);
+        const _0x982383 = _0x81c9d7.charCodeAt(_0x4b603b++);
+        if (_0x2cb402 > 255 || _0x90cf70 > 255 || _0x982383 > 255) {
+          throw new Error("Input not valid");
+        }
+        const _0x325275 = _0x2cb402 << 16 | _0x90cf70 << 8 | _0x982383;
+        _0x5c76bc += _0x38ff7a[_0x325275 >> 18 & 63] + _0x38ff7a[_0x325275 >> 12 & 63] + _0x38ff7a[_0x325275 >> 6 & 63] + _0x38ff7a[_0x325275 & 63];
+      }
+      return _0x2d112d > 0 ? _0x5c76bc.slice(0, _0x2d112d - 3) : _0x5c76bc;
+    };
+    _0x3a8de5 = encodeURIComponent(_0x3a8de5);
+    let _0x157ea1 = _0x3a8de5[0];
+    for (let _0x2280f2 = 1; _0x2280f2 < _0x3a8de5.length; ++_0x2280f2) {
+      _0x157ea1 += String.fromCharCode((_0x157ea1.charCodeAt(_0x2280f2 - 1) + _0x3a8de5.charCodeAt(_0x2280f2)) % 256);
+    }
+    return _0x32d470(_0x157ea1);
+  }
+  function a0_0x4eae() {
+    const _0x5e34cc = ['FRAGMENT_SHADER', 'Edge', "Windows 8", 'getContext', 'timeZone', 'geolocation', 'UNMASKED_VENDOR_WEBGL', 'createDocumentFragment', 'replace', '__webdriver_script_fn', 'Safari', "video/ogg; codecs=\"theora\"", '32mSetex', 'includes', 'x-vec', 'hardwareConcurrency', 'OS/2', 'background-sync', "Windows NT 4.0", 'depTtw', "Windows 2000", 'setItem', "video/mp4; codecs=\"avc1.42E01E\"", 'Version', 'innerHTML', '$cdc_asdjflasutopfhvcZLmcfl_', 'type', 'pow', 'channelCount', 'running', "audio/ogg; codecs=\"flac\"", 'exec', 'height', 'phantom', 'documentElement', 'TRIANGLE_STRIP', 'availWidth', 'availHeight', 'clipboard-read', 'linkProgram', 'enumerateDevices', 'sampleRate', '#069', 'b-I4nQ-C61rI', "Mac OS X", 'monospace', 'nothing!', '__selenium_unwrapped', 'readPixels', 'runtime', 'send', 'getParameter', 'map', 'blue', 'selenium', 'all', 'b-I2rx-E', "Windows 3.11", 'accelerometer', "Sun OS", 'uniform2f', 'triangle', '__pw_manual', 'compileShader', 'domAutomationController', 'audio/mpeg', 'visibility', 'fp-check-runtime-0.0.1', 'callPhantom', 'dts-siGT', 'position', 'visibilityState', 'audio', "Windows Server 2003", 'd9w-pRFXpw', 'effectiveType', 'd-BEuCA', 'setDate', '161OqHMek', 'webChannelTransport', 'name', 'width', '__playwright', 'vertexPosArray', 'canPlayType', 'persistent-storage', 'microphone', 'mmmmmmmmmmlli', 'forEach', "Windows 10", '177141fbCXZE', '3044125mIDXVj', 'renderer', 'toDataURL', 'experimental-webgl2', 'screen', 'fixed', 'stack', 'Edg', 'Opera', 'undefined', 'value', "video/mp4; codecs=\"flac\"", 'fill', "Windows 7", '__webdriver_script_func', 'version', 'sans-serif', 'webgl', 'offsetUniform', 'kind', 'rotate', 'oncomplete', '__driver_evaluate', 'UNSIGNED_BYTE', '72px', 'playwright', 'getTime', 'RGBA', 'dehNvwBnzDqu', '10347540ZDfjxK', "Windows CE", '_phantom', '__puppeteer_evaluation_script__', '22164VWRBfD', 'getUniformLocation', 'toISOString', '__PW_inspect', 'chrome', 'UNMASKED_RENDERER_WEBGL', 'Firefox', 'random', 'createProgram', '9yXWcvh', 'fillRect', 'div', 'itemSize', 'push', 'split', '23993vmPunn', "application/x-mpegURL; codecs=\"avc1.42E01E\"", "video/webm; codecs=\"vp9\"", 'vertexPosAttrib', 'WEBGL_debug_renderer_info', "audio/mp4; codecs=\"mp4a.40.2\"", 'video', 'bdI2nwA', "rgba(102, 200, 0, 0.7)", 'floor', 'languages', 'connection', '34LVSDEx', 'BeOS', 'toString', '40FwNPzp', "Mac OS", 'bufferData', 'dO4', "Chrome OS", 'cdc_adoQpoasnfa76pfcZLmcfl_Symbol', 'webdriver', 'span', 'Z9dM', 'DateTimeFormat', 'YdY6oxJV', 'timeout', 'getExtension', 'audio/aac', 'destination', 'suspended', 'Y9U6mw9451U', "Windows 95", 'fillText', 'lastIndexOf', 'substr', 'STATIC_DRAW', 'body', 'fp-div-check-runtime-0.0.1', 'OPR', 'mediaDevices', 'status', 'pop', "16px 'Arial'", 'length', "video/ogg; codecs=\"opus\"", 'bdI_', '__webdriver_evaluate', 'font', 'Unknown', 'then', 'Y9JA', 'Android', 'x-game', 'cdc_adoQpoasnfa76pfcZLmcfl_Promise', 'puppeteer', 'onreadystatechange', "no info", 'canvas', 'moz-webgl', 'csi', '1555192htzkTS', 'midi', 'experimental-webgl', 'shadowBlur', 'bindBuffer', 'classList', 'join', 'indexOf', 'https://gameforge.com/tra/game1.js', '$wdc_', 'i9asdm..$#po((^@KbXrww!~cz', 'ZtVDtyo', 'textBaseline', 'webkitOfflineAudioContext', 'dt9DqBc', 'btoa', 'YtFF', 'readyState', 'style', 'fromCharCode', 'denied', 'unshift', 'offsetHeight', '#f60', 'stringify', 'startRendering', 'magnetometer', 'getItem', 'Y8QyqAl8whI', 'iOS', 'getAttribLocation', 'camera', 'cdc_adoQpoasnfa76pfcZLmcfl_Array', 'start', 'resolvedOptions', 'YdFB', "precision mediump float;varying vec2 varyinTexCoordinate;void main() {gl_FragColor=vec4(varyinTexCoordinate,0,1);}", 'Linux', "attribute vec2 attrVertex;varying vec2 varyinTexCoordinate;uniform vec2 uniformOffset;void main(){varyinTexCoordinate=attrVertex+uniformOffset;gl_Position=vec4(attrVertex,0,1);}", 'outerHeight', '__webdriver_script_function', 'Trident/', 'deviceMemory', 'add', 'useProgram', 'mozConnection', 'createShader', 'loadTimes', 'reduce', 'numItems', 'FLOAT', 'QNX', 'vendor', 'shaderSource', 'appVersion', '__selenium_evaluate', 'webgl2', 'ARRAY_BUFFER', 'enableVertexAttribArray', 'createElement', 'filter', 'attachShader', "Windows ME", '__fxdriver_unwrapped', 'attrVertex', 'date', 'outerWidth', '__driver_unwrapped', 'frequency', 'appendChild', 'keys', 'rv:', 'top', 'Windows', 'serif', "Internet Explorer", 'renderedBuffer', 'remove', 'connect', 'getAttribute', 'clipboard-write', 'release', 'substring', 'MSIE', 'hidden', 'ctdIvSKVCQ', 'test', "audio/wav; codecs=\"1\"", 'ratio', 'createDynamicsCompressor', 'sort', 'numberOfOutputs', "audio/ogg; codecs=\"opus\"", 'slice', 'fillStyle', 'permissions', 'cNVHtB2QA2zbSbw', 'catch', 'aM02nQV5', 'charCodeAt', '696091qoPiWL', 'fontFamily', 'createOscillator', 'GET', 'maxChannelCount', 'plugins', 'userAgent', 'alphabetic', "audio/ogg; codecs=\"vorbis\"", 'getSupportedExtensions', 'state'];
+    a0_0x4eae = function () {
+      return _0x5e34cc;
+    };
+    return a0_0x4eae();
+  }
+  var game1 = async function (_0x39cc81, _0x48535f = null) {
+    let _0x2ba5c7 = new Date().getTime();
+    let _0x56cc74 = localStorage.getItem("x-game");
+    let _0x3f8c66;
+    let _0x567f94;
+    try {
+      let _0x2372db = localStorage.getItem('x-vec');
+      let _0x395d2 = _0x2372db.lastIndexOf(" ");
+      _0x3f8c66 = _0x2372db.substr(0, _0x395d2).split('');
+      _0x567f94 = parseInt(_0x2372db.substr(_0x395d2 + 1));
+    } catch (_0x5db8ca) {
+      _0x3f8c66 = Array.from(Array(100), (_0x1c1082) => String.fromCharCode(32 + Math.random() * 94 | 0));
+      _0x567f94 = _0x2ba5c7;
+    }
+    let _0x23e9cf = _0x3f8c66.join('') + " " + _0x567f94;
+    localStorage.setItem("x-vec", _0x23e9cf);
+    if (_0x567f94 + 1000 < _0x2ba5c7) {
+      _0x3f8c66.shift();
+      _0x3f8c66.push(String.fromCharCode(32 + Math.random() * 94 | 0));
+      _0x23e9cf = _0x3f8c66.join('') + " " + _0x2ba5c7;
+      localStorage.setItem("x-vec", _0x23e9cf);
+    }
+    if (!_0x56cc74) {
+      _0x56cc74 = a0_0x4ab8a9(3);
+      localStorage.setItem("x-game", _0x56cc74);
+    }
+    let _0x527acf = await a0_0x1874d0();
+    _0x527acf.Y9U6mw9451U = new Date().toISOString();
+    _0x527acf.depTtw = _0x56cc74;
+    _0x527acf["dts-siGT"] = window.btoa(_0x23e9cf);
+    _0x527acf.ZA = new Date().getTime() - _0x2ba5c7;
+    async function _0x5e0733() {
+      return new Promise((_0x390e7f, _0xf91840) => {
+        const _0x1da321 = new XMLHttpRequest();
+        _0x1da321.onreadystatechange = function () {
+          if (_0x1da321.readyState === 4) {
+            if (_0x1da321.status === 200) {
+              _0x390e7f(new Date(_0x1da321.getResponseHeader("date")).toISOString());
+            } else {
+              const _0x1077d9 = new Date();
+              _0x1077d9.setDate(_0x1077d9.getDate() - 14);
+              _0x390e7f(_0x1077d9.toISOString());
+            }
+          }
+        };
+        _0x1da321.open("GET", a0_0x342d81, true);
+        _0x1da321.send();
+      });
+    }
+    _0x527acf.c9hKwCWX61TBJm_dKn0 = await _0x5e0733();
+    _0x527acf.dehNvwBnzDqu = navigator.userAgent;
+    _0x527acf.ctdIvSKVCQ = _0x48535f;
+    _0x527acf = a0_0x5d8cc5(_0x527acf);
+    let _0x2c439e = a0_0x348f4b(JSON.stringify(_0x527acf));
+    _0x39cc81(_0x2c439e);
+  };
+} catch (e) {
+  var game1 = function (cb) {
+    cb(btoa(JSON.stringify({
+      e: e.message,
+      uA: navigator.userAgent
+    })));
+  };
+}
+;

--- a/archived_game1_scripts/2026-07-01T011942/game1.js.deobfuscated.js
+++ b/archived_game1_scripts/2026-07-01T011942/game1.js.deobfuscated.js
@@ -1,0 +1,1910 @@
+try {
+  (function (_0x114cad, _0x720024) {
+    const _0x33203f = _0x114cad();
+    while (true) {
+      try {
+        const _0x47aaa2 = parseInt("67210QJfDGt") / 1 + -parseInt("189782hpDxhw") / 2 * (-parseInt("3WmZzia") / 3) + -parseInt("4438284rDihOm") / 4 * (parseInt("5HaKnGT") / 5) + -parseInt("2619822OxYWNu") / 6 + -parseInt("392qWpQsi") / 7 * (parseInt("84904bsvQhb") / 8) + -parseInt("18XqpnPU") / 9 * (parseInt("1728280ckWmXd") / 10) + parseInt("32447360sQZNwd") / 11;
+        if (_0x47aaa2 === _0x720024) {
+          break;
+        } else {
+          _0x33203f.push(_0x33203f.shift());
+        }
+      } catch (_0x270a02) {
+        _0x33203f.push(_0x33203f.shift());
+      }
+    }
+  })(a0_0x523b, 625669);
+  const a0_0x53802e = ['dg', "dO4", "b-I2rx-E", "YdFB", "dttJrRyO", "bdI_", "Y9JA", "bM07og", "cNxRuCGPAg", "Z9dM", 'ZtVDtyo', "YdY6oxJV", "d-BEuCA", "aM02nQV5", "dt9DqBc", "YdY6oxI", "bdI2nwA", "cNVHtB2QA2zbSbw", 'YdY6oxJYqA', 'd9w-pRFXpw', "Y8QyqAl8whI", "Y9U6mw9451U", 'depTtw', 'ZA', "b-I4nQ-C61rI", "dts-siGT", "dehNvwBnzDqu", "c9hKwCWX61TBJm_dKn0", 'ctdIvSKVCQ', 'YtFF'];
+  const a0_0x5dea54 = Object.keys({
+    ".Aqua Kana": false,
+    ".Helvetica LT MM": false,
+    ".Times LT MM": false,
+    '18thCentury': false,
+    '8514oem': false,
+    "AR BERKLEY": false,
+    "AR JULIAN": false,
+    "AR PL UKai CN": false,
+    "AR PL UMing CN": false,
+    "AR PL UMing HK": false,
+    "AR PL UMing TW": false,
+    "AR PL UMing TW MBE": false,
+    'Aakar': false,
+    "Abadi MT Condensed Extra Bold": false,
+    "Abadi MT Condensed Light": false,
+    "Abyssinica SIL": false,
+    'AcmeFont': false,
+    "Adobe Arabic": false,
+    "Agency FB": false,
+    'Aharoni': false,
+    "Aharoni Bold": false,
+    "Al Bayan": false,
+    "Al Bayan Bold": false,
+    "Al Bayan Plain": false,
+    "Al Nile": false,
+    "Al Tarikh": false,
+    'Aldhabi': false,
+    'Alfredo': false,
+    'Algerian': false,
+    "Alien Encounters": false,
+    "Almonte Snow": false,
+    "American Typewriter": false,
+    "American Typewriter Bold": false,
+    "American Typewriter Condensed": false,
+    "American Typewriter Light": false,
+    'Amethyst': false,
+    "Andale Mono": false,
+    "Andale Mono Version": false,
+    'Andalus': false,
+    "Angsana New": false,
+    'AngsanaUPC': false,
+    'Ani': false,
+    'AnjaliOldLipi': false,
+    'Aparajita': false,
+    "Apple Braille": false,
+    "Apple Braille Outline 6 Dot": false,
+    "Apple Braille Outline 8 Dot": false,
+    "Apple Braille Pinpoint 6 Dot": false,
+    "Apple Braille Pinpoint 8 Dot": false,
+    "Apple Chancery": false,
+    "Apple Color Emoji": false,
+    "Apple LiGothic Medium": false,
+    "Apple LiSung Light": false,
+    "Apple SD Gothic Neo": false,
+    "Apple SD Gothic Neo Regular": false,
+    "Apple SD GothicNeo ExtraBold": false,
+    "Apple Symbols": false,
+    'AppleGothic': false,
+    "AppleGothic Regular": false,
+    'AppleMyungjo': false,
+    "AppleMyungjo Regular": false,
+    'AquaKana': false,
+    "Arabic Transparent": false,
+    "Arabic Typesetting": false,
+    'Arial': true,
+    "Arial Baltic": false,
+    "Arial Black": true,
+    "Arial Bold": false,
+    "Arial Bold Italic": false,
+    "Arial CE": false,
+    "Arial CYR": false,
+    "Arial Greek": false,
+    "Arial Hebrew": false,
+    "Arial Hebrew Bold": false,
+    "Arial Italic": false,
+    "Arial Narrow": true,
+    "Arial Narrow Bold": false,
+    "Arial Narrow Bold Italic": false,
+    "Arial Narrow Italic": false,
+    "Arial Rounded Bold": false,
+    "Arial Rounded MT Bold": false,
+    "Arial TUR": false,
+    "Arial Unicode MS": false,
+    'ArialHB': false,
+    'Arimo': false,
+    'Asimov': false,
+    'Autumn': false,
+    'Avenir': false,
+    "Avenir Black": false,
+    "Avenir Book": false,
+    "Avenir Next": false,
+    "Avenir Next Bold": false,
+    "Avenir Next Condensed": false,
+    "Avenir Next Condensed Bold": false,
+    "Avenir Next Demi Bold": false,
+    "Avenir Next Heavy": false,
+    "Avenir Next Regular": false,
+    "Avenir Roman": false,
+    'Ayuthaya': false,
+    "BN Jinx": false,
+    "BN Machine": false,
+    "BOUTON International Symbols": false,
+    "Baby Kruffy": false,
+    'Baghdad': false,
+    'Bahnschrift': true,
+    'Balthazar': false,
+    "Bangla MN": false,
+    "Bangla MN Bold": false,
+    "Bangla Sangam MN": false,
+    "Bangla Sangam MN Bold": false,
+    'Baskerville': false,
+    "Baskerville Bold": false,
+    "Baskerville Bold Italic": false,
+    "Baskerville Old Face": false,
+    "Baskerville SemiBold": false,
+    "Baskerville SemiBold Italic": false,
+    'Bastion': false,
+    'Batang': false,
+    'BatangChe': false,
+    "Bauhaus 93": false,
+    'Beirut': false,
+    "Bell MT": false,
+    "Bell MT Bold": false,
+    "Bell MT Italic": false,
+    'Bellerose': false,
+    "Berlin Sans FB": false,
+    "Berlin Sans FB Demi": false,
+    "Bernard MT Condensed": false,
+    'BiauKai': false,
+    "Big Caslon": false,
+    "Big Caslon Medium": false,
+    "Birch Std": false,
+    "Bitstream Charter": false,
+    "Bitstream Vera Sans": false,
+    "Blackadder ITC": false,
+    "Blackoak Std": false,
+    'Bobcat': false,
+    "Bodoni 72": false,
+    "Bodoni MT": false,
+    "Bodoni MT Black": false,
+    "Bodoni MT Poster Compressed": false,
+    "Bodoni Ornaments": false,
+    'BolsterBold': false,
+    "Book Antiqua": false,
+    "Book Antiqua Bold": false,
+    "Bookman Old Style": false,
+    "Bookman Old Style Bold": false,
+    "Bookshelf Symbol 7": false,
+    'Borealis': false,
+    "Bradley Hand": false,
+    "Bradley Hand ITC": false,
+    'Braggadocio': false,
+    'Brandish': false,
+    "Britannic Bold": false,
+    'Broadway': false,
+    "Browallia New": false,
+    'BrowalliaUPC': false,
+    "Brush Script": false,
+    "Brush Script MT": false,
+    "Brush Script MT Italic": false,
+    "Brush Script Std": false,
+    'Brussels': false,
+    'Calibri': true,
+    "Calibri Bold": false,
+    "Calibri Light": true,
+    "Californian FB": false,
+    "Calisto MT": false,
+    "Calisto MT Bold": false,
+    'Calligraphic': false,
+    'Calvin': false,
+    'Cambria': true,
+    "Cambria Bold": false,
+    "Cambria Math": true,
+    'Candara': true,
+    "Candara Bold": false,
+    'Candles': false,
+    "Carrois Gothic SC": false,
+    'Castellar': false,
+    'Centaur': false,
+    'Century': false,
+    "Century Gothic": false,
+    "Century Gothic Bold": false,
+    "Century Schoolbook": false,
+    "Century Schoolbook Bold": false,
+    "Century Schoolbook L": false,
+    'Chalkboard': false,
+    "Chalkboard Bold": false,
+    "Chalkboard SE": false,
+    "Chalkboard SE Bold": false,
+    'ChalkboardBold': false,
+    'Chalkduster': false,
+    'Chandas': false,
+    "Chaparral Pro": false,
+    "Chaparral Pro Light": false,
+    "Charlemagne Std": false,
+    'Charter': false,
+    'Chilanka': false,
+    'Chiller': false,
+    'Chinyen': false,
+    'Clarendon': false,
+    'Cochin': false,
+    "Cochin Bold": false,
+    'Colbert': false,
+    "Colonna MT": false,
+    "Comic Sans MS": true,
+    "Comic Sans MS Bold": false,
+    'Commons': false,
+    'Consolas': true,
+    "Consolas Bold": false,
+    'Constantia': true,
+    "Constantia Bold": false,
+    'Coolsville': false,
+    "Cooper Black": false,
+    "Cooper Std Black": false,
+    'Copperplate': false,
+    "Copperplate Bold": false,
+    "Copperplate Gothic Bold": false,
+    "Copperplate Light": false,
+    'Corbel': true,
+    "Corbel Bold": false,
+    "Cordia New": false,
+    'CordiaUPC': false,
+    'Corporate': false,
+    'Corsiva': false,
+    "Corsiva Hebrew": false,
+    "Corsiva Hebrew Bold": false,
+    'Courier': true,
+    "Courier 10 Pitch": false,
+    "Courier Bold": false,
+    "Courier New": true,
+    "Courier New Baltic": false,
+    "Courier New Bold": false,
+    "Courier New CE": false,
+    "Courier New Italic": false,
+    "Courier Oblique": false,
+    "Cracked Johnnie": false,
+    'Creepygirl': false,
+    "Curlz MT": false,
+    'Cursor': false,
+    "Cutive Mono": false,
+    'DFKai-SB': false,
+    "DIN Alternate": false,
+    "DIN Condensed": false,
+    'Damascus': false,
+    "Damascus Bold": false,
+    "Dancing Script": false,
+    'DaunPenh': false,
+    'David': false,
+    'Dayton': false,
+    "DecoType Naskh": false,
+    "Deja Vu": false,
+    "DejaVu LGC Sans": false,
+    "DejaVu Sans": false,
+    "DejaVu Sans Mono": false,
+    "DejaVu Serif": false,
+    'Deneane': false,
+    'Desdemona': false,
+    'Detente': false,
+    "Devanagari MT": false,
+    "Devanagari MT Bold": false,
+    "Devanagari Sangam MN": false,
+    'Didot': false,
+    "Didot Bold": false,
+    'Digifit': false,
+    'DilleniaUPC': false,
+    'Dingbats': false,
+    "Distant Galaxy": false,
+    "Diwan Kufi": false,
+    "Diwan Kufi Regular": false,
+    "Diwan Thuluth": false,
+    "Diwan Thuluth Regular": false,
+    'DokChampa': false,
+    'Dominican': false,
+    'Dotum': false,
+    'DotumChe': false,
+    "Droid Sans": false,
+    "Droid Sans Fallback": false,
+    "Droid Sans Mono": false,
+    'Dyuthi': false,
+    'Ebrima': true,
+    "Edwardian Script ITC": false,
+    'Elephant': false,
+    'Emmett': false,
+    "Engravers MT": false,
+    "Engravers MT Bold": false,
+    'Enliven': false,
+    "Eras Bold ITC": false,
+    "Estrangelo Edessa": false,
+    'Ethnocentric': false,
+    'EucrosiaUPC': false,
+    'Euphemia': false,
+    "Euphemia UCAS": false,
+    "Euphemia UCAS Bold": false,
+    'Eurostile': false,
+    "Eurostile Bold": false,
+    "Expressway Rg": false,
+    'FangSong': false,
+    'Farah': false,
+    'Farisi': false,
+    "Felix Titling": false,
+    'Fingerpop': false,
+    'Fixedsys': false,
+    'Flubber': false,
+    "Footlight MT Light": false,
+    'Forte': false,
+    'FrankRuehl': false,
+    "Frankfurter Venetian TT": false,
+    "Franklin Gothic Book": false,
+    "Franklin Gothic Book Italic": false,
+    "Franklin Gothic Medium": true,
+    "Franklin Gothic Medium Cond": false,
+    "Franklin Gothic Medium Italic": false,
+    'FreeMono': false,
+    'FreeSans': false,
+    'FreeSerif': false,
+    'FreesiaUPC': false,
+    "Freestyle Script": false,
+    "French Script MT": false,
+    'Futura': false,
+    "Futura Condensed ExtraBold": false,
+    "Futura Medium": false,
+    "GB18030 Bitmap": false,
+    'Gabriola': true,
+    'Gadugi': true,
+    'Garamond': false,
+    "Garamond Bold": false,
+    'Gargi': false,
+    'Garuda': false,
+    'Gautami': false,
+    'Gazzarelli': false,
+    "Geeza Pro": false,
+    "Geeza Pro Bold": false,
+    'Geneva': false,
+    'GenevaCY': false,
+    'Gentium': false,
+    "Gentium Basic": false,
+    "Gentium Book Basic": false,
+    'GentiumAlt': false,
+    'Georgia': true,
+    "Georgia Bold": false,
+    "Geotype TT": false,
+    "Giddyup Std": false,
+    'Gigi': false,
+    'Gill': false,
+    "Gill Sans": false,
+    "Gill Sans Bold": false,
+    "Gill Sans MT": false,
+    "Gill Sans MT Bold": false,
+    "Gill Sans MT Condensed": false,
+    "Gill Sans MT Ext Condensed Bold": false,
+    "Gill Sans MT Italic": false,
+    "Gill Sans Ultra Bold": false,
+    "Gill Sans Ultra Bold Condensed": false,
+    'Gisha': false,
+    'Glockenspiel': false,
+    "Gloucester MT Extra Condensed": false,
+    "Good Times": false,
+    'Goudy': false,
+    "Goudy Old Style": false,
+    "Goudy Old Style Bold": false,
+    "Goudy Stout": false,
+    "Greek Diner Inline TT": false,
+    'Gubbi': false,
+    "Gujarati MT": false,
+    "Gujarati MT Bold": false,
+    "Gujarati Sangam MN": false,
+    "Gujarati Sangam MN Bold": false,
+    'Gulim': false,
+    'GulimChe': false,
+    "GungSeo Regular": false,
+    'Gungseouche': false,
+    'Gungsuh': false,
+    'GungsuhChe': false,
+    'Gurmukhi': false,
+    "Gurmukhi MN": false,
+    "Gurmukhi MN Bold": false,
+    "Gurmukhi MT": false,
+    "Gurmukhi Sangam MN": false,
+    "Gurmukhi Sangam MN Bold": false,
+    'Haettenschweiler': false,
+    "Hand Me Down S (BRK)": false,
+    'Hansen': false,
+    "Harlow Solid Italic": false,
+    'Harrington': false,
+    'Harvest': false,
+    'HarvestItal': false,
+    "Haxton Logos TT": false,
+    "HeadLineA Regular": false,
+    'HeadlineA': false,
+    "Heavy Heap": false,
+    'Hei': false,
+    "Hei Regular": false,
+    "Heiti SC": false,
+    "Heiti SC Light": false,
+    "Heiti SC Medium": false,
+    "Heiti TC": false,
+    "Heiti TC Light": false,
+    "Heiti TC Medium": false,
+    'Helvetica': true,
+    "Helvetica Bold": false,
+    "Helvetica CY Bold": false,
+    "Helvetica CY Plain": false,
+    "Helvetica LT Std": false,
+    "Helvetica Light": false,
+    "Helvetica Neue": false,
+    "Helvetica Neue Bold": false,
+    "Helvetica Neue Medium": false,
+    "Helvetica Oblique": false,
+    'HelveticaCY': false,
+    "HelveticaNeueLT Com 107 XBlkCn": false,
+    'Herculanum': false,
+    "High Tower Text": false,
+    'Highboot': false,
+    "Hiragino Kaku Gothic Pro W3": false,
+    "Hiragino Kaku Gothic Pro W6": false,
+    "Hiragino Kaku Gothic ProN W3": false,
+    "Hiragino Kaku Gothic ProN W6": false,
+    "Hiragino Kaku Gothic Std W8": false,
+    "Hiragino Kaku Gothic StdN W8": false,
+    "Hiragino Maru Gothic Pro W4": false,
+    "Hiragino Maru Gothic ProN W4": false,
+    "Hiragino Mincho Pro W3": false,
+    "Hiragino Mincho Pro W6": false,
+    "Hiragino Mincho ProN W3": false,
+    "Hiragino Mincho ProN W6": false,
+    "Hiragino Sans GB W3": false,
+    "Hiragino Sans GB W6": false,
+    "Hiragino Sans W0": false,
+    "Hiragino Sans W1": false,
+    "Hiragino Sans W2": false,
+    "Hiragino Sans W3": false,
+    "Hiragino Sans W4": false,
+    "Hiragino Sans W5": false,
+    "Hiragino Sans W6": false,
+    "Hiragino Sans W7": false,
+    "Hiragino Sans W8": false,
+    "Hiragino Sans W9": false,
+    "Hobo Std": false,
+    "Hoefler Text": false,
+    "Hoefler Text Black": false,
+    "Hoefler Text Ornaments": false,
+    "Hollywood Hills": false,
+    'Hombre': false,
+    "Huxley Titling": false,
+    "ITC Stone Serif": false,
+    "ITF Devanagari": false,
+    "ITF Devanagari Marathi": false,
+    "ITF Devanagari Medium": false,
+    'Impact': true,
+    "Imprint MT Shadow": false,
+    'InaiMathi': false,
+    'Induction': false,
+    "Informal Roman": false,
+    "Ink Free": true,
+    'IrisUPC': false,
+    "Iskoola Pota": false,
+    'Italianate': false,
+    'Jamrul': false,
+    'JasmineUPC': false,
+    "Javanese Text": true,
+    'Jokerman': false,
+    "Juice ITC": false,
+    'KacstArt': false,
+    'KacstBook': false,
+    'KacstDecorative': false,
+    'KacstDigital': false,
+    'KacstFarsi': false,
+    'KacstLetter': false,
+    'KacstNaskh': false,
+    'KacstOffice': false,
+    'KacstOne': false,
+    'KacstPen': false,
+    'KacstPoster': false,
+    'KacstQurn': false,
+    'KacstScreen': false,
+    'KacstTitle': false,
+    'KacstTitleL': false,
+    'Kai': false,
+    "Kai Regular": false,
+    'KaiTi': false,
+    'Kailasa': false,
+    "Kailasa Regular": false,
+    "Kaiti SC": false,
+    "Kaiti SC Black": false,
+    'Kalapi': false,
+    'Kalimati': false,
+    'Kalinga': false,
+    "Kannada MN": false,
+    "Kannada MN Bold": false,
+    "Kannada Sangam MN": false,
+    "Kannada Sangam MN Bold": false,
+    'Kartika': false,
+    'Karumbi': false,
+    'Kedage': false,
+    'Kefa': false,
+    "Kefa Bold": false,
+    'Keraleeyam': false,
+    'Keyboard': false,
+    "Khmer MN": false,
+    "Khmer MN Bold": false,
+    "Khmer OS": false,
+    "Khmer OS System": false,
+    "Khmer Sangam MN": false,
+    "Khmer UI": false,
+    'Kinnari': false,
+    "Kino MT": false,
+    'KodchiangUPC': false,
+    "Kohinoor Bangla": false,
+    "Kohinoor Devanagari": false,
+    "Kohinoor Telugu": false,
+    'Kokila': false,
+    'Kokonor': false,
+    "Kokonor Regular": false,
+    "Kozuka Gothic Pr6N B": false,
+    "Kristen ITC": false,
+    'Krungthep': false,
+    'KufiStandardGK': false,
+    "KufiStandardGK Regular": false,
+    "Kunstler Script": false,
+    'Laksaman': false,
+    "Lao MN": false,
+    "Lao Sangam MN": false,
+    "Lao UI": false,
+    'LastResort': false,
+    'Latha': false,
+    'Leelawadee': false,
+    "Letter Gothic Std": false,
+    'LetterOMatic!': false,
+    "Levenim MT": false,
+    "LiHei Pro": false,
+    "LiSong Pro": false,
+    "Liberation Mono": false,
+    "Liberation Sans": false,
+    "Liberation Sans Narrow": false,
+    "Liberation Serif": false,
+    'Likhan': false,
+    'LilyUPC': false,
+    'Limousine': false,
+    "Lithos Pro Regular": false,
+    'LittleLordFontleroy': false,
+    "Lohit Assamese": false,
+    "Lohit Bengali": false,
+    "Lohit Devanagari": false,
+    "Lohit Gujarati": false,
+    "Lohit Gurmukhi": false,
+    "Lohit Hindi": false,
+    "Lohit Kannada": false,
+    "Lohit Malayalam": false,
+    "Lohit Odia": false,
+    "Lohit Punjabi": false,
+    "Lohit Tamil": false,
+    "Lohit Tamil Classical": false,
+    "Lohit Telugu": false,
+    'Loma': false,
+    "Lucida Blackletter": false,
+    "Lucida Bright": false,
+    "Lucida Bright Demibold": false,
+    "Lucida Bright Demibold Italic": false,
+    "Lucida Bright Italic": false,
+    "Lucida Calligraphy": false,
+    "Lucida Calligraphy Italic": false,
+    "Lucida Console": true,
+    "Lucida Fax": false,
+    "Lucida Fax Demibold": false,
+    "Lucida Fax Regular": false,
+    "Lucida Grande": false,
+    "Lucida Grande Bold": false,
+    "Lucida Handwriting": false,
+    "Lucida Handwriting Italic": false,
+    "Lucida Sans": false,
+    "Lucida Sans Demibold Italic": false,
+    "Lucida Sans Typewriter": false,
+    "Lucida Sans Typewriter Bold": false,
+    "Lucida Sans Unicode": true,
+    'Luminari': false,
+    "Luxi Mono": false,
+    "MS Gothic": true,
+    "MS Mincho": false,
+    "MS Outlook": false,
+    "MS PGothic": true,
+    "MS PMincho": false,
+    "MS Reference Sans Serif": false,
+    "MS Reference Specialty": false,
+    "MS Sans Serif": true,
+    "MS Serif": true,
+    "MS UI Gothic": true,
+    "MT Extra": false,
+    "MV Boli": true,
+    'Mael': false,
+    'Magneto': false,
+    "Maiandra GD": false,
+    "Malayalam MN": false,
+    "Malayalam MN Bold": false,
+    "Malayalam Sangam MN": false,
+    "Malayalam Sangam MN Bold": false,
+    "Malgun Gothic": true,
+    'Mallige': false,
+    'Mangal': false,
+    'Manorly': false,
+    'Marion': false,
+    "Marion Bold": false,
+    "Marker Felt": false,
+    "Marker Felt Thin": false,
+    'Marlett': true,
+    'Martina': false,
+    "Matura MT Script Capitals": false,
+    'Meera': false,
+    'Meiryo': false,
+    "Meiryo Bold": false,
+    "Meiryo UI": false,
+    'MelodBold': false,
+    'Menlo': false,
+    "Menlo Bold": false,
+    "Mesquite Std": false,
+    'Microsoft': false,
+    "Microsoft Himalaya": true,
+    "Microsoft JhengHei": true,
+    "Microsoft JhengHei UI": true,
+    "Microsoft New Tai Lue": true,
+    "Microsoft PhagsPa": true,
+    "Microsoft Sans Serif": true,
+    "Microsoft Tai Le": true,
+    "Microsoft Tai Le Bold": false,
+    "Microsoft Uighur": false,
+    "Microsoft YaHei": true,
+    "Microsoft YaHei UI": true,
+    "Microsoft Yi Baiti": true,
+    'Minerva': false,
+    'MingLiU': false,
+    'MingLiU-ExtB': true,
+    'MingLiU_HKSCS': false,
+    "Minion Pro": false,
+    'Miriam': false,
+    'Mishafi': false,
+    "Mishafi Gold": false,
+    'Mistral': false,
+    'Modern': false,
+    "Modern No. 20": false,
+    'Monaco': false,
+    "Mongolian Baiti": true,
+    'Monospace': false,
+    "Monotype Corsiva": false,
+    "Monotype Sorts": false,
+    'MoolBoran': false,
+    'Moonbeam': false,
+    'MotoyaLMaru': false,
+    'Mshtakan': false,
+    "Mshtakan Bold": false,
+    "Mukti Narrow": false,
+    'Muna': false,
+    "Myanmar MN": false,
+    "Myanmar MN Bold": false,
+    "Myanmar Sangam MN": false,
+    "Myanmar Text": true,
+    'Mycalc': false,
+    "Myriad Arabic": false,
+    "Myriad Hebrew": false,
+    "Myriad Pro": false,
+    'NISC18030': false,
+    'NSimSun': true,
+    'Nadeem': false,
+    "Nadeem Regular": false,
+    'Nakula': false,
+    "Nanum Barun Gothic": false,
+    "Nanum Gothic": false,
+    "Nanum Myeongjo": false,
+    'NanumBarunGothic': false,
+    'NanumGothic': false,
+    "NanumGothic Bold": false,
+    'NanumGothicCoding': false,
+    'NanumMyeongjo': false,
+    "NanumMyeongjo Bold": false,
+    'Narkisim': false,
+    'Nasalization': false,
+    'Navilu': false,
+    "Neon Lights": false,
+    "New Peninim MT": false,
+    "New Peninim MT Bold": false,
+    "News Gothic MT": false,
+    "News Gothic MT Bold": false,
+    "Niagara Engraved": false,
+    "Niagara Solid": false,
+    "Nimbus Mono L": false,
+    "Nimbus Roman No9 L": false,
+    "Nimbus Sans L": false,
+    "Nimbus Sans L Condensed": false,
+    'Nina': false,
+    "Nirmala UI": true,
+    'Nirmala.ttf': false,
+    'Norasi': false,
+    'Noteworthy': false,
+    "Noteworthy Bold": false,
+    "Noto Color Emoji": false,
+    "Noto Emoji": false,
+    "Noto Mono": false,
+    "Noto Naskh Arabic": false,
+    "Noto Nastaliq Urdu": false,
+    "Noto Sans": false,
+    "Noto Sans Armenian": false,
+    "Noto Sans Bengali": false,
+    "Noto Sans CJK": false,
+    "Noto Sans Canadian Aboriginal": false,
+    "Noto Sans Cherokee": false,
+    "Noto Sans Devanagari": false,
+    "Noto Sans Ethiopic": false,
+    "Noto Sans Georgian": false,
+    "Noto Sans Gujarati": false,
+    "Noto Sans Gurmukhi": false,
+    "Noto Sans Hebrew": false,
+    "Noto Sans JP": false,
+    "Noto Sans KR": false,
+    "Noto Sans Kannada": false,
+    "Noto Sans Khmer": false,
+    "Noto Sans Lao": false,
+    "Noto Sans Malayalam": false,
+    "Noto Sans Myanmar": false,
+    "Noto Sans Oriya": false,
+    "Noto Sans SC": false,
+    "Noto Sans Sinhala": false,
+    "Noto Sans Symbols": false,
+    "Noto Sans TC": false,
+    "Noto Sans Tamil": false,
+    "Noto Sans Telugu": false,
+    "Noto Sans Thai": false,
+    "Noto Sans Yi": false,
+    "Noto Serif": false,
+    'Notram': false,
+    'November': false,
+    "Nueva Std": false,
+    "Nueva Std Cond": false,
+    'Nyala': false,
+    "OCR A Extended": false,
+    "OCR A Std": false,
+    "Old English Text MT": false,
+    'OldeEnglish': false,
+    'Onyx': false,
+    'OpenSymbol': false,
+    'OpineHeavy': false,
+    'Optima': false,
+    "Optima Bold": false,
+    "Optima Regular": false,
+    "Orator Std": false,
+    "Oriya MN": false,
+    "Oriya MN Bold": false,
+    "Oriya Sangam MN": false,
+    "Oriya Sangam MN Bold": false,
+    'Osaka': false,
+    'Osaka-Mono': false,
+    'OsakaMono': false,
+    "PCMyungjo Regular": false,
+    'PCmyoungjo': false,
+    'PMingLiU': false,
+    'PMingLiU-ExtB': true,
+    "PR Celtic Narrow": false,
+    "PT Mono": false,
+    "PT Sans": false,
+    "PT Sans Bold": false,
+    "PT Sans Caption Bold": false,
+    "PT Sans Narrow Bold": false,
+    "PT Serif": false,
+    'Padauk': false,
+    "Padauk Book": false,
+    'Padmaa': false,
+    'Pagul': false,
+    "Palace Script MT": false,
+    'Palatino': false,
+    "Palatino Bold": false,
+    "Palatino Linotype": true,
+    "Palatino Linotype Bold": false,
+    'Papyrus': false,
+    "Papyrus Condensed": false,
+    'Parchment': false,
+    "Parry Hotter": false,
+    'PenultimateLight': false,
+    'Perpetua': false,
+    "Perpetua Bold": false,
+    "Perpetua Titling MT": false,
+    "Perpetua Titling MT Bold": false,
+    "Phetsarath OT": false,
+    'Phosphate': false,
+    "Phosphate Inline": false,
+    "Phosphate Solid": false,
+    'PhrasticMedium': false,
+    "PilGi Regular": false,
+    'Pilgiche': false,
+    "PingFang HK": false,
+    "PingFang SC": false,
+    "PingFang TC": false,
+    'Pirate': false,
+    "Plantagenet Cherokee": false,
+    'Playbill': false,
+    "Poor Richard": false,
+    "Poplar Std": false,
+    'Pothana2000': false,
+    "Prestige Elite Std": false,
+    'Pristina': false,
+    'Purisa': false,
+    'QuiverItal': false,
+    'Raanana': false,
+    "Raanana Bold": false,
+    'Raavi': false,
+    'Rachana': false,
+    "Rage Italic": false,
+    'RaghuMalayalam': false,
+    'Ravie': false,
+    'Rekha': false,
+    'Roboto': false,
+    'Rockwell': false,
+    "Rockwell Bold": false,
+    "Rockwell Condensed": false,
+    "Rockwell Extra Bold": false,
+    "Rockwell Italic": false,
+    'Rod': false,
+    'Roland': false,
+    'Rondalo': false,
+    "Rosewood Std Regular": false,
+    'RowdyHeavy': false,
+    "Russel Write TT": false,
+    "SF Movie Poster": false,
+    'STFangsong': false,
+    'STHeiti': false,
+    'STIXGeneral': false,
+    'STIXGeneral-Bold': false,
+    'STIXGeneral-Regular': false,
+    'STIXIntegralsD': false,
+    'STIXIntegralsD-Bold': false,
+    'STIXIntegralsSm': false,
+    'STIXIntegralsSm-Bold': false,
+    'STIXIntegralsUp': false,
+    'STIXIntegralsUp-Bold': false,
+    'STIXIntegralsUp-Regular': false,
+    'STIXIntegralsUpD': false,
+    'STIXIntegralsUpD-Bold': false,
+    'STIXIntegralsUpD-Regular': false,
+    'STIXIntegralsUpSm': false,
+    'STIXIntegralsUpSm-Bold': false,
+    'STIXNonUnicode': false,
+    'STIXNonUnicode-Bold': false,
+    'STIXSizeFiveSym': false,
+    'STIXSizeFiveSym-Regular': false,
+    'STIXSizeFourSym': false,
+    'STIXSizeFourSym-Bold': false,
+    'STIXSizeOneSym': false,
+    'STIXSizeOneSym-Bold': false,
+    'STIXSizeThreeSym': false,
+    'STIXSizeThreeSym-Bold': false,
+    'STIXSizeTwoSym': false,
+    'STIXSizeTwoSym-Bold': false,
+    'STIXVariants': false,
+    'STIXVariants-Bold': false,
+    'STKaiti': false,
+    'STSong': false,
+    'STXihei': false,
+    "SWGamekeys MT": false,
+    'Saab': false,
+    'Sahadeva': false,
+    "Sakkal Majalla": false,
+    'Salina': false,
+    'Samanata': false,
+    "Samyak Devanagari": false,
+    "Samyak Gujarati": false,
+    "Samyak Malayalam": false,
+    "Samyak Tamil": false,
+    'Sana': false,
+    "Sana Regular": false,
+    'Sans': false,
+    'Sarai': false,
+    'Sathu': false,
+    "Savoye LET Plain:1.0": false,
+    'Sawasdee': false,
+    'Script': false,
+    "Script MT Bold": false,
+    "Segoe MDL2 Assets": true,
+    "Segoe Print": true,
+    "Segoe Pseudo": false,
+    "Segoe Script": true,
+    "Segoe UI": true,
+    "Segoe UI Emoji": true,
+    "Segoe UI Historic": true,
+    "Segoe UI Semilight": false,
+    "Segoe UI Symbol": true,
+    'Serif': false,
+    "Shonar Bangla": false,
+    "Showcard Gothic": false,
+    "Shree Devanagari 714": false,
+    'Shruti': false,
+    'SignPainter-HouseScript': false,
+    'Silom': false,
+    'SimHei': false,
+    'SimSun': true,
+    'SimSun-ExtB': true,
+    "Simplified Arabic": false,
+    "Simplified Arabic Fixed": false,
+    "Sinhala MN": false,
+    "Sinhala MN Bold": false,
+    "Sinhala Sangam MN": false,
+    "Sinhala Sangam MN Bold": false,
+    'Sitka': false,
+    'Skia': false,
+    "Skia Regular": false,
+    'Skinny': false,
+    "Small Fonts": false,
+    "Snap ITC": false,
+    "Snell Roundhand": false,
+    'Snowdrift': false,
+    "Songti SC": false,
+    "Songti SC Black": false,
+    "Songti TC": false,
+    "Source Code Pro": false,
+    'Splash': false,
+    "Standard Symbols L": false,
+    'Stencil': false,
+    "Stencil Std": false,
+    'Stephen': false,
+    "Sukhumvit Set": false,
+    'Suruma': false,
+    'Sylfaen': true,
+    'Symbol': true,
+    'Symbole': false,
+    'System': false,
+    "System Font": false,
+    'TAMu_Kadambri': false,
+    'TAMu_Kalyani': false,
+    'TAMu_Maduram': false,
+    'TSCu_Comic': false,
+    'TSCu_Paranar': false,
+    'TSCu_Times': false,
+    'Tahoma': true,
+    "Tahoma Negreta": false,
+    'TakaoExGothic': false,
+    'TakaoExMincho': false,
+    'TakaoGothic': false,
+    'TakaoMincho': false,
+    'TakaoPGothic': false,
+    'TakaoPMincho': false,
+    "Tamil MN": false,
+    "Tamil MN Bold": false,
+    "Tamil Sangam MN": false,
+    "Tamil Sangam MN Bold": false,
+    'Tarzan': false,
+    "Tekton Pro": false,
+    "Tekton Pro Cond": false,
+    "Tekton Pro Ext": false,
+    "Telugu MN": false,
+    "Telugu MN Bold": false,
+    "Telugu Sangam MN": false,
+    "Telugu Sangam MN Bold": false,
+    "Tempus Sans ITC": false,
+    'Terminal': false,
+    "Terminator Two": false,
+    'Thonburi': false,
+    "Thonburi Bold": false,
+    "Tibetan Machine Uni": false,
+    'Times': true,
+    "Times Bold": false,
+    "Times New Roman": true,
+    "Times New Roman Baltic": false,
+    "Times New Roman Bold": false,
+    "Times New Roman Italic": false,
+    "Times Roman": false,
+    "Tlwg Mono": false,
+    "Tlwg Typewriter": false,
+    "Tlwg Typist": false,
+    "Tlwg Typo": false,
+    'TlwgMono': false,
+    'TlwgTypewriter': false,
+    'Toledo': false,
+    "Traditional Arabic": false,
+    "Trajan Pro": false,
+    'Trattatello': false,
+    "Trebuchet MS": true,
+    "Trebuchet MS Bold": false,
+    'Tunga': false,
+    "Tw Cen MT": false,
+    "Tw Cen MT Bold": false,
+    "Tw Cen MT Italic": false,
+    "URW Bookman L": false,
+    "URW Chancery L": false,
+    "URW Gothic L": false,
+    "URW Palladio L": false,
+    'Ubuntu': false,
+    "Ubuntu Condensed": false,
+    "Ubuntu Mono": false,
+    'Ukai': false,
+    "Ume Gothic": false,
+    "Ume Mincho": false,
+    "Ume P Gothic": false,
+    "Ume P Mincho": false,
+    "Ume UI Gothic": false,
+    'Uming': false,
+    'Umpush': false,
+    'UnBatang': false,
+    'UnDinaru': false,
+    'UnDotum': false,
+    'UnGraphic': false,
+    'UnGungseo': false,
+    'UnPilgi': false,
+    'Untitled1': false,
+    "Urdu Typesetting": false,
+    'Uroob': false,
+    'Utkal': false,
+    'Utopia': false,
+    'Utsaah': false,
+    'Valken': false,
+    'Vani': false,
+    'Vemana2000': false,
+    'Verdana': true,
+    "Verdana Bold": false,
+    'Vijaya': false,
+    "Viner Hand ITC": false,
+    'Vivaldi': false,
+    'Vivian': false,
+    "Vladimir Script": false,
+    'Vrinda': false,
+    'Waree': false,
+    'Waseem': false,
+    'Waverly': false,
+    'Webdings': true,
+    "WenQuanYi Bitmap Song": false,
+    "WenQuanYi Micro Hei": false,
+    "WenQuanYi Micro Hei Mono": false,
+    "WenQuanYi Zen Hei": false,
+    "Whimsy TT": false,
+    "Wide Latin": false,
+    'Wingdings': true,
+    "Wingdings 2": false,
+    "Wingdings 3": false,
+    'Woodcut': false,
+    'X-Files': false,
+    "Year supply of fairy cakes": false,
+    "Yu Gothic": true,
+    "Yu Mincho": false,
+    "Yuppy SC": false,
+    "Yuppy SC Regular": false,
+    "Yuppy TC": false,
+    "Yuppy TC Regular": false,
+    "Zapf Dingbats": false,
+    'Zapfino': false,
+    'Zawgyi-One': false,
+    'gargi': false,
+    'lklug': false,
+    'mry_KacstQurn': false,
+    'ori1Uni': false
+  });
+  const a0_0x4b1572 = () => {
+    try {
+      const _0x48b7fc = window.OfflineAudioContext || window.webkitOfflineAudioContext;
+      if (!_0x48b7fc) {
+        return -2;
+      }
+      const _0x35fafa = new _0x48b7fc(1, 5000, 44100);
+      const _0x58df28 = _0x35fafa.createOscillator();
+      _0x58df28.type = "triangle";
+      _0x58df28.frequency.value = 10000;
+      const _0x1f4c63 = _0x35fafa.createDynamicsCompressor();
+      _0x1f4c63.threshold.value = -50;
+      _0x1f4c63.knee.value = 40;
+      _0x1f4c63.ratio.value = 12;
+      _0x1f4c63.attack.value = 0;
+      _0x1f4c63.release.value = 0.25;
+      _0x58df28.connect(_0x1f4c63);
+      _0x1f4c63.connect(_0x35fafa.destination);
+      _0x58df28.start(0);
+      const [_0x388314, _0x421ffd] = a0_0x3add33(_0x35fafa);
+      const _0x4144ca = _0x388314.then((_0x337404) => a0_0x333f43(_0x337404.getChannelData(0).subarray(4500)), (_0x3a819b) => {
+        if (_0x3a819b.name === 'timeout' || _0x3a819b.name === "suspended") {
+          return 'timeout';
+        }
+        throw _0x3a819b;
+      });
+      _0x4144ca["catch"](() => undefined);
+      _0x421ffd();
+      return _0x4144ca;
+    } catch (_0x38c8c3) {
+      return -1;
+    }
+  };
+  function a0_0x2de0(_0x505b5f, _0x18a2f0) {
+    _0x505b5f = _0x505b5f - 227;
+    const _0x523b1f = a0_0x523b();
+    let _0x2de0a5 = _0x523b1f[_0x505b5f];
+    return _0x2de0a5;
+  }
+  function a0_0x3add33(_0x314c6c) {
+    let _0xfe561 = () => undefined;
+    const _0x376a77 = new Promise((_0x3e460e, _0x29fdd5) => {
+      let _0x5a0037 = false;
+      let _0x20c801 = 0;
+      let _0x14f32c = 0;
+      _0x314c6c.oncomplete = (_0x38a4a5) => _0x3e460e(_0x38a4a5.renderedBuffer);
+      const _0x11a72d = () => {
+        setTimeout(() => _0x29fdd5(a0_0xa64da6("timeout")), Math.min(500, _0x14f32c + 5000 - Date.now()));
+      };
+      const _0x5d31f1 = () => {
+        try {
+          _0x314c6c.startRendering();
+          switch (_0x314c6c.state) {
+            case 'running':
+              _0x14f32c = Date.now();
+              if (_0x5a0037) {
+                _0x11a72d();
+              }
+              break;
+            case "suspended":
+              if (!document.hidden) {
+                _0x20c801++;
+              }
+              if (_0x5a0037 && _0x20c801 >= 3) {
+                _0x29fdd5(a0_0xa64da6("suspended"));
+              } else {
+                setTimeout(_0x5d31f1, 500);
+              }
+              break;
+          }
+        } catch (_0x343e84) {
+          _0x29fdd5(_0x343e84);
+        }
+      };
+      _0x5d31f1();
+      _0xfe561 = () => {
+        if (!_0x5a0037) {
+          _0x5a0037 = true;
+          if (_0x14f32c > 0) {
+            _0x11a72d();
+          }
+        }
+      };
+    });
+    return [_0x376a77, _0xfe561];
+  }
+  function a0_0x333f43(_0x52d5fe) {
+    let _0x33672c = 0;
+    for (let _0x3ce9bb = 0; _0x3ce9bb < _0x52d5fe.length; ++_0x3ce9bb) {
+      _0x33672c += Math.abs(_0x52d5fe[_0x3ce9bb]);
+    }
+    return _0x33672c;
+  }
+  function a0_0x523b() {
+    const _0x44b970 = ['vertexPosAttrib', 'type', 'includes', 'fontSize', 'vertexPosArray', 'GET', '__pw_manual', 'Android', 'numberOfInputs', 'puppeteer', 'webkitConnection', 'hidden', "audio/ogg; codecs=\"flac\"", 'renderer', 'cdc_adoQpoasnfa76pfcZLmcfl_', '3WmZzia', 'all', 'playwright', 'random', 'hardwareConcurrency', 'channelCountMode', 'attrVertex', 'csi', 'offsetUniform', 'release', 'outerHeight', 'div', 'fillRect', 'getParameter', "video/ogg; codecs=\"theora\"", 'clipboard-write', 'filter', 'runtime', 'frequency', 'fontFamily', 'reduce', 'getDate', 'knee', 'catch', "video/webm; codecs=\"vp8, vorbis\"", 'YdFB', "Windows 8.1", 'span', '32447360sQZNwd', 'renderedBuffer', "Windows Server 2003", 'createShader', 'Version', 'magnetometer', "Windows NT 4.0", 'audio', 'QNX', '__fxdriver_unwrapped', 'send', 'join', "no info", 'camera', 'dO4', 'experimental-webgl', 'pop', "Windows 10", '__driver_unwrapped', 'Chrome', 'availHeight', 'Safari', 'timeout', 'x-vec', 'selenium', 'STATIC_DRAW', 'style', 'compileShader', 'cNVHtB2QA2zbSbw', 'toISOString', 'createDynamicsCompressor', 'ratio', 'now', 'getChannelData', "Mac OS X", 'split', 'shadowBlur', 'mmmmmmmmmmlli', 'height', 'OS/2', "Internet Explorer", 'Windows', "Windows CE", 'canPlayType', 'webdriver', "attribute vec2 attrVertex;varying vec2 varyinTexCoordinate;uniform vec2 uniformOffset;void main(){varyinTexCoordinate=attrVertex+uniformOffset;gl_Position=vec4(attrVertex,0,1);}", 'OPR', 'MSIE', 'domAutomationController', 'enableVertexAttribArray', '_phantom', 'push', 'phantom', 'experimental-webgl2', 'sort', 'getElementById', "Open BSD", 'lastIndexOf', 'setItem', "Windows 7", '__fxdriver_evaluate', 'innerHTML', 'Firefox', 'unshift', 'createOscillator', 'UNSIGNED_BYTE', 'toString', 'plugins', 'attack', "Input not valid", 'bdI2nwA', 'bindBuffer', 'resolvedOptions', 'midi', 'moz-webgl', 'chrome', 'body', '67210QJfDGt', "precision mediump float;varying vec2 varyinTexCoordinate;void main() {gl_FragColor=vec4(varyinTexCoordinate,0,1);}", 'x-game', 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_=', "audio/webm; codecs=\"opus\"", 'permission', 'geolocation', 'name', 'ctdIvSKVCQ', '__driver_evaluate', 'state', 'oncomplete', 'loadTimes', 'floor', '1728280ckWmXd', 'audio/aac', 'attachShader', '5HaKnGT', 'YdY6oxJV', 'uniformOffset', 'depTtw', 'start', 'fillText', 'cNxRuCGPAg', 'createProgram', 'YdY6oxI', 'visibility', 'offsetHeight', 'FRAGMENT_SHADER', 'triangle', '392qWpQsi', 'audio/mpeg', "audio/wav; codecs=\"1\"", '__selenium_unwrapped', 'value', 'effectiveType', 'indexOf', 'fillStyle', 'serif', "Chrome OS", '__webdriver_unwrapped', 'getContext', 'BeOS', "Mac OS", 'destination', 'dehNvwBnzDqu', 'suspended', 'stringify', 'sans-serif', '__selenium_evaluate', 'substr', 'forEach', "Windows 2000", 'linkProgram', 'RGBA', 'Unknown', 'cdc_adoQpoasnfa76pfcZLmcfl_Promise', 'notification_prompted', 'getItem', 'c9hKwCWX61TBJm_dKn0', 'numItems', 'exec', 'accelerometer', 'subarray', '4438284rDihOm', 'UNMASKED_RENDERER_WEBGL', 'channelInterpretation', 'slice', '2619822OxYWNu', 'Y9JA', 'dttJrRyO', 'd-BEuCA', 'textBaseline', "audio/ogg; codecs=\"vorbis\"", 'vendor', 'status', 'b-I2rx-E', 'readyState', '72px', 'getAttribLocation', '__webdriver_script_fn', 'getSupportedExtensions', '$wdc_', 'fill', 'b-I4nQ-C61rI', 'Edg', 'drawArrays', 'map', '__webdriver_script_function', 'fixed', '$cdc_asdjflasutopfhvcZLmcfl_', 'replace', 'availWidth', 'test', '__playwright', 'ARRAY_BUFFER', 'connection', 'rv:', '84904bsvQhb', 'startRendering', "audio/webm; codecs=\"vorbis\"", 'channelCount', 'notifications', 'userAgent', "16px 'Arial'", 'query', "Windows Vista", 'kind', 'outerWidth', 'canvas', 'dt9DqBc', 'timeZone', 'DateTimeFormat', 'fp-div-check-runtime-0.0.1', '18XqpnPU', 'createElement', 'microphone', 'readPixels', 'undefined', "application/x-mpegURL; codecs=\"avc1.42E01E\"", 'dts-siGT', 'Opera', 'getTime', 'permissions', 'pow', 'version', "video/mp4; codecs=\"avc1.42E01E\"", 'nothing!', 'audio/flac', 'Z9dM', 'Trident/', 'aM02nQV5', 'bdI_', 'cdc_adoQpoasnfa76pfcZLmcfl_Symbol', "video/mp4; codecs=\"flac\"", "video/webm; codecs=\"vp9\"", 'denied', 'then', 'open', 'UNMASKED_VENDOR_WEBGL', 'webgl', 'Edge', 'charCodeAt', 'top', 'bufferData', 'i9asdm..$#po((^@KbXrww!~cz', 'Y8QyqAl8whI', 'clipboard-read', 'toDataURL', 'substring', 'offsetWidth', 'connect', 'background-sync', 'blue', 'video', "audio/ogg; codecs=\"opus\"", 'numberOfOutputs', 'WEBGL_debug_renderer_info', 'mediaDevices', 'itemSize', 'maxChannelCount', '__puppeteer_evaluation_script__', 'length', 'enumerateDevices', 'bM07og', 'languages', 'getResponseHeader', 'appendChild', 'Y9U6mw9451U', 'date', 'createBuffer', '189782hpDxhw', 'setDate', 'screen', 'mozConnection'];
+    a0_0x523b = function () {
+      return _0x44b970;
+    };
+    return a0_0x523b();
+  }
+  function a0_0xa64da6(_0x183929) {
+    const _0x5effed = new Error(_0x183929);
+    _0x5effed.name = _0x183929;
+    return _0x5effed;
+  }
+  const a0_0x4e6708 = () => {
+    try {
+      const _0x2b5a87 = [{
+        's': "Windows 10",
+        'r': /(Windows 10.0|Windows NT 10.0)/
+      }, {
+        's': "Windows 8.1",
+        'r': /(Windows 8.1|Windows NT 6.3)/
+      }, {
+        's': "Windows 8",
+        'r': /(Windows 8|Windows NT 6.2)/
+      }, {
+        's': "Windows 7",
+        'r': /(Windows 7|Windows NT 6.1)/
+      }, {
+        's': "Windows Vista",
+        'r': /Windows NT 6.0/
+      }, {
+        's': "Windows Server 2003",
+        'r': /Windows NT 5.2/
+      }, {
+        's': "Windows XP",
+        'r': /(Windows NT 5.1|Windows XP)/
+      }, {
+        's': "Windows 2000",
+        'r': /(Windows NT 5.0|Windows 2000)/
+      }, {
+        's': "Windows ME",
+        'r': /(Win 9x 4.90|Windows ME)/
+      }, {
+        's': "Windows 98",
+        'r': /(Windows 98|Win98)/
+      }, {
+        's': "Windows 95",
+        'r': /(Windows 95|Win95|Windows_95)/
+      }, {
+        's': "Windows NT 4.0",
+        'r': /(Windows NT 4.0|WinNT4.0|WinNT|Windows NT)/
+      }, {
+        's': "Windows CE",
+        'r': /Windows CE/
+      }, {
+        's': "Windows 3.11",
+        'r': /Win16/
+      }, {
+        's': "Android",
+        'r': /Android/
+      }, {
+        's': "Open BSD",
+        'r': /OpenBSD/
+      }, {
+        's': "Sun OS",
+        'r': /SunOS/
+      }, {
+        's': "Chrome OS",
+        'r': /CrOS/
+      }, {
+        's': 'Linux',
+        'r': /(Linux|X11(?!.*CrOS))/
+      }, {
+        's': 'iOS',
+        'r': /(iPhone|iPad|iPod)/
+      }, {
+        's': "Mac OS X",
+        'r': /Mac OS X/
+      }, {
+        's': "Mac OS",
+        'r': /(Mac OS|MacPPC|MacIntel|Mac_PowerPC|Macintosh)/
+      }, {
+        's': "QNX",
+        'r': /QNX/
+      }, {
+        's': 'UNIX',
+        'r': /UNIX/
+      }, {
+        's': "BeOS",
+        'r': /BeOS/
+      }, {
+        's': "OS/2",
+        'r': /OS\/2/
+      }, {
+        's': "Search Bot",
+        'r': /(nuhk|Googlebot|Yammybot|Openbot|Slurp|MSNBot|Ask Jeeves\/Teoma|ia_archiver)/
+      }];
+      let _0x431bc9;
+      let _0x3aae3b = _0x2b5a87.filter((_0x2f445b) => _0x2f445b.r.test(navigator.userAgent))[0].s;
+      if (/Windows/.test(_0x3aae3b)) {
+        _0x431bc9 = /Windows (.*)/.exec(_0x3aae3b)[1];
+        _0x3aae3b = "Windows";
+      }
+      switch (_0x3aae3b) {
+        case "Mac OS":
+        case "Mac OS X":
+        case "Android":
+          _0x431bc9 = /(?:Android|Mac OS|Mac OS X|MacPPC|MacIntel|Mac_PowerPC|Macintosh) ([._\d]+)/.exec(navigator.userAgent)[1];
+          break;
+        case 'iOS':
+          _0x431bc9 = /OS (\d+)_(\d+)_?(\d+)?/.exec(navigator.appVersion);
+          _0x431bc9 = _0x431bc9[1] + '.' + _0x431bc9[2] + '.' + (_0x431bc9[3] | 0);
+          break;
+      }
+      return {
+        'name': _0x3aae3b,
+        'version': _0x431bc9
+      };
+    } catch (_0x2d1b46) {
+      return {
+        'name': "Unknown",
+        'version': "Unknown"
+      };
+    }
+  };
+  const a0_0x30264b = () => {
+    try {
+      const _0x45702c = navigator.userAgent;
+      const _0x10ca82 = [{
+        'name': 'Opera',
+        'getInfo': (_0x1abfa9) => {
+          if (_0x45702c.indexOf("Version") !== -1) {
+            return {
+              'name': "Opera",
+              'version': _0x45702c.substring(_0x1abfa9 + 8)
+            };
+          }
+          return {
+            'name': 'Opera',
+            'version': _0x45702c.substring(_0x1abfa9 + 6)
+          };
+        }
+      }, {
+        'name': "OPR",
+        'getInfo': (_0x57924d) => {
+          return {
+            'name': "Opera",
+            'version': _0x45702c.substring(_0x57924d + 4)
+          };
+        }
+      }, {
+        'name': "Edge",
+        'getInfo': (_0x377b51) => {
+          return {
+            'name': 'Edge',
+            'version': _0x45702c.substring(_0x377b51 + 5)
+          };
+        }
+      }, {
+        'name': "Edg",
+        'getInfo': (_0x18d6cd) => {
+          return {
+            'name': 'Edge',
+            'version': _0x45702c.substring(_0x18d6cd + 4)
+          };
+        }
+      }, {
+        'name': "MSIE",
+        'getInfo': (_0x4e1e1c) => {
+          return {
+            'name': "Internet Explorer",
+            'version': _0x45702c.substring(_0x4e1e1c + 5)
+          };
+        }
+      }, {
+        'name': 'Chrome',
+        'getInfo': (_0x50885f) => {
+          return {
+            'name': "Chrome",
+            'version': _0x45702c.substring(_0x50885f + 7)
+          };
+        }
+      }, {
+        'name': "Safari",
+        'getInfo': (_0xe241b2) => {
+          const _0x59634 = _0x45702c.indexOf('Version');
+          if (_0x59634 !== -1) {
+            return {
+              'name': "Safari",
+              'version': _0x45702c.substring(_0xe241b2 + 8)
+            };
+          }
+          return {
+            'name': 'Safari',
+            'version': _0x45702c.substring(_0xe241b2 + 7)
+          };
+        }
+      }, {
+        'name': "Firefox",
+        'getInfo': (_0x33e875) => {
+          return {
+            'name': "Firefox",
+            'version': _0x45702c.substring(_0x33e875 + 8)
+          };
+        }
+      }, {
+        'name': "Trident/",
+        'getInfo': () => {
+          return {
+            'name': "Internet Explorer",
+            'version': _0x45702c.substring(_0x45702c.indexOf("rv:") + 3)
+          };
+        }
+      }];
+      return _0x10ca82.filter(({
+        name: _0x17afe9
+      }) => _0x45702c.indexOf(_0x17afe9) !== -1).map(({
+        getInfo: _0x496913,
+        name: _0xd024ec
+      }) => _0x496913(_0x45702c.indexOf(_0xd024ec)))[0];
+    } catch (_0x568151) {
+      return {
+        'name': "Unknown",
+        'version': 'Unknown'
+      };
+    }
+  };
+  const a0_0x7c0a6d = () => {
+    try {
+      const _0x410873 = document.createElement("canvas");
+      const _0x1e8a58 = _0x410873.getContext('2d');
+      const _0x1201a8 = "i9asdm..$#po((^@KbXrww!~cz";
+      _0x1e8a58.textBaseline = "top";
+      _0x1e8a58.font = "16px 'Arial'";
+      _0x1e8a58.textBaseline = 'alphabetic';
+      _0x1e8a58.rotate(0.05);
+      _0x1e8a58.fillStyle = '#f60';
+      _0x1e8a58.fillRect(125, 1, 62, 20);
+      _0x1e8a58.fillStyle = '#069';
+      _0x1e8a58.fillText(_0x1201a8, 2, 15);
+      _0x1e8a58.fillStyle = "rgba(102, 200, 0, 0.7)";
+      _0x1e8a58.fillText(_0x1201a8, 4, 17);
+      _0x1e8a58.shadowBlur = 10;
+      _0x1e8a58.shadowColor = "blue";
+      _0x1e8a58.fillRect(-20, 10, 234, 5);
+      const _0x4320ff = _0x410873.toDataURL();
+      let _0x51a40b = 0;
+      if (_0x4320ff.length === 0) {
+        return "nothing!";
+      }
+      for (let _0x2fcd0b = 0; _0x2fcd0b < _0x4320ff.length; _0x2fcd0b++) {
+        const _0x5da47e = _0x4320ff.charCodeAt(_0x2fcd0b);
+        _0x51a40b = (_0x51a40b << 5) - _0x51a40b + _0x5da47e;
+        _0x51a40b = _0x51a40b & _0x51a40b;
+      }
+      return _0x51a40b;
+    } catch (_0x542754) {
+      return -1;
+    }
+  };
+  const a0_0x15b107 = () => {
+    try {
+      const _0xfed1a9 = document.createElement("canvas");
+      _0xfed1a9.width = 256;
+      _0xfed1a9.height = 128;
+      const _0x2f53c7 = _0xfed1a9.getContext('webgl2') || _0xfed1a9.getContext("experimental-webgl2") || _0xfed1a9.getContext("webgl") || _0xfed1a9.getContext("experimental-webgl") || _0xfed1a9.getContext("moz-webgl");
+      try {
+        const _0x5e8a76 = "attribute vec2 attrVertex;varying vec2 varyinTexCoordinate;uniform vec2 uniformOffset;void main(){varyinTexCoordinate=attrVertex+uniformOffset;gl_Position=vec4(attrVertex,0,1);}";
+        const _0x573ca1 = "precision mediump float;varying vec2 varyinTexCoordinate;void main() {gl_FragColor=vec4(varyinTexCoordinate,0,1);}";
+        const _0x395e7d = _0x2f53c7.createBuffer();
+        _0x2f53c7.bindBuffer(_0x2f53c7.ARRAY_BUFFER, _0x395e7d);
+        const _0x5be340 = new Float32Array([-0.2, -0.9, 0, 0.4, -0.26, 0, 0, 0.7321, 0]);
+        _0x2f53c7.bufferData(_0x2f53c7.ARRAY_BUFFER, _0x5be340, _0x2f53c7.STATIC_DRAW);
+        _0x395e7d.itemSize = 3;
+        _0x395e7d.numItems = 3;
+        const _0x39f675 = _0x2f53c7.createProgram();
+        const _0x4cb72f = _0x2f53c7.createShader(_0x2f53c7.VERTEX_SHADER);
+        _0x2f53c7.shaderSource(_0x4cb72f, _0x5e8a76);
+        _0x2f53c7.compileShader(_0x4cb72f);
+        const _0x8457fc = _0x2f53c7.createShader(_0x2f53c7.FRAGMENT_SHADER);
+        _0x2f53c7.shaderSource(_0x8457fc, _0x573ca1);
+        _0x2f53c7.compileShader(_0x8457fc);
+        _0x2f53c7.attachShader(_0x39f675, _0x4cb72f);
+        _0x2f53c7.attachShader(_0x39f675, _0x8457fc);
+        _0x2f53c7.linkProgram(_0x39f675);
+        _0x2f53c7.useProgram(_0x39f675);
+        _0x39f675.vertexPosAttrib = _0x2f53c7.getAttribLocation(_0x39f675, "attrVertex");
+        _0x39f675.offsetUniform = _0x2f53c7.getUniformLocation(_0x39f675, "uniformOffset");
+        _0x2f53c7.enableVertexAttribArray(_0x39f675.vertexPosArray);
+        _0x2f53c7.vertexAttribPointer(_0x39f675.vertexPosAttrib, _0x395e7d.itemSize, _0x2f53c7.FLOAT, false, 0, 0);
+        _0x2f53c7.uniform2f(_0x39f675.offsetUniform, 1, 1);
+        _0x2f53c7.drawArrays(_0x2f53c7.TRIANGLE_STRIP, 0, _0x395e7d.numItems);
+      } catch (_0x525d28) {}
+      const _0x140cd3 = new Uint8Array(131072);
+      _0x2f53c7.readPixels(0, 0, 256, 128, _0x2f53c7.RGBA, _0x2f53c7.UNSIGNED_BYTE, _0x140cd3);
+      let _0x42d6ed = JSON.stringify(_0x140cd3).replace(/,?"[0-9]+":/g, '');
+      return a0_0x4cca20(_0x42d6ed);
+    } catch (_0x376a11) {
+      return '-1';
+    }
+  };
+  const a0_0x4cca20 = function () {
+    let _0x5c7aa6 = 1;
+    let _0xdcba9e;
+    let _0x243e02 = [];
+    let _0x3c62d = [];
+    while (++_0x5c7aa6 < 18) {
+      for (_0xdcba9e = _0x5c7aa6 * _0x5c7aa6; _0xdcba9e < 312; _0xdcba9e += _0x5c7aa6) {
+        _0x243e02[_0xdcba9e] = 1;
+      }
+    }
+    _0x5c7aa6 = 1;
+    for (_0xdcba9e = 0; _0x5c7aa6 < 313;) {
+      if (!_0x243e02[++_0x5c7aa6]) {
+        _0x3c62d[_0xdcba9e] = Math.pow(_0x5c7aa6, 0.5) % 1 * 0x100000000 | 0;
+        _0x243e02[_0xdcba9e++] = Math.pow(_0x5c7aa6, 0.3333333333333333) % 1 * 0x100000000 | 0;
+      }
+    }
+    function _0x26fabf(_0x29e806) {
+      let _0x21385f = _0x3c62d.slice(_0x5c7aa6 = 0);
+      let _0x54a3b4 = unescape(encodeURI(_0x29e806));
+      let _0x79cccb = [];
+      let _0x520e11 = _0x54a3b4.length;
+      let _0x314c37 = [];
+      let _0x356348;
+      let _0x40e898;
+      let _0x249974;
+      for (; _0x5c7aa6 < _0x520e11;) {
+        _0x314c37[_0x5c7aa6 >> 2] |= (_0x54a3b4.charCodeAt(_0x5c7aa6) & 255) << 8 * (3 - _0x5c7aa6++ % 4);
+      }
+      _0x520e11 *= 8;
+      _0x314c37[_0x520e11 >> 5] |= 128 << 24 - _0x520e11 % 32;
+      _0x314c37[_0x249974 = _0x520e11 + 64 >> 5 | 15] = _0x520e11;
+      for (_0x5c7aa6 = 0; _0x5c7aa6 < _0x249974; _0x5c7aa6 += 16) {
+        _0x356348 = _0x21385f.slice(_0xdcba9e = 0, 8);
+        for (; _0xdcba9e < 64; _0x356348[4] += _0x40e898) {
+          if (_0xdcba9e < 16) {
+            _0x79cccb[_0xdcba9e] = _0x314c37[_0xdcba9e + _0x5c7aa6];
+          } else {
+            _0x79cccb[_0xdcba9e] = (((_0x40e898 = _0x79cccb[_0xdcba9e - 2]) >>> 17 | (_0x40e898 = _0x79cccb[_0xdcba9e - 2]) << 15) ^ (_0x40e898 >>> 19 | _0x40e898 << 13) ^ _0x40e898 >>> 10) + (_0x79cccb[_0xdcba9e - 7] | 0) + (((_0x40e898 = _0x79cccb[_0xdcba9e - 15]) >>> 7 | (_0x40e898 = _0x79cccb[_0xdcba9e - 15]) << 25) ^ (_0x40e898 >>> 18 | _0x40e898 << 14) ^ _0x40e898 >>> 3) + (_0x79cccb[_0xdcba9e - 16] | 0);
+          }
+          _0x356348.unshift((_0x40e898 = (_0x356348.pop() + (((_0x29e806 = _0x356348[4]) >>> 6 | (_0x29e806 = _0x356348[4]) << 26) ^ (_0x29e806 >>> 11 | _0x29e806 << 21) ^ (_0x29e806 >>> 25 | _0x29e806 << 7)) + ((_0x29e806 & _0x356348[5] ^ ~_0x29e806 & _0x356348[6]) + _0x243e02[_0xdcba9e]) | 0) + (_0x79cccb[_0xdcba9e++] | 0)) + (((_0x520e11 = _0x356348[0]) >>> 2 | (_0x520e11 = _0x356348[0]) << 30) ^ (_0x520e11 >>> 13 | _0x520e11 << 19) ^ (_0x520e11 >>> 22 | _0x520e11 << 10)) + (_0x520e11 & _0x356348[1] ^ _0x356348[1] & _0x356348[2] ^ _0x356348[2] & _0x520e11));
+        }
+        for (_0xdcba9e = 8; _0xdcba9e--;) {
+          _0x21385f[_0xdcba9e] = _0x356348[_0xdcba9e] + _0x21385f[_0xdcba9e];
+        }
+      }
+      for (_0x54a3b4 = ''; _0xdcba9e < 63;) {
+        _0x54a3b4 += (_0x21385f[++_0xdcba9e >> 3] >> 4 * (7 - _0xdcba9e % 8) & 15).toString(16);
+      }
+      return _0x54a3b4;
+    }
+    return _0x26fabf;
+  }();
+  const a0_0x17e3c0 = () => new Promise(async (_0x249326) => {
+    let _0x188ac1 = setTimeout(() => _0x249326([]), 200);
+    const _0x33794a = await navigator.mediaDevices.enumerateDevices();
+    clearTimeout(_0x188ac1);
+    let _0x54cb45 = _0x33794a.map((_0x1ef15c) => _0x1ef15c.kind).sort();
+    _0x249326(_0x54cb45);
+  })["catch"]((_0x5db521) => []);
+  const a0_0x2a1bb9 = () => {
+    const _0x2ddbe7 = ["audio/aac", "audio/flac", "audio/mpeg", "audio/mp4; codecs=\"mp4a.40.2\"", "audio/ogg; codecs=\"flac\"", "audio/ogg; codecs=\"vorbis\"", "audio/ogg; codecs=\"opus\"", "audio/wav; codecs=\"1\"", "audio/webm; codecs=\"vorbis\"", "audio/webm; codecs=\"opus\""];
+    try {
+      const _0x1dd4d3 = document.createElement("audio");
+      return _0x2ddbe7.map((_0x4e2f0c) => {
+        return {
+          'type': _0x4e2f0c,
+          'canPlay': _0x1dd4d3.canPlayType(_0x4e2f0c)
+        };
+      });
+    } catch (_0x384817) {
+      return _0x2ddbe7.map((_0x469d20) => {
+        return {
+          'type': _0x469d20,
+          'canPlay': "no info"
+        };
+      });
+    }
+  };
+  const a0_0x43e953 = () => {
+    const _0x4ae132 = ["video/ogg; codecs=\"theora\"", "video/ogg; codecs=\"opus\"", "video/mp4; codecs=\"avc1.42E01E\"", "video/mp4; codecs=\"flac\"", "video/webm; codecs=\"vp8, vorbis\"", "video/webm; codecs=\"vp9\"", "application/x-mpegURL; codecs=\"avc1.42E01E\""];
+    try {
+      const _0x54d647 = document.createElement("video");
+      return _0x4ae132.map((_0x160c8b) => {
+        return {
+          'type': _0x160c8b,
+          'canPlay': _0x54d647.canPlayType(_0x160c8b)
+        };
+      });
+    } catch (_0x256174) {
+      return _0x4ae132.map((_0x179c7b) => {
+        return {
+          'type': _0x179c7b,
+          'canPlay': "no info"
+        };
+      });
+    }
+  };
+  const a0_0x442d1e = async () => {
+    try {
+      const _0x6ba7d = ["accelerometer", "camera", "clipboard-read", "clipboard-write", "geolocation", "background-sync", "magnetometer", "microphone", "midi", "notifications", 'payment-handler', 'persistent-storage'];
+      const _0x52e12e = {};
+      await Promise.all(_0x6ba7d.map(async (_0x25cdc4) => {
+        try {
+          const {
+            state: _0x1d756d
+          } = await navigator.permissions.query({
+            'name': _0x25cdc4
+          });
+          _0x52e12e[_0x25cdc4] = _0x1d756d;
+        } catch (_0x66fc8a) {}
+      }));
+      return _0x52e12e;
+    } catch (_0x27ff91) {
+      return {};
+    }
+  };
+  const a0_0xf57689 = () => {
+    try {
+      const _0x3128fb = document.createElement("canvas");
+      const _0x55d1b7 = _0x3128fb.getContext("webgl") || _0x3128fb.getContext("experimental-webgl");
+      const _0x1f550a = _0x55d1b7.getExtension("WEBGL_debug_renderer_info");
+      return {
+        'vendor': _0x55d1b7.getParameter(_0x1f550a.UNMASKED_VENDOR_WEBGL),
+        'renderer': _0x55d1b7.getParameter(_0x1f550a.UNMASKED_RENDERER_WEBGL),
+        'extensions': _0x55d1b7.getSupportedExtensions()
+      };
+    } catch (_0x9d7f0a) {
+      return {
+        'vendor': "Unknown",
+        'renderer': "Unknown",
+        'extensions': []
+      };
+    }
+  };
+  const a0_0x4a5c36 = () => {
+    try {
+      const _0x4f2845 = new AudioContext();
+      return {
+        'state': _0x4f2845.state,
+        'sampleRate': _0x4f2845.sampleRate,
+        'channelCount': _0x4f2845.destination.channelCount,
+        'channelCountMode': _0x4f2845.destination.channelCountMode,
+        'channelInterpretation': _0x4f2845.destination.channelInterpretation,
+        'maxChannelCount': _0x4f2845.destination.maxChannelCount,
+        'numberOfInputs': _0x4f2845.destination.numberOfInputs,
+        'numberOfOutputs': _0x4f2845.destination.numberOfOutputs
+      };
+    } catch (_0x34a4c) {
+      return {};
+    }
+  };
+  const a0_0x1a0c3b = () => {
+    const _0x52997d = document.getElementsByTagName("body")[0];
+    const _0x42656c = document.createElement("div");
+    let _0x4dd178 = document.createDocumentFragment();
+    const _0x5e3149 = ['monospace', "sans-serif", "serif"];
+    const _0x2de7eb = {
+      'monospace': {},
+      'sans-serif': {},
+      'serif': {}
+    };
+    const _0xfd241c = "fp-div-check-runtime-0.0.1";
+    const _0x107aaf = {};
+    const _0x44dacf = {};
+    _0x42656c.id = _0xfd241c;
+    _0x52997d.appendChild(_0x42656c);
+    _0x5e3149.forEach((_0x36caf2, _0xb5c288) => {
+      const _0x414fef = document.createElement('span');
+      _0x414fef.style.fontSize = '72px';
+      _0x414fef.innerHTML = "mmmmmmmmmmlli";
+      _0x414fef.style.fontFamily = _0x5e3149[_0xb5c288];
+      _0x414fef.style.position = "fixed";
+      _0x414fef.style.visibility = "hidden";
+      _0x414fef.classList.add('fp-check-runtime-0.0.1');
+      _0x4dd178.appendChild(_0x414fef);
+    });
+    a0_0x5dea54.forEach((_0x41683f) => {
+      _0x5e3149.forEach((_0x3cd2f9) => {
+        const _0xbc6861 = document.createElement("span");
+        _0xbc6861.style.fontSize = "72px";
+        _0xbc6861.innerHTML = "mmmmmmmmmmlli";
+        _0xbc6861.style.fontFamily = _0x41683f + ',' + _0x3cd2f9;
+        _0xbc6861.style.position = "fixed";
+        _0xbc6861.style.visibility = "hidden";
+        _0xbc6861.id = _0x41683f + '&' + _0x3cd2f9;
+        _0xbc6861.classList.add('fp-check-runtime-0.0.1');
+        _0x4dd178.appendChild(_0xbc6861);
+      });
+    });
+    _0x42656c.appendChild(_0x4dd178);
+    const _0x346f1e = _0x42656c.children;
+    _0x5e3149.forEach((_0x19d614, _0x187a30) => {
+      _0x107aaf[_0x5e3149[_0x187a30]] = _0x346f1e[_0x187a30].offsetWidth;
+      _0x44dacf[_0x5e3149[_0x187a30]] = _0x346f1e[_0x187a30].offsetHeight;
+    });
+    for (let _0x5cd8fa = 0; _0x5cd8fa < _0x346f1e.length; _0x5cd8fa++) {
+      const [_0x28f025, _0x2bc3a3] = _0x346f1e[_0x5cd8fa].id.split('&');
+      if (_0x2bc3a3) {
+        _0x2de7eb[_0x2bc3a3][_0x28f025] = _0x346f1e[_0x5cd8fa];
+      }
+    }
+    const _0x57088d = [];
+    for (let _0x4000ae = 0; _0x4000ae < a0_0x5dea54.length; _0x4000ae++) {
+      for (let _0x4e8f44 = 0; _0x4e8f44 < _0x5e3149.length; _0x4e8f44++) {
+        let _0x4417b3 = false;
+        let _0x312186 = _0x2de7eb[_0x5e3149[_0x4e8f44]][a0_0x5dea54[_0x4000ae]];
+        const _0x293d0b = _0x312186.offsetWidth !== _0x107aaf[_0x5e3149[_0x4e8f44]] || _0x312186.offsetHeight !== _0x44dacf[_0x5e3149[_0x4e8f44]];
+        _0x4417b3 = _0x4417b3 || _0x293d0b;
+        if (_0x4417b3) {
+          _0x57088d.push(a0_0x5dea54[_0x4000ae]);
+          break;
+        }
+      }
+    }
+    document.getElementById(_0xfd241c).remove();
+    return _0x57088d;
+  };
+  const a0_0xb71442 = () => {
+    try {
+      const _0x42ff32 = [];
+      for (let _0x131988 = 0; _0x131988 < navigator.plugins.length; _0x131988++) {
+        _0x42ff32.push(navigator.plugins[_0x131988].name);
+      }
+      return _0x42ff32;
+    } catch (_0x5e9c05) {
+      return [];
+    }
+  };
+  const a0_0x3b19c7 = () => {
+    let _0x59f465 = 0;
+    try {
+      if (navigator.webdriver === true) {
+        _0x59f465 |= 1;
+      }
+      if (!window.chrome && !/Firefox/.test(navigator.userAgent) && /Chrome/.test(navigator.userAgent)) {
+        _0x59f465 |= 2;
+      }
+      try {
+        if (navigator.permissions) {
+          const _0x77609c = Notification.permission;
+          if (_0x77609c === "denied" && !document.hidden) {
+            _0x59f465 |= 4;
+          }
+        }
+      } catch (_0x1b2f2b) {}
+      if (window.cdc_adoQpoasnfa76pfcZLmcfl_Array || window.cdc_adoQpoasnfa76pfcZLmcfl_Promise || window.cdc_adoQpoasnfa76pfcZLmcfl_Symbol || document.documentElement.getAttribute("cdc_adoQpoasnfa76pfcZLmcfl_")) {
+        _0x59f465 |= 8;
+      }
+      if (window.callPhantom || window._phantom || window.phantom) {
+        _0x59f465 |= 16;
+      }
+      if (window.$cdc_asdjflasutopfhvcZLmcfl_ || window.$wdc_ || window.__webdriver_script_fn || document.$cdc_asdjflasutopfhvcZLmcfl_ || document.__webdriver_evaluate || document.__selenium_evaluate || document.__webdriver_script_function || document.__webdriver_script_func || document.__webdriver_script_fn || document.__fxdriver_evaluate || document.__driver_unwrapped || document.__webdriver_unwrapped || document.__driver_evaluate || document.__selenium_unwrapped || document.__fxdriver_unwrapped) {
+        _0x59f465 |= 32;
+      }
+      if (navigator.webdriver || window.__puppeteer_evaluation_script__ || window.domAutomation || window.domAutomationController) {
+        _0x59f465 |= 64;
+      }
+      if (window.__playwright || window.__pw_manual || window.__PW_inspect) {
+        _0x59f465 |= 128;
+      }
+      if (document.hidden && document.visibilityState === "hidden") {
+        _0x59f465 |= 256;
+      }
+      if (window.outerWidth === 0 || window.outerHeight === 0) {
+        _0x59f465 |= 512;
+      }
+      if (/HeadlessChrome/.test(navigator.userAgent)) {
+        _0x59f465 |= 1024;
+      }
+      if (!navigator.languages || navigator.languages.length === 0) {
+        _0x59f465 |= 2048;
+      }
+      try {
+        const _0x303b9f = navigator.connection || navigator.mozConnection || navigator.webkitConnection;
+        if (_0x303b9f && _0x303b9f.type === 'none' && !_0x303b9f.effectiveType) {
+          _0x59f465 |= 4096;
+        }
+      } catch (_0x3dc6c8) {}
+      try {
+        const _0x29d921 = navigator.plugins;
+        if (_0x29d921.length === 0 && /Chrome/.test(navigator.userAgent)) {
+          _0x59f465 |= 8192;
+        }
+        if (_0x29d921.length > 0 && !(_0x29d921[0] instanceof Plugin)) {
+          _0x59f465 |= 8192;
+        }
+      } catch (_0x5671ee) {}
+      try {
+        if (Notification.permission === "denied" && !localStorage.getItem("notification_prompted")) {
+          _0x59f465 |= 16384;
+        }
+      } catch (_0xfd6ce2) {}
+      try {
+        const _0x4a61a4 = new Error().stack;
+        if (_0x4a61a4 && (_0x4a61a4.includes("puppeteer") || _0x4a61a4.includes("playwright") || _0x4a61a4.includes("selenium") || _0x4a61a4.includes("webdriver"))) {
+          _0x59f465 |= 32768;
+        }
+      } catch (_0x22eb5d) {}
+      if (typeof qt !== 'undefined' || typeof QWebChannel !== 'undefined' || window.qt && window.qt.webChannelTransport || typeof callbackHandler !== "undefined") {
+        _0x59f465 |= 65536;
+      }
+      try {
+        const _0x1c420e = !!window.chrome;
+        const _0x1a2ac3 = !!(window.chrome && window.chrome.runtime);
+        const _0x3e0a60 = !!(window.chrome && window.chrome.loadTimes);
+        const _0x1b6165 = !!(window.chrome && window.chrome.csi);
+        if (_0x1c420e && !_0x1a2ac3 && !_0x3e0a60 && !_0x1b6165) {
+          _0x59f465 |= 131072;
+        }
+        if (!_0x1c420e && /Chrome/.test(navigator.userAgent) && !/Chromium/.test(navigator.userAgent)) {
+          _0x59f465 |= 131072;
+        }
+      } catch (_0x170dad) {}
+    } catch (_0x2beceb) {
+      return -1;
+    }
+    return _0x59f465;
+  };
+  const a0_0x4c1453 = (_0x35b012) => {
+    return new Array(_0x35b012).fill(0).map(() => Math.random().toString(36).substr(2, 9)).reduce((_0x27b1e8, _0x59e099) => _0x27b1e8 + _0x59e099, '');
+  };
+  const a0_0x385393 = async () => {
+    const _0x242fb1 = await Promise.all([a0_0x442d1e(), a0_0x17e3c0(), a0_0x4b1572()]);
+    const _0x3a3483 = a0_0x30264b();
+    const _0x1f0b0c = a0_0x4e6708();
+    const _0x3668f3 = a0_0xf57689();
+    const _0x1d0eda = a0_0x4cca20(JSON.stringify(a0_0x1a0c3b()));
+    const _0x141f60 = a0_0x15b107();
+    const _0x4b575c = a0_0x7c0a6d();
+    return {
+      'dg': 12,
+      'dO4': Intl.DateTimeFormat().resolvedOptions().timeZone,
+      'b-I2rx-E': _0x1f0b0c.name,
+      'YdFB': _0x3a3483.name,
+      'dttJrRyO': navigator.vendor,
+      'bdI_': navigator.deviceMemory || 0,
+      'Y9JA': navigator.hardwareConcurrency || 0,
+      'bM07og': navigator.languages.join(','),
+      'cNxRuCGPAg': a0_0x4cca20(JSON.stringify(a0_0xb71442())),
+      'Z9dM': _0x3668f3.vendor + ',' + _0x3668f3.renderer,
+      'ZtVDtyo': _0x1d0eda,
+      'YdY6oxJV': a0_0x4cca20(JSON.stringify(a0_0x4a5c36())),
+      'b-I4nQ-C61rI': _0x1f0b0c.version,
+      'd-BEuCA': window.screen.availWidth,
+      'aM02nQV5': window.screen.availHeight,
+      'bL8zohR5': Boolean(localStorage),
+      'c8Y6qRuA': Boolean(sessionStorage),
+      'dt9DqBc': a0_0x4cca20(JSON.stringify(a0_0x43e953())),
+      'YdY6oxI': a0_0x4cca20(JSON.stringify(a0_0x2a1bb9())),
+      'bdI2nwA': a0_0x4cca20(JSON.stringify(_0x242fb1[1])),
+      'cNVHtB2QA2zbSbw': a0_0x4cca20(JSON.stringify(_0x242fb1[0])),
+      'YdY6oxJYqA': _0x242fb1[2],
+      'd9w-pRFXpw': _0x141f60,
+      'Y8QyqAl8whI': _0x4b575c,
+      'YtFF': a0_0x3b19c7()
+    };
+  };
+  function a0_0x300792(_0x1741a5) {
+    let _0x228b43 = [];
+    a0_0x53802e.forEach((_0x152215) => {
+      _0x228b43.push(_0x1741a5[_0x152215]);
+      delete _0x1741a5[_0x152215];
+    });
+    return _0x228b43;
+  }
+  function a0_0x2aa6eb(_0x506616) {
+    const _0xc9c158 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_=".split('');
+    const _0x59b200 = function (_0x4afe94) {
+      let _0x4904fd = '';
+      const _0x237419 = _0x4afe94.length % 3;
+      for (let _0x24fe7c = 0; _0x24fe7c < _0x4afe94.length;) {
+        const _0x4ea2f6 = _0x4afe94.charCodeAt(_0x24fe7c++);
+        const _0x341730 = _0x4afe94.charCodeAt(_0x24fe7c++);
+        const _0x14e1f6 = _0x4afe94.charCodeAt(_0x24fe7c++);
+        if (_0x4ea2f6 > 255 || _0x341730 > 255 || _0x14e1f6 > 255) {
+          throw new Error("Input not valid");
+        }
+        const _0x14f7d6 = _0x4ea2f6 << 16 | _0x341730 << 8 | _0x14e1f6;
+        _0x4904fd += _0xc9c158[_0x14f7d6 >> 18 & 63] + _0xc9c158[_0x14f7d6 >> 12 & 63] + _0xc9c158[_0x14f7d6 >> 6 & 63] + _0xc9c158[_0x14f7d6 & 63];
+      }
+      return _0x237419 > 0 ? _0x4904fd.slice(0, _0x237419 - 3) : _0x4904fd;
+    };
+    _0x506616 = encodeURIComponent(_0x506616);
+    let _0x343230 = _0x506616[0];
+    for (let _0x3203e6 = 1; _0x3203e6 < _0x506616.length; ++_0x3203e6) {
+      _0x343230 += String.fromCharCode((_0x343230.charCodeAt(_0x3203e6 - 1) + _0x506616.charCodeAt(_0x3203e6)) % 256);
+    }
+    return _0x59b200(_0x343230);
+  }
+  var game1 = async function (_0x264b23, _0x4557cf = null) {
+    let _0x92dfe6 = new Date().getTime();
+    let _0x442419 = localStorage.getItem("x-game");
+    let _0xbf6dc4;
+    let _0x55cb6f;
+    try {
+      let _0x3166b4 = localStorage.getItem('x-vec');
+      let _0x1091a8 = _0x3166b4.lastIndexOf(" ");
+      _0xbf6dc4 = _0x3166b4.substr(0, _0x1091a8).split('');
+      _0x55cb6f = parseInt(_0x3166b4.substr(_0x1091a8 + 1));
+    } catch (_0x2d031e) {
+      _0xbf6dc4 = Array.from(Array(100), (_0x594a33) => String.fromCharCode(32 + Math.random() * 94 | 0));
+      _0x55cb6f = _0x92dfe6;
+    }
+    let _0x246e57 = _0xbf6dc4.join('') + " " + _0x55cb6f;
+    localStorage.setItem("x-vec", _0x246e57);
+    if (_0x55cb6f + 1000 < _0x92dfe6) {
+      _0xbf6dc4.shift();
+      _0xbf6dc4.push(String.fromCharCode(32 + Math.random() * 94 | 0));
+      _0x246e57 = _0xbf6dc4.join('') + " " + _0x92dfe6;
+      localStorage.setItem("x-vec", _0x246e57);
+    }
+    if (!_0x442419) {
+      _0x442419 = a0_0x4c1453(3);
+      localStorage.setItem("x-game", _0x442419);
+    }
+    let _0xc978de = await a0_0x385393();
+    _0xc978de.Y9U6mw9451U = new Date().toISOString();
+    _0xc978de.depTtw = _0x442419;
+    _0xc978de['dts-siGT'] = window.btoa(_0x246e57);
+    _0xc978de.ZA = new Date().getTime() - _0x92dfe6;
+    async function _0x20e0b3() {
+      return new Promise((_0x387845, _0x147193) => {
+        const _0x398f31 = new XMLHttpRequest();
+        _0x398f31.onreadystatechange = function () {
+          if (_0x398f31.readyState === 4) {
+            if (_0x398f31.status === 200) {
+              _0x387845(new Date(_0x398f31.getResponseHeader("date")).toISOString());
+            } else {
+              const _0x598437 = new Date();
+              _0x598437.setDate(_0x598437.getDate() - 14);
+              _0x387845(_0x598437.toISOString());
+            }
+          }
+        };
+        _0x398f31.open("GET", 'https://gameforge.com/tra/game1.js', true);
+        _0x398f31.send();
+      });
+    }
+    _0xc978de.c9hKwCWX61TBJm_dKn0 = await _0x20e0b3();
+    _0xc978de.dehNvwBnzDqu = navigator.userAgent;
+    _0xc978de.ctdIvSKVCQ = _0x4557cf;
+    _0xc978de = a0_0x300792(_0xc978de);
+    let _0x33de64 = a0_0x2aa6eb(JSON.stringify(_0xc978de));
+    _0x264b23(_0x33de64);
+  };
+} catch (e) {
+  var game1 = function (cb) {
+    cb(btoa(JSON.stringify({
+      e: e.message,
+      uA: navigator.userAgent
+    })));
+  };
+}
+;

--- a/deobfuscator/package-lock.json
+++ b/deobfuscator/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@babel/generator": "^7.29.2",
         "@babel/parser": "^7.29.2",
         "@babel/traverse": "^7.29.0",
         "@babel/types": "^7.29.0",
@@ -81,13 +82,13 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -152,18 +153,18 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -192,12 +193,12 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -239,13 +240,13 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"


### PR DESCRIPTION
### Changes

- **CI workflow**: Added a new step in `archive-game1.yml` that runs the deobfuscator pipeline after archiving a new `game1.js`, producing `game1.js.deobfuscated.js` automatically.
- **Missing deobfuscated variants**: Generated `game1.js.deobfuscated.js` for 6 archived versions that were missing it (2026-04-30, 2026-05-08, 2026-05-13, 2026-05-20, 2026-06-24, 2026-07-01).

Now every archive folder contains both the original obfuscated script and its deobfuscated counterpart.