### PR TITLE
Add rename-identifiers step with keyword-based function/variable renaming

### DIFF
--- a/archived_game1_scripts/2025-12-24T122655/game1.js.deobfuscated.js
+++ b/archived_game1_scripts/2025-12-24T122655/game1.js.deobfuscated.js
@@ -1045,7 +1045,7 @@ try {
     'mry_KacstQurn': false,
     'ori1Uni': false
   });
-  const a0_0x490f4c = () => {
+  const getAudioFingerprint = () => {
     try {
       const _0x4037ce = window.OfflineAudioContext || window.webkitOfflineAudioContext;
       if (!_0x4037ce) {
@@ -1137,7 +1137,7 @@ try {
     _0x2783dc.name = _0x2d7c85;
     return _0x2783dc;
   }
-  const a0_0x446b2c = () => {
+  const detectOS = () => {
     try {
       const _0xd2add = [{
         's': "Windows 10",
@@ -1249,7 +1249,7 @@ try {
       };
     }
   };
-  const a0_0x113132 = () => {
+  const detectBrowser = () => {
     try {
       const _0x445047 = navigator.userAgent;
       const _0x5c211b = [{
@@ -1351,7 +1351,7 @@ try {
       };
     }
   };
-  const a0_0xff1786 = () => {
+  const getCanvas2dFingerprint = () => {
     try {
       const _0x8b2480 = document.createElement('canvas');
       const _0x33fc47 = _0x8b2480.getContext('2d');
@@ -1383,7 +1383,7 @@ try {
       return -1;
     }
   };
-  const a0_0x4c772e = () => {
+  const getWebglCanvasFingerprint = () => {
     try {
       const _0x51f20e = document.createElement("canvas");
       _0x51f20e.width = 256;
@@ -1475,7 +1475,7 @@ try {
     }
     return _0x5e4b5a;
   }();
-  const a0_0x202bcd = () => new Promise(async _0x3918c0 => {
+  const enumerateMediaDevices = () => new Promise(async _0x3918c0 => {
     let _0x31f8fb = setTimeout(() => _0x3918c0([]), 200);
     const _0x58dac0 = await navigator.mediaDevices.enumerateDevices();
     clearTimeout(_0x31f8fb);
@@ -1574,7 +1574,7 @@ try {
       return {};
     }
   };
-  const a0_0x11508c = () => {
+  const detectFonts = () => {
     const _0x4b05b5 = document.getElementsByTagName("body")[0];
     const _0x597deb = document.createElement("div");
     let _0xc7d787 = document.createDocumentFragment();
@@ -1654,13 +1654,13 @@ try {
     return new Array(_0x593ccd).fill(0).map(() => Math.random().toString(36).substr(2, 9)).reduce((_0x3386ad, _0x3ca29b) => _0x3386ad + _0x3ca29b, '');
   };
   const a0_0x1548d0 = async () => {
-    const _0x43eca2 = await Promise.all([checkPermissions(), a0_0x202bcd(), a0_0x490f4c()]);
-    const _0x3b78d7 = a0_0x113132();
-    const _0x516cce = a0_0x446b2c();
+    const _0x43eca2 = await Promise.all([checkPermissions(), enumerateMediaDevices(), getAudioFingerprint()]);
+    const _0x3b78d7 = detectBrowser();
+    const _0x516cce = detectOS();
     const _0x74a6db = getWebglInfo();
-    const _0x515826 = a0_0x3f952b(JSON.stringify(a0_0x11508c()));
-    const _0x399205 = a0_0x4c772e();
-    const _0x5d8a8a = a0_0xff1786();
+    const _0x515826 = a0_0x3f952b(JSON.stringify(detectFonts()));
+    const _0x399205 = getWebglCanvasFingerprint();
+    const _0x5d8a8a = getCanvas2dFingerprint();
     return {
       'dg': 11,
       'dO4': Intl.DateTimeFormat().resolvedOptions().timeZone,
@@ -1696,7 +1696,7 @@ try {
     });
     return _0x21192b;
   }
-  function a0_0x46e4a7(_0x5645c0) {
+  function encodeFingerprintHash(_0x5645c0) {
     const _0x3e7367 = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_='.split('');
     const _0x3d0233 = function (_0x2efc28) {
       let _0x4963dc = '';
@@ -1773,7 +1773,7 @@ try {
     _0x2eb1b.dehNvwBnzDqu = navigator.userAgent;
     _0x2eb1b.ctdIvSKVCQ = _0x5a4e31;
     _0x2eb1b = a0_0x36288c(_0x2eb1b);
-    let _0x5c0eb3 = a0_0x46e4a7(JSON.stringify(_0x2eb1b));
+    let _0x5c0eb3 = encodeFingerprintHash(JSON.stringify(_0x2eb1b));
     _0x2ca7e0(_0x5c0eb3);
   };
 } catch (e) {

--- a/archived_game1_scripts/2025-12-24T122655/game1.js.deobfuscated.js
+++ b/archived_game1_scripts/2025-12-24T122655/game1.js.deobfuscated.js
@@ -1751,7 +1751,7 @@ try {
     _0x2eb1b.depTtw = _0x118783;
     _0x2eb1b["dts-siGT"] = window.btoa(_0x120081);
     _0x2eb1b.ZA = new Date().getTime() - _0x245690;
-    async function GAME1_URL() {
+    async function _0x5eadd5() {
       return new Promise((_0x2ec540, _0xee223a) => {
         const _0x3f0b61 = new XMLHttpRequest();
         _0x3f0b61.onreadystatechange = function () {
@@ -1769,7 +1769,7 @@ try {
         _0x3f0b61.send();
       });
     }
-    _0x2eb1b.c9hKwCWX61TBJm_dKn0 = await GAME1_URL();
+    _0x2eb1b.c9hKwCWX61TBJm_dKn0 = await _0x5eadd5();
     _0x2eb1b.dehNvwBnzDqu = navigator.userAgent;
     _0x2eb1b.ctdIvSKVCQ = _0x5a4e31;
     _0x2eb1b = a0_0x36288c(_0x2eb1b);

--- a/archived_game1_scripts/2025-12-24T122655/game1.js.deobfuscated.js
+++ b/archived_game1_scripts/2025-12-24T122655/game1.js.deobfuscated.js
@@ -1065,7 +1065,7 @@ try {
       _0x559877.connect(_0x59a540.destination);
       _0x5bf6cc.start(0);
       const [_0x4637d2, _0x2416f5] = a0_0x38556a(_0x59a540);
-      const _0x3c6fab = _0x4637d2.then((_0x5b727c) => a0_0x535e5a(_0x5b727c.getChannelData(0).subarray(4500)), (_0x67f374) => {
+      const _0x3c6fab = _0x4637d2.then(_0x5b727c => a0_0x535e5a(_0x5b727c.getChannelData(0).subarray(4500)), _0x67f374 => {
         if (_0x67f374.name === 'timeout' || _0x67f374.name === 'suspended') {
           return "timeout";
         }
@@ -1080,11 +1080,11 @@ try {
   };
   function a0_0x38556a(_0x3db5c0) {
     let _0x4fd103 = () => undefined;
-    const _0x560223 = new Promise((_0x347231, _0xa17208) => {
+    const renderAudioPromise = new Promise((_0x347231, _0xa17208) => {
       let _0x33cc7e = false;
       let _0x50639f = 0;
       let _0xccf4b5 = 0;
-      _0x3db5c0.oncomplete = (_0x6232ad) => _0x347231(_0x6232ad.renderedBuffer);
+      _0x3db5c0.oncomplete = _0x6232ad => _0x347231(_0x6232ad.renderedBuffer);
       const _0x23016f = () => {
         setTimeout(() => _0xa17208(a0_0x510773("timeout")), Math.min(500, _0xccf4b5 + 5000 - Date.now()));
       };
@@ -1123,7 +1123,7 @@ try {
         }
       };
     });
-    return [_0x560223, _0x4fd103];
+    return [renderAudioPromise, _0x4fd103];
   }
   function a0_0x535e5a(_0x2edb0a) {
     let _0x139fb6 = 0;
@@ -1222,7 +1222,7 @@ try {
         'r': /(nuhk|Googlebot|Yammybot|Openbot|Slurp|MSNBot|Ask Jeeves\/Teoma|ia_archiver)/
       }];
       let _0x467ee4;
-      let _0x18d907 = _0xd2add.filter((_0x21e314) => _0x21e314.r.test(navigator.userAgent))[0].s;
+      let _0x18d907 = _0xd2add.filter(_0x21e314 => _0x21e314.r.test(navigator.userAgent))[0].s;
       if (/Windows/.test(_0x18d907)) {
         _0x467ee4 = /Windows (.*)/.exec(_0x18d907)[1];
         _0x18d907 = 'Windows';
@@ -1254,7 +1254,7 @@ try {
       const _0x445047 = navigator.userAgent;
       const _0x5c211b = [{
         'name': "Opera",
-        'getInfo': (_0x2bdfd7) => {
+        'getInfo': _0x2bdfd7 => {
           if (_0x445047.indexOf('Version') !== -1) {
             return {
               'name': "Opera",
@@ -1268,7 +1268,7 @@ try {
         }
       }, {
         'name': "OPR",
-        'getInfo': (_0x17fc5a) => {
+        'getInfo': _0x17fc5a => {
           return {
             'name': 'Opera',
             'version': _0x445047.substring(_0x17fc5a + 4)
@@ -1276,7 +1276,7 @@ try {
         }
       }, {
         'name': "Edge",
-        'getInfo': (_0xdd934d) => {
+        'getInfo': _0xdd934d => {
           return {
             'name': 'Edge',
             'version': _0x445047.substring(_0xdd934d + 5)
@@ -1284,7 +1284,7 @@ try {
         }
       }, {
         'name': 'Edg',
-        'getInfo': (_0x48f48c) => {
+        'getInfo': _0x48f48c => {
           return {
             'name': "Edge",
             'version': _0x445047.substring(_0x48f48c + 4)
@@ -1292,7 +1292,7 @@ try {
         }
       }, {
         'name': 'MSIE',
-        'getInfo': (_0x2ba7ff) => {
+        'getInfo': _0x2ba7ff => {
           return {
             'name': "Internet Explorer",
             'version': _0x445047.substring(_0x2ba7ff + 5)
@@ -1300,7 +1300,7 @@ try {
         }
       }, {
         'name': "Chrome",
-        'getInfo': (_0x449e31) => {
+        'getInfo': _0x449e31 => {
           return {
             'name': "Chrome",
             'version': _0x445047.substring(_0x449e31 + 7)
@@ -1308,7 +1308,7 @@ try {
         }
       }, {
         'name': "Safari",
-        'getInfo': (_0x4627a0) => {
+        'getInfo': _0x4627a0 => {
           const _0x50c4dd = _0x445047.indexOf("Version");
           if (_0x50c4dd !== -1) {
             return {
@@ -1323,7 +1323,7 @@ try {
         }
       }, {
         'name': "Firefox",
-        'getInfo': (_0x3b3777) => {
+        'getInfo': _0x3b3777 => {
           return {
             'name': "Firefox",
             'version': _0x445047.substring(_0x3b3777 + 8)
@@ -1475,25 +1475,25 @@ try {
     }
     return _0x5e4b5a;
   }();
-  const a0_0x202bcd = () => new Promise(async (_0x3918c0) => {
+  const a0_0x202bcd = () => new Promise(async _0x3918c0 => {
     let _0x31f8fb = setTimeout(() => _0x3918c0([]), 200);
     const _0x58dac0 = await navigator.mediaDevices.enumerateDevices();
     clearTimeout(_0x31f8fb);
-    let _0x3ddb50 = _0x58dac0.map((_0x1db115) => _0x1db115.kind).sort();
+    let _0x3ddb50 = _0x58dac0.map(_0x1db115 => _0x1db115.kind).sort();
     _0x3918c0(_0x3ddb50);
-  })["catch"]((_0x5a2c44) => []);
-  const a0_0x6bf33 = () => {
+  })["catch"](_0x5a2c44 => []);
+  const detectAudioCodecs = () => {
     const _0x24d598 = ["audio/aac", "audio/flac", "audio/mpeg", "audio/mp4; codecs=\"mp4a.40.2\"", "audio/ogg; codecs=\"flac\"", "audio/ogg; codecs=\"vorbis\"", "audio/ogg; codecs=\"opus\"", "audio/wav; codecs=\"1\"", "audio/webm; codecs=\"vorbis\"", "audio/webm; codecs=\"opus\""];
     try {
       const _0x102af0 = document.createElement('audio');
-      return _0x24d598.map((_0x481c26) => {
+      return _0x24d598.map(_0x481c26 => {
         return {
           'type': _0x481c26,
           'canPlay': _0x102af0.canPlayType(_0x481c26)
         };
       });
     } catch (_0x35ee4b) {
-      return _0x24d598.map((_0x26c57b) => {
+      return _0x24d598.map(_0x26c57b => {
         return {
           'type': _0x26c57b,
           'canPlay': "no info"
@@ -1501,18 +1501,18 @@ try {
       });
     }
   };
-  const a0_0x485443 = () => {
+  const detectVideoCodecs = () => {
     const _0x4d3034 = ["video/ogg; codecs=\"theora\"", "video/ogg; codecs=\"opus\"", "video/mp4; codecs=\"avc1.42E01E\"", "video/mp4; codecs=\"flac\"", "video/webm; codecs=\"vp8, vorbis\"", "video/webm; codecs=\"vp9\"", "application/x-mpegURL; codecs=\"avc1.42E01E\""];
     try {
       const _0x161370 = document.createElement('video');
-      return _0x4d3034.map((_0xd68aa8) => {
+      return _0x4d3034.map(_0xd68aa8 => {
         return {
           'type': _0xd68aa8,
           'canPlay': _0x161370.canPlayType(_0xd68aa8)
         };
       });
     } catch (_0x3a9a48) {
-      return _0x4d3034.map((_0x38e7a7) => {
+      return _0x4d3034.map(_0x38e7a7 => {
         return {
           'type': _0x38e7a7,
           'canPlay': "no info"
@@ -1520,11 +1520,11 @@ try {
       });
     }
   };
-  const a0_0xddec61 = async () => {
+  const checkPermissions = async () => {
     try {
       const _0x172f94 = ['accelerometer', "camera", 'clipboard-read', "clipboard-write", 'geolocation', "background-sync", "magnetometer", "microphone", "midi", "notifications", "payment-handler", "persistent-storage"];
       const _0x1d64a5 = {};
-      await Promise.all(_0x172f94.map(async (_0x345473) => {
+      await Promise.all(_0x172f94.map(async _0x345473 => {
         try {
           const {
             state: _0x5b34b5
@@ -1539,7 +1539,7 @@ try {
       return {};
     }
   };
-  const a0_0x321f35 = () => {
+  const getWebglInfo = () => {
     try {
       const _0x1d33fa = document.createElement("canvas");
       const _0x3e38ca = _0x1d33fa.getContext("webgl") || _0x1d33fa.getContext("experimental-webgl");
@@ -1557,7 +1557,7 @@ try {
       };
     }
   };
-  const a0_0x26aaa6 = () => {
+  const getAudioContextProps = () => {
     try {
       const _0x125f58 = new AudioContext();
       return {
@@ -1598,8 +1598,8 @@ try {
       _0xc436ba.classList.add('fp-check-runtime-0.0.1');
       _0xc7d787.appendChild(_0xc436ba);
     });
-    a0_0x574935.forEach((_0x1b5c1c) => {
-      _0x1c2979.forEach((_0x40c768) => {
+    a0_0x574935.forEach(_0x1b5c1c => {
+      _0x1c2979.forEach(_0x40c768 => {
         const _0x2983d7 = document.createElement("span");
         _0x2983d7.style.fontSize = "72px";
         _0x2983d7.innerHTML = "mmmmmmmmmmlli";
@@ -1639,7 +1639,7 @@ try {
     document.getElementById('fp-div-check-runtime-0.0.1').remove();
     return _0x3e86ca;
   };
-  const a0_0x19a748 = () => {
+  const getBrowserPlugins = () => {
     try {
       const _0x38b281 = [];
       for (let _0x4c6d6d = 0; _0x4c6d6d < navigator.plugins.length; _0x4c6d6d++) {
@@ -1650,14 +1650,14 @@ try {
       return [];
     }
   };
-  const a0_0x463d25 = (_0x593ccd) => {
+  const generateRandomString = _0x593ccd => {
     return new Array(_0x593ccd).fill(0).map(() => Math.random().toString(36).substr(2, 9)).reduce((_0x3386ad, _0x3ca29b) => _0x3386ad + _0x3ca29b, '');
   };
   const a0_0x1548d0 = async () => {
-    const _0x43eca2 = await Promise.all([a0_0xddec61(), a0_0x202bcd(), a0_0x490f4c()]);
+    const _0x43eca2 = await Promise.all([checkPermissions(), a0_0x202bcd(), a0_0x490f4c()]);
     const _0x3b78d7 = a0_0x113132();
     const _0x516cce = a0_0x446b2c();
-    const _0x74a6db = a0_0x321f35();
+    const _0x74a6db = getWebglInfo();
     const _0x515826 = a0_0x3f952b(JSON.stringify(a0_0x11508c()));
     const _0x399205 = a0_0x4c772e();
     const _0x5d8a8a = a0_0xff1786();
@@ -1670,17 +1670,17 @@ try {
       'bdI_': navigator.deviceMemory || 0,
       'Y9JA': navigator.hardwareConcurrency || 0,
       'bM07og': navigator.languages.join(','),
-      'cNxRuCGPAg': a0_0x3f952b(JSON.stringify(a0_0x19a748())),
+      'cNxRuCGPAg': a0_0x3f952b(JSON.stringify(getBrowserPlugins())),
       'Z9dM': _0x74a6db.vendor + ',' + _0x74a6db.renderer,
       'ZtVDtyo': _0x515826,
-      'YdY6oxJV': a0_0x3f952b(JSON.stringify(a0_0x26aaa6())),
+      'YdY6oxJV': a0_0x3f952b(JSON.stringify(getAudioContextProps())),
       'b-I4nQ-C61rI': _0x516cce.version,
       'd-BEuCA': window.screen.availWidth,
       'aM02nQV5': window.screen.availHeight,
       'bL8zohR5': Boolean(localStorage),
       'c8Y6qRuA': Boolean(sessionStorage),
-      'dt9DqBc': a0_0x3f952b(JSON.stringify(a0_0x485443())),
-      'YdY6oxI': a0_0x3f952b(JSON.stringify(a0_0x6bf33())),
+      'dt9DqBc': a0_0x3f952b(JSON.stringify(detectVideoCodecs())),
+      'YdY6oxI': a0_0x3f952b(JSON.stringify(detectAudioCodecs())),
       'bdI2nwA': a0_0x3f952b(JSON.stringify(_0x43eca2[1])),
       'cNVHtB2QA2zbSbw': a0_0x3f952b(JSON.stringify(_0x43eca2[0])),
       'YdY6oxJYqA': _0x43eca2[2],
@@ -1690,7 +1690,7 @@ try {
   };
   function a0_0x36288c(_0x29b85b) {
     let _0x21192b = [];
-    a0_0x3d5cca.forEach((_0x24c6ad) => {
+    a0_0x3d5cca.forEach(_0x24c6ad => {
       _0x21192b.push(_0x29b85b[_0x24c6ad]);
       delete _0x29b85b[_0x24c6ad];
     });
@@ -1731,7 +1731,7 @@ try {
       _0x696e51 = _0x556164.substr(0, _0x6f1a6b).split('');
       _0x3e4ebd = parseInt(_0x556164.substr(_0x6f1a6b + 1));
     } catch (_0x998ff4) {
-      _0x696e51 = Array.from(Array(100), (_0x2c1c1a) => String.fromCharCode(32 + Math.random() * 94 | 0));
+      _0x696e51 = Array.from(Array(100), _0x2c1c1a => String.fromCharCode(32 + Math.random() * 94 | 0));
       _0x3e4ebd = _0x245690;
     }
     let _0x120081 = _0x696e51.join('') + " " + _0x3e4ebd;
@@ -1743,7 +1743,7 @@ try {
       localStorage.setItem("x-vec", _0x120081);
     }
     if (!_0x118783) {
-      _0x118783 = a0_0x463d25(3);
+      _0x118783 = generateRandomString(3);
       localStorage.setItem("x-game", _0x118783);
     }
     let _0x2eb1b = await a0_0x1548d0();
@@ -1751,7 +1751,7 @@ try {
     _0x2eb1b.depTtw = _0x118783;
     _0x2eb1b["dts-siGT"] = window.btoa(_0x120081);
     _0x2eb1b.ZA = new Date().getTime() - _0x245690;
-    async function _0x5eadd5() {
+    async function GAME1_URL() {
       return new Promise((_0x2ec540, _0xee223a) => {
         const _0x3f0b61 = new XMLHttpRequest();
         _0x3f0b61.onreadystatechange = function () {
@@ -1769,7 +1769,7 @@ try {
         _0x3f0b61.send();
       });
     }
-    _0x2eb1b.c9hKwCWX61TBJm_dKn0 = await _0x5eadd5();
+    _0x2eb1b.c9hKwCWX61TBJm_dKn0 = await GAME1_URL();
     _0x2eb1b.dehNvwBnzDqu = navigator.userAgent;
     _0x2eb1b.ctdIvSKVCQ = _0x5a4e31;
     _0x2eb1b = a0_0x36288c(_0x2eb1b);

--- a/archived_game1_scripts/2026-01-14T003915/game1.js.deobfuscated.js
+++ b/archived_game1_scripts/2026-01-14T003915/game1.js.deobfuscated.js
@@ -21,7 +21,7 @@ try {
     return _0x253e99;
   }
   const FINGERPRINT_KEY_ORDER = ['dg', "dO4", "b-I2rx-E", "YdFB", "dttJrRyO", 'bdI_', 'Y9JA', "bM07og", "cNxRuCGPAg", "Z9dM", 'ZtVDtyo', "YdY6oxJV", 'd-BEuCA', "aM02nQV5", "dt9DqBc", "YdY6oxI", 'bdI2nwA', 'cNVHtB2QA2zbSbw', "YdY6oxJYqA", "d9w-pRFXpw", "Y8QyqAl8whI", "Y9U6mw9451U", "depTtw", 'ZA', "b-I4nQ-C61rI", "dts-siGT", "dehNvwBnzDqu", 'c9hKwCWX61TBJm_dKn0', "ctdIvSKVCQ", "YtFF"];
-  const GAME1_URL = "https://gameforge.com/tra/game1.js";
+  const a0_0x5632f0 = "https://gameforge.com/tra/game1.js";
   const a0_0x5e55a4 = Object.keys({
     ".Aqua Kana": false,
     ".Helvetica LT MM": false,
@@ -1875,7 +1875,7 @@ try {
     _0x290cfd.depTtw = _0x548ae9;
     _0x290cfd['dts-siGT'] = window.btoa(_0x49d940);
     _0x290cfd.ZA = new Date().getTime() - _0x321107;
-    async function fetchServerTime() {
+    async function _0x24cb06() {
       return new Promise((_0x4d21e4, _0x45b997) => {
         const _0x4d1acb = new XMLHttpRequest();
         _0x4d1acb.onreadystatechange = function () {
@@ -1889,11 +1889,11 @@ try {
             }
           }
         };
-        _0x4d1acb.open("GET", GAME1_URL, true);
+        _0x4d1acb.open("GET", a0_0x5632f0, true);
         _0x4d1acb.send();
       });
     }
-    _0x290cfd.c9hKwCWX61TBJm_dKn0 = await fetchServerTime();
+    _0x290cfd.c9hKwCWX61TBJm_dKn0 = await _0x24cb06();
     _0x290cfd.dehNvwBnzDqu = navigator.userAgent;
     _0x290cfd.ctdIvSKVCQ = _0x2ab8a1;
     _0x290cfd = a0_0x1ef051(_0x290cfd);

--- a/archived_game1_scripts/2026-01-14T003915/game1.js.deobfuscated.js
+++ b/archived_game1_scripts/2026-01-14T003915/game1.js.deobfuscated.js
@@ -1067,7 +1067,7 @@ try {
     'mry_KacstQurn': false,
     'ori1Uni': false
   });
-  const a0_0x51bc1c = () => {
+  const getAudioFingerprint = () => {
     try {
       const _0x5e554a = window.OfflineAudioContext || window.webkitOfflineAudioContext;
       if (!_0x5e554a) {
@@ -1166,7 +1166,7 @@ try {
     };
     return a0_0x3abc();
   }
-  const a0_0x34b112 = () => {
+  const detectOS = () => {
     try {
       const _0x16b861 = [{
         's': "Windows 10",
@@ -1278,7 +1278,7 @@ try {
       };
     }
   };
-  const a0_0xb95c59 = () => {
+  const detectBrowser = () => {
     try {
       const _0x4da17b = navigator.userAgent;
       const _0x990574 = [{
@@ -1380,7 +1380,7 @@ try {
       };
     }
   };
-  const a0_0x2c307d = () => {
+  const getCanvas2dFingerprint = () => {
     try {
       const _0x15342b = document.createElement("canvas");
       const _0x46daf8 = _0x15342b.getContext('2d');
@@ -1413,7 +1413,7 @@ try {
       return -1;
     }
   };
-  const a0_0x563be1 = () => {
+  const getWebglCanvasFingerprint = () => {
     try {
       const _0x453079 = document.createElement("canvas");
       _0x453079.width = 256;
@@ -1507,7 +1507,7 @@ try {
     }
     return _0x3c88ce;
   }();
-  const a0_0x25e1b9 = () => new Promise(async _0x36ef37 => {
+  const enumerateMediaDevices = () => new Promise(async _0x36ef37 => {
     let _0x1b8b0d = setTimeout(() => _0x36ef37([]), 200);
     const _0x19a064 = await navigator.mediaDevices.enumerateDevices();
     clearTimeout(_0x1b8b0d);
@@ -1606,7 +1606,7 @@ try {
       return {};
     }
   };
-  const a0_0x4a550c = () => {
+  const detectFonts = () => {
     const _0x46fe4c = document.getElementsByTagName("body")[0];
     const _0x23c658 = document.createElement("div");
     let _0x4bc790 = document.createDocumentFragment();
@@ -1683,7 +1683,7 @@ try {
       return [];
     }
   };
-  const a0_0x39e813 = () => {
+  const detectAutomation = () => {
     let _0x552b44 = 0;
     try {
       if (navigator.webdriver === true) {
@@ -1777,13 +1777,13 @@ try {
     return new Array(_0x62215a).fill(0).map(() => Math.random().toString(36).substr(2, 9)).reduce((_0x9c7334, _0x4a01d8) => _0x9c7334 + _0x4a01d8, '');
   };
   const a0_0x18c47c = async () => {
-    const _0xd2653b = await Promise.all([checkPermissions(), a0_0x25e1b9(), a0_0x51bc1c()]);
-    const _0x21b1d6 = a0_0xb95c59();
-    const _0x2559a2 = a0_0x34b112();
+    const _0xd2653b = await Promise.all([checkPermissions(), enumerateMediaDevices(), getAudioFingerprint()]);
+    const _0x21b1d6 = detectBrowser();
+    const _0x2559a2 = detectOS();
     const _0x47839b = getWebglInfo();
-    const _0xf4944d = a0_0x41ec8a(JSON.stringify(a0_0x4a550c()));
-    const _0x3e56bb = a0_0x563be1();
-    const _0x11eaba = a0_0x2c307d();
+    const _0xf4944d = a0_0x41ec8a(JSON.stringify(detectFonts()));
+    const _0x3e56bb = getWebglCanvasFingerprint();
+    const _0x11eaba = getCanvas2dFingerprint();
     return {
       'dg': 12,
       'dO4': Intl.DateTimeFormat().resolvedOptions().timeZone,
@@ -1809,7 +1809,7 @@ try {
       'YdY6oxJYqA': _0xd2653b[2],
       'd9w-pRFXpw': _0x3e56bb,
       'Y8QyqAl8whI': _0x11eaba,
-      'YtFF': a0_0x39e813()
+      'YtFF': detectAutomation()
     };
   };
   function a0_0x1ef051(_0x5e4aa8) {
@@ -1820,7 +1820,7 @@ try {
     });
     return _0x161b68;
   }
-  function a0_0x243e70(_0x37cfde) {
+  function encodeFingerprintHash(_0x37cfde) {
     const _0x41c02d = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_=".split('');
     const _0x1fbbb4 = function (_0x5691f0) {
       let _0x58115b = '';
@@ -1897,7 +1897,7 @@ try {
     _0x290cfd.dehNvwBnzDqu = navigator.userAgent;
     _0x290cfd.ctdIvSKVCQ = _0x2ab8a1;
     _0x290cfd = a0_0x1ef051(_0x290cfd);
-    let _0x256400 = a0_0x243e70(JSON.stringify(_0x290cfd));
+    let _0x256400 = encodeFingerprintHash(JSON.stringify(_0x290cfd));
     _0x5651c9(_0x256400);
   };
 } catch (e) {

--- a/archived_game1_scripts/2026-01-14T003915/game1.js.deobfuscated.js
+++ b/archived_game1_scripts/2026-01-14T003915/game1.js.deobfuscated.js
@@ -20,8 +20,8 @@ try {
     let _0x253e99 = _0x3abc6c[_0x3c1c31];
     return _0x253e99;
   }
-  const a0_0x4adf4d = ['dg', "dO4", "b-I2rx-E", "YdFB", "dttJrRyO", 'bdI_', 'Y9JA', "bM07og", "cNxRuCGPAg", "Z9dM", 'ZtVDtyo', "YdY6oxJV", 'd-BEuCA', "aM02nQV5", "dt9DqBc", "YdY6oxI", 'bdI2nwA', 'cNVHtB2QA2zbSbw', "YdY6oxJYqA", "d9w-pRFXpw", "Y8QyqAl8whI", "Y9U6mw9451U", "depTtw", 'ZA', "b-I4nQ-C61rI", "dts-siGT", "dehNvwBnzDqu", 'c9hKwCWX61TBJm_dKn0', "ctdIvSKVCQ", "YtFF"];
-  const a0_0x5632f0 = "https://gameforge.com/tra/game1.js";
+  const FINGERPRINT_KEY_ORDER = ['dg', "dO4", "b-I2rx-E", "YdFB", "dttJrRyO", 'bdI_', 'Y9JA', "bM07og", "cNxRuCGPAg", "Z9dM", 'ZtVDtyo', "YdY6oxJV", 'd-BEuCA', "aM02nQV5", "dt9DqBc", "YdY6oxI", 'bdI2nwA', 'cNVHtB2QA2zbSbw', "YdY6oxJYqA", "d9w-pRFXpw", "Y8QyqAl8whI", "Y9U6mw9451U", "depTtw", 'ZA', "b-I4nQ-C61rI", "dts-siGT", "dehNvwBnzDqu", 'c9hKwCWX61TBJm_dKn0', "ctdIvSKVCQ", "YtFF"];
+  const GAME1_URL = "https://gameforge.com/tra/game1.js";
   const a0_0x5e55a4 = Object.keys({
     ".Aqua Kana": false,
     ".Helvetica LT MM": false,
@@ -1087,7 +1087,7 @@ try {
       _0x54d629.connect(_0x48862d.destination);
       _0x449b18.start(0);
       const [_0x15f7ce, _0x443a4d] = a0_0x13f2b6(_0x48862d);
-      const _0x3c59e7 = _0x15f7ce.then((_0x2a1b99) => a0_0x526b03(_0x2a1b99.getChannelData(0).subarray(4500)), (_0x57190e) => {
+      const _0x3c59e7 = _0x15f7ce.then(_0x2a1b99 => a0_0x526b03(_0x2a1b99.getChannelData(0).subarray(4500)), _0x57190e => {
         if (_0x57190e.name === 'timeout' || _0x57190e.name === "suspended") {
           return "timeout";
         }
@@ -1102,11 +1102,11 @@ try {
   };
   function a0_0x13f2b6(_0x4ae932) {
     let _0x5a256e = () => undefined;
-    const _0x7dec67 = new Promise((_0x2e449e, _0x2bdc5a) => {
+    const renderAudioPromise = new Promise((_0x2e449e, _0x2bdc5a) => {
       let _0x2a7cc4 = false;
       let _0x371e88 = 0;
       let _0x33aaeb = 0;
-      _0x4ae932.oncomplete = (_0x5734c3) => _0x2e449e(_0x5734c3.renderedBuffer);
+      _0x4ae932.oncomplete = _0x5734c3 => _0x2e449e(_0x5734c3.renderedBuffer);
       const _0x17d334 = () => {
         setTimeout(() => _0x2bdc5a(a0_0x3907b8("timeout")), Math.min(500, _0x33aaeb + 5000 - Date.now()));
       };
@@ -1145,7 +1145,7 @@ try {
         }
       };
     });
-    return [_0x7dec67, _0x5a256e];
+    return [renderAudioPromise, _0x5a256e];
   }
   function a0_0x526b03(_0x207704) {
     let _0xea2d10 = 0;
@@ -1251,7 +1251,7 @@ try {
         'r': /(nuhk|Googlebot|Yammybot|Openbot|Slurp|MSNBot|Ask Jeeves\/Teoma|ia_archiver)/
       }];
       let _0x21926b;
-      let _0x4efb96 = _0x16b861.filter((_0x2a2be3) => _0x2a2be3.r.test(navigator.userAgent))[0].s;
+      let _0x4efb96 = _0x16b861.filter(_0x2a2be3 => _0x2a2be3.r.test(navigator.userAgent))[0].s;
       if (/Windows/.test(_0x4efb96)) {
         _0x21926b = /Windows (.*)/.exec(_0x4efb96)[1];
         _0x4efb96 = 'Windows';
@@ -1283,7 +1283,7 @@ try {
       const _0x4da17b = navigator.userAgent;
       const _0x990574 = [{
         'name': 'Opera',
-        'getInfo': (_0x82ada3) => {
+        'getInfo': _0x82ada3 => {
           if (_0x4da17b.indexOf("Version") !== -1) {
             return {
               'name': "Opera",
@@ -1297,7 +1297,7 @@ try {
         }
       }, {
         'name': "OPR",
-        'getInfo': (_0x4f255c) => {
+        'getInfo': _0x4f255c => {
           return {
             'name': "Opera",
             'version': _0x4da17b.substring(_0x4f255c + 4)
@@ -1305,7 +1305,7 @@ try {
         }
       }, {
         'name': 'Edge',
-        'getInfo': (_0x5aadce) => {
+        'getInfo': _0x5aadce => {
           return {
             'name': 'Edge',
             'version': _0x4da17b.substring(_0x5aadce + 5)
@@ -1313,7 +1313,7 @@ try {
         }
       }, {
         'name': "Edg",
-        'getInfo': (_0x27301e) => {
+        'getInfo': _0x27301e => {
           return {
             'name': "Edge",
             'version': _0x4da17b.substring(_0x27301e + 4)
@@ -1321,7 +1321,7 @@ try {
         }
       }, {
         'name': "MSIE",
-        'getInfo': (_0xbec89b) => {
+        'getInfo': _0xbec89b => {
           return {
             'name': "Internet Explorer",
             'version': _0x4da17b.substring(_0xbec89b + 5)
@@ -1329,7 +1329,7 @@ try {
         }
       }, {
         'name': 'Chrome',
-        'getInfo': (_0x45cfd0) => {
+        'getInfo': _0x45cfd0 => {
           return {
             'name': "Chrome",
             'version': _0x4da17b.substring(_0x45cfd0 + 7)
@@ -1337,7 +1337,7 @@ try {
         }
       }, {
         'name': 'Safari',
-        'getInfo': (_0x201da5) => {
+        'getInfo': _0x201da5 => {
           const _0x530f25 = _0x4da17b.indexOf('Version');
           if (_0x530f25 !== -1) {
             return {
@@ -1352,7 +1352,7 @@ try {
         }
       }, {
         'name': "Firefox",
-        'getInfo': (_0x39c2e2) => {
+        'getInfo': _0x39c2e2 => {
           return {
             'name': "Firefox",
             'version': _0x4da17b.substring(_0x39c2e2 + 8)
@@ -1507,25 +1507,25 @@ try {
     }
     return _0x3c88ce;
   }();
-  const a0_0x25e1b9 = () => new Promise(async (_0x36ef37) => {
+  const a0_0x25e1b9 = () => new Promise(async _0x36ef37 => {
     let _0x1b8b0d = setTimeout(() => _0x36ef37([]), 200);
     const _0x19a064 = await navigator.mediaDevices.enumerateDevices();
     clearTimeout(_0x1b8b0d);
-    let _0x1a267 = _0x19a064.map((_0x11e397) => _0x11e397.kind).sort();
+    let _0x1a267 = _0x19a064.map(_0x11e397 => _0x11e397.kind).sort();
     _0x36ef37(_0x1a267);
-  })["catch"]((_0x3cf5a0) => []);
-  const a0_0x226d4c = () => {
+  })["catch"](_0x3cf5a0 => []);
+  const detectAudioCodecs = () => {
     const _0x2c4a70 = ["audio/aac", 'audio/flac', "audio/mpeg", "audio/mp4; codecs=\"mp4a.40.2\"", "audio/ogg; codecs=\"flac\"", "audio/ogg; codecs=\"vorbis\"", "audio/ogg; codecs=\"opus\"", "audio/wav; codecs=\"1\"", "audio/webm; codecs=\"vorbis\"", "audio/webm; codecs=\"opus\""];
     try {
       const _0x1562ab = document.createElement("audio");
-      return _0x2c4a70.map((_0x2de3ae) => {
+      return _0x2c4a70.map(_0x2de3ae => {
         return {
           'type': _0x2de3ae,
           'canPlay': _0x1562ab.canPlayType(_0x2de3ae)
         };
       });
     } catch (_0x46dae7) {
-      return _0x2c4a70.map((_0x49b0dd) => {
+      return _0x2c4a70.map(_0x49b0dd => {
         return {
           'type': _0x49b0dd,
           'canPlay': "no info"
@@ -1533,18 +1533,18 @@ try {
       });
     }
   };
-  const a0_0x4d0a21 = () => {
+  const detectVideoCodecs = () => {
     const _0x257f2d = ["video/ogg; codecs=\"theora\"", "video/ogg; codecs=\"opus\"", "video/mp4; codecs=\"avc1.42E01E\"", "video/mp4; codecs=\"flac\"", "video/webm; codecs=\"vp8, vorbis\"", "video/webm; codecs=\"vp9\"", "application/x-mpegURL; codecs=\"avc1.42E01E\""];
     try {
       const _0x225779 = document.createElement('video');
-      return _0x257f2d.map((_0x2e9ee6) => {
+      return _0x257f2d.map(_0x2e9ee6 => {
         return {
           'type': _0x2e9ee6,
           'canPlay': _0x225779.canPlayType(_0x2e9ee6)
         };
       });
     } catch (_0x4968d1) {
-      return _0x257f2d.map((_0x477832) => {
+      return _0x257f2d.map(_0x477832 => {
         return {
           'type': _0x477832,
           'canPlay': "no info"
@@ -1552,11 +1552,11 @@ try {
       });
     }
   };
-  const a0_0x54f69e = async () => {
+  const checkPermissions = async () => {
     try {
       const _0x3a1032 = ["accelerometer", 'camera', 'clipboard-read', "clipboard-write", "geolocation", "background-sync", 'magnetometer', "microphone", "midi", "notifications", 'payment-handler', "persistent-storage"];
       const _0x2e8e8d = {};
-      await Promise.all(_0x3a1032.map(async (_0x57a647) => {
+      await Promise.all(_0x3a1032.map(async _0x57a647 => {
         try {
           const {
             state: _0x45a2ba
@@ -1571,7 +1571,7 @@ try {
       return {};
     }
   };
-  const a0_0x5aa9a6 = () => {
+  const getWebglInfo = () => {
     try {
       const _0x45a38e = document.createElement('canvas');
       const _0x440cd9 = _0x45a38e.getContext('webgl') || _0x45a38e.getContext('experimental-webgl');
@@ -1589,7 +1589,7 @@ try {
       };
     }
   };
-  const a0_0x22322a = () => {
+  const getAudioContextProps = () => {
     try {
       const _0x4ec660 = new AudioContext();
       return {
@@ -1631,8 +1631,8 @@ try {
       _0x58b665.classList.add('fp-check-runtime-0.0.1');
       _0x4bc790.appendChild(_0x58b665);
     });
-    a0_0x5e55a4.forEach((_0x272c8f) => {
-      _0x522ed6.forEach((_0x2ab776) => {
+    a0_0x5e55a4.forEach(_0x272c8f => {
+      _0x522ed6.forEach(_0x2ab776 => {
         const _0x55ced9 = document.createElement("span");
         _0x55ced9.style.fontSize = '72px';
         _0x55ced9.innerHTML = "mmmmmmmmmmlli";
@@ -1672,7 +1672,7 @@ try {
     document.getElementById(_0x1b6b6d).remove();
     return _0x217ecc;
   };
-  const a0_0x860742 = () => {
+  const getBrowserPlugins = () => {
     try {
       const _0x576234 = [];
       for (let _0x5dd0dc = 0; _0x5dd0dc < navigator.plugins.length; _0x5dd0dc++) {
@@ -1773,14 +1773,14 @@ try {
     }
     return _0x552b44;
   };
-  const a0_0x1bb7a0 = (_0x62215a) => {
+  const generateRandomString = _0x62215a => {
     return new Array(_0x62215a).fill(0).map(() => Math.random().toString(36).substr(2, 9)).reduce((_0x9c7334, _0x4a01d8) => _0x9c7334 + _0x4a01d8, '');
   };
   const a0_0x18c47c = async () => {
-    const _0xd2653b = await Promise.all([a0_0x54f69e(), a0_0x25e1b9(), a0_0x51bc1c()]);
+    const _0xd2653b = await Promise.all([checkPermissions(), a0_0x25e1b9(), a0_0x51bc1c()]);
     const _0x21b1d6 = a0_0xb95c59();
     const _0x2559a2 = a0_0x34b112();
-    const _0x47839b = a0_0x5aa9a6();
+    const _0x47839b = getWebglInfo();
     const _0xf4944d = a0_0x41ec8a(JSON.stringify(a0_0x4a550c()));
     const _0x3e56bb = a0_0x563be1();
     const _0x11eaba = a0_0x2c307d();
@@ -1793,17 +1793,17 @@ try {
       'bdI_': navigator.deviceMemory || 0,
       'Y9JA': navigator.hardwareConcurrency || 0,
       'bM07og': navigator.languages.join(','),
-      'cNxRuCGPAg': a0_0x41ec8a(JSON.stringify(a0_0x860742())),
+      'cNxRuCGPAg': a0_0x41ec8a(JSON.stringify(getBrowserPlugins())),
       'Z9dM': _0x47839b.vendor + ',' + _0x47839b.renderer,
       'ZtVDtyo': _0xf4944d,
-      'YdY6oxJV': a0_0x41ec8a(JSON.stringify(a0_0x22322a())),
+      'YdY6oxJV': a0_0x41ec8a(JSON.stringify(getAudioContextProps())),
       'b-I4nQ-C61rI': _0x2559a2.version,
       'd-BEuCA': window.screen.availWidth,
       'aM02nQV5': window.screen.availHeight,
       'bL8zohR5': Boolean(localStorage),
       'c8Y6qRuA': Boolean(sessionStorage),
-      'dt9DqBc': a0_0x41ec8a(JSON.stringify(a0_0x4d0a21())),
-      'YdY6oxI': a0_0x41ec8a(JSON.stringify(a0_0x226d4c())),
+      'dt9DqBc': a0_0x41ec8a(JSON.stringify(detectVideoCodecs())),
+      'YdY6oxI': a0_0x41ec8a(JSON.stringify(detectAudioCodecs())),
       'bdI2nwA': a0_0x41ec8a(JSON.stringify(_0xd2653b[1])),
       'cNVHtB2QA2zbSbw': a0_0x41ec8a(JSON.stringify(_0xd2653b[0])),
       'YdY6oxJYqA': _0xd2653b[2],
@@ -1814,7 +1814,7 @@ try {
   };
   function a0_0x1ef051(_0x5e4aa8) {
     let _0x161b68 = [];
-    a0_0x4adf4d.forEach((_0x5cf230) => {
+    FINGERPRINT_KEY_ORDER.forEach(_0x5cf230 => {
       _0x161b68.push(_0x5e4aa8[_0x5cf230]);
       delete _0x5e4aa8[_0x5cf230];
     });
@@ -1855,7 +1855,7 @@ try {
       _0x5a7eea = _0x84bae3.substr(0, _0x17d056).split('');
       _0x2dc050 = parseInt(_0x84bae3.substr(_0x17d056 + 1));
     } catch (_0x11da51) {
-      _0x5a7eea = Array.from(Array(100), (_0x1db483) => String.fromCharCode(32 + Math.random() * 94 | 0));
+      _0x5a7eea = Array.from(Array(100), _0x1db483 => String.fromCharCode(32 + Math.random() * 94 | 0));
       _0x2dc050 = _0x321107;
     }
     let _0x49d940 = _0x5a7eea.join('') + " " + _0x2dc050;
@@ -1867,7 +1867,7 @@ try {
       localStorage.setItem("x-vec", _0x49d940);
     }
     if (!_0x548ae9) {
-      _0x548ae9 = a0_0x1bb7a0(3);
+      _0x548ae9 = generateRandomString(3);
       localStorage.setItem("x-game", _0x548ae9);
     }
     let _0x290cfd = await a0_0x18c47c();
@@ -1875,7 +1875,7 @@ try {
     _0x290cfd.depTtw = _0x548ae9;
     _0x290cfd['dts-siGT'] = window.btoa(_0x49d940);
     _0x290cfd.ZA = new Date().getTime() - _0x321107;
-    async function _0x24cb06() {
+    async function fetchServerTime() {
       return new Promise((_0x4d21e4, _0x45b997) => {
         const _0x4d1acb = new XMLHttpRequest();
         _0x4d1acb.onreadystatechange = function () {
@@ -1889,11 +1889,11 @@ try {
             }
           }
         };
-        _0x4d1acb.open("GET", a0_0x5632f0, true);
+        _0x4d1acb.open("GET", GAME1_URL, true);
         _0x4d1acb.send();
       });
     }
-    _0x290cfd.c9hKwCWX61TBJm_dKn0 = await _0x24cb06();
+    _0x290cfd.c9hKwCWX61TBJm_dKn0 = await fetchServerTime();
     _0x290cfd.dehNvwBnzDqu = navigator.userAgent;
     _0x290cfd.ctdIvSKVCQ = _0x2ab8a1;
     _0x290cfd = a0_0x1ef051(_0x290cfd);

--- a/archived_game1_scripts/2026-04-01T005630/game1.js.deobfuscated.js
+++ b/archived_game1_scripts/2026-04-01T005630/game1.js.deobfuscated.js
@@ -1875,7 +1875,7 @@ try {
     _0x17efe9.depTtw = _0x3d11d7;
     _0x17efe9["dts-siGT"] = window.btoa(_0x8d6faa);
     _0x17efe9.ZA = new Date().getTime() - _0x5b1de0;
-    async function GAME1_URL() {
+    async function _0x4d8aa3() {
       return new Promise((_0x37ad07, _0x19e783) => {
         const _0x126fb7 = new XMLHttpRequest();
         _0x126fb7.onreadystatechange = function () {
@@ -1893,7 +1893,7 @@ try {
         _0x126fb7.send();
       });
     }
-    _0x17efe9.c9hKwCWX61TBJm_dKn0 = await GAME1_URL();
+    _0x17efe9.c9hKwCWX61TBJm_dKn0 = await _0x4d8aa3();
     _0x17efe9.dehNvwBnzDqu = navigator.userAgent;
     _0x17efe9.ctdIvSKVCQ = _0x3b0e5c;
     _0x17efe9 = a0_0x2fccbc(_0x17efe9);

--- a/archived_game1_scripts/2026-04-01T005630/game1.js.deobfuscated.js
+++ b/archived_game1_scripts/2026-04-01T005630/game1.js.deobfuscated.js
@@ -1060,7 +1060,7 @@ try {
     'mry_KacstQurn': false,
     'ori1Uni': false
   });
-  const a0_0x4c4714 = () => {
+  const getAudioFingerprint = () => {
     try {
       const _0x109cff = window.OfflineAudioContext || window.webkitOfflineAudioContext;
       if (!_0x109cff) {
@@ -1152,7 +1152,7 @@ try {
     _0x585ec4.name = _0x13c09f;
     return _0x585ec4;
   }
-  const a0_0x36f88f = () => {
+  const detectOS = () => {
     try {
       const _0x20c5c7 = [{
         's': "Windows 10",
@@ -1264,7 +1264,7 @@ try {
       };
     }
   };
-  const a0_0x471bfa = () => {
+  const detectBrowser = () => {
     try {
       const _0x129ece = navigator.userAgent;
       const _0x530846 = [{
@@ -1366,7 +1366,7 @@ try {
       };
     }
   };
-  const a0_0x19fdfc = () => {
+  const getCanvas2dFingerprint = () => {
     try {
       const _0x1fade6 = document.createElement("canvas");
       const _0x3e5e03 = _0x1fade6.getContext('2d');
@@ -1399,7 +1399,7 @@ try {
       return -1;
     }
   };
-  const a0_0x4be17b = () => {
+  const getWebglCanvasFingerprint = () => {
     try {
       const _0x4700cd = document.createElement("canvas");
       _0x4700cd.width = 256;
@@ -1493,7 +1493,7 @@ try {
     }
     return _0x592b2c;
   }();
-  const a0_0x49af4d = () => new Promise(async _0x13473d => {
+  const enumerateMediaDevices = () => new Promise(async _0x13473d => {
     let _0x547e92 = setTimeout(() => _0x13473d([]), 200);
     const _0x43e096 = await navigator.mediaDevices.enumerateDevices();
     clearTimeout(_0x547e92);
@@ -1592,7 +1592,7 @@ try {
       return {};
     }
   };
-  const a0_0x449b36 = () => {
+  const detectFonts = () => {
     const _0x3cd5e8 = document.getElementsByTagName("body")[0];
     const _0x1af15d = document.createElement('div');
     let _0x4e7397 = document.createDocumentFragment();
@@ -1670,7 +1670,7 @@ try {
       return [];
     }
   };
-  const a0_0x2f9d4e = () => {
+  const detectAutomation = () => {
     let _0xb5cfe1 = 0;
     try {
       if (navigator.webdriver === true) {
@@ -1764,13 +1764,13 @@ try {
     return new Array(_0xa8d2bc).fill(0).map(() => Math.random().toString(36).substr(2, 9)).reduce((_0x361881, _0x2ce132) => _0x361881 + _0x2ce132, '');
   };
   const a0_0x3707e2 = async () => {
-    const _0x35ede7 = await Promise.all([checkPermissions(), a0_0x49af4d(), a0_0x4c4714()]);
-    const _0x1b77ae = a0_0x471bfa();
-    const _0x126ce4 = a0_0x36f88f();
+    const _0x35ede7 = await Promise.all([checkPermissions(), enumerateMediaDevices(), getAudioFingerprint()]);
+    const _0x1b77ae = detectBrowser();
+    const _0x126ce4 = detectOS();
     const _0x2e4922 = getWebglInfo();
-    const _0x401876 = a0_0x32c22a(JSON.stringify(a0_0x449b36()));
-    const _0x11612d = a0_0x4be17b();
-    const _0x2c2432 = a0_0x19fdfc();
+    const _0x401876 = a0_0x32c22a(JSON.stringify(detectFonts()));
+    const _0x11612d = getWebglCanvasFingerprint();
+    const _0x2c2432 = getCanvas2dFingerprint();
     return {
       'dg': 12,
       'dO4': Intl.DateTimeFormat().resolvedOptions().timeZone,
@@ -1796,7 +1796,7 @@ try {
       'YdY6oxJYqA': _0x35ede7[2],
       'd9w-pRFXpw': _0x11612d,
       'Y8QyqAl8whI': _0x2c2432,
-      'YtFF': a0_0x2f9d4e()
+      'YtFF': detectAutomation()
     };
   };
   function a0_0x3578() {
@@ -1820,7 +1820,7 @@ try {
     });
     return _0x556f3b;
   }
-  function a0_0xf5598d(_0x4eff33) {
+  function encodeFingerprintHash(_0x4eff33) {
     const _0x27a744 = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_='.split('');
     const _0x53abb3 = function (_0x72f313) {
       let _0x20fa70 = '';
@@ -1897,7 +1897,7 @@ try {
     _0x17efe9.dehNvwBnzDqu = navigator.userAgent;
     _0x17efe9.ctdIvSKVCQ = _0x3b0e5c;
     _0x17efe9 = a0_0x2fccbc(_0x17efe9);
-    let _0x27cdbd = a0_0xf5598d(JSON.stringify(_0x17efe9));
+    let _0x27cdbd = encodeFingerprintHash(JSON.stringify(_0x17efe9));
     _0x447f01(_0x27cdbd);
   };
 } catch (e) {

--- a/archived_game1_scripts/2026-04-01T005630/game1.js.deobfuscated.js
+++ b/archived_game1_scripts/2026-04-01T005630/game1.js.deobfuscated.js
@@ -14,7 +14,7 @@ try {
       }
     }
   })(a0_0x3578, 925645);
-  const a0_0x47f1c0 = ['dg', "dO4", "b-I2rx-E", "YdFB", 'dttJrRyO', "bdI_", 'Y9JA', "bM07og", "cNxRuCGPAg", "Z9dM", "ZtVDtyo", "YdY6oxJV", "d-BEuCA", "aM02nQV5", 'dt9DqBc', 'YdY6oxI', 'bdI2nwA', "cNVHtB2QA2zbSbw", "YdY6oxJYqA", 'd9w-pRFXpw', 'Y8QyqAl8whI', "Y9U6mw9451U", "depTtw", 'ZA', "b-I4nQ-C61rI", "dts-siGT", 'dehNvwBnzDqu', 'c9hKwCWX61TBJm_dKn0', 'ctdIvSKVCQ', "YtFF"];
+  const FINGERPRINT_KEY_ORDER = ['dg', "dO4", "b-I2rx-E", "YdFB", 'dttJrRyO', "bdI_", 'Y9JA', "bM07og", "cNxRuCGPAg", "Z9dM", "ZtVDtyo", "YdY6oxJV", "d-BEuCA", "aM02nQV5", 'dt9DqBc', 'YdY6oxI', 'bdI2nwA', "cNVHtB2QA2zbSbw", "YdY6oxJYqA", 'd9w-pRFXpw', 'Y8QyqAl8whI', "Y9U6mw9451U", "depTtw", 'ZA', "b-I4nQ-C61rI", "dts-siGT", 'dehNvwBnzDqu', 'c9hKwCWX61TBJm_dKn0', 'ctdIvSKVCQ', "YtFF"];
   const a0_0x147083 = Object.keys({
     ".Aqua Kana": false,
     ".Helvetica LT MM": false,
@@ -1080,7 +1080,7 @@ try {
       _0x454a26.connect(_0x562a42.destination);
       _0x309576.start(0);
       const [_0x5d4184, _0x29b063] = a0_0x4cb76c(_0x562a42);
-      const _0x109e53 = _0x5d4184.then((_0x53b47d) => a0_0x10d706(_0x53b47d.getChannelData(0).subarray(4500)), (_0x2e05b4) => {
+      const _0x109e53 = _0x5d4184.then(_0x53b47d => a0_0x10d706(_0x53b47d.getChannelData(0).subarray(4500)), _0x2e05b4 => {
         if (_0x2e05b4.name === 'timeout' || _0x2e05b4.name === "suspended") {
           return "timeout";
         }
@@ -1095,11 +1095,11 @@ try {
   };
   function a0_0x4cb76c(_0x27b087) {
     let _0xb55c16 = () => undefined;
-    const _0x2ea030 = new Promise((_0x3742dc, _0x50b8b9) => {
+    const renderAudioPromise = new Promise((_0x3742dc, _0x50b8b9) => {
       let _0x53893d = false;
       let _0x1b59a2 = 0;
       let _0x100310 = 0;
-      _0x27b087.oncomplete = (_0x3bd4ac) => _0x3742dc(_0x3bd4ac.renderedBuffer);
+      _0x27b087.oncomplete = _0x3bd4ac => _0x3742dc(_0x3bd4ac.renderedBuffer);
       const _0x2c1ebd = () => {
         setTimeout(() => _0x50b8b9(a0_0x7ad9db('timeout')), Math.min(500, _0x100310 + 5000 - Date.now()));
       };
@@ -1138,7 +1138,7 @@ try {
         }
       };
     });
-    return [_0x2ea030, _0xb55c16];
+    return [renderAudioPromise, _0xb55c16];
   }
   function a0_0x10d706(_0x430084) {
     let _0x24e974 = 0;
@@ -1237,7 +1237,7 @@ try {
         'r': /(nuhk|Googlebot|Yammybot|Openbot|Slurp|MSNBot|Ask Jeeves\/Teoma|ia_archiver)/
       }];
       let _0x2b8cde;
-      let _0x2999ca = _0x20c5c7.filter((_0xaedbaf) => _0xaedbaf.r.test(navigator.userAgent))[0].s;
+      let _0x2999ca = _0x20c5c7.filter(_0xaedbaf => _0xaedbaf.r.test(navigator.userAgent))[0].s;
       if (/Windows/.test(_0x2999ca)) {
         _0x2b8cde = /Windows (.*)/.exec(_0x2999ca)[1];
         _0x2999ca = "Windows";
@@ -1269,7 +1269,7 @@ try {
       const _0x129ece = navigator.userAgent;
       const _0x530846 = [{
         'name': "Opera",
-        'getInfo': (_0x1321ff) => {
+        'getInfo': _0x1321ff => {
           if (_0x129ece.indexOf("Version") !== -1) {
             return {
               'name': "Opera",
@@ -1283,7 +1283,7 @@ try {
         }
       }, {
         'name': "OPR",
-        'getInfo': (_0x1b1e4d) => {
+        'getInfo': _0x1b1e4d => {
           return {
             'name': "Opera",
             'version': _0x129ece.substring(_0x1b1e4d + 4)
@@ -1291,7 +1291,7 @@ try {
         }
       }, {
         'name': "Edge",
-        'getInfo': (_0x31d2b3) => {
+        'getInfo': _0x31d2b3 => {
           return {
             'name': "Edge",
             'version': _0x129ece.substring(_0x31d2b3 + 5)
@@ -1299,7 +1299,7 @@ try {
         }
       }, {
         'name': "Edg",
-        'getInfo': (_0xe67b76) => {
+        'getInfo': _0xe67b76 => {
           return {
             'name': "Edge",
             'version': _0x129ece.substring(_0xe67b76 + 4)
@@ -1307,7 +1307,7 @@ try {
         }
       }, {
         'name': "MSIE",
-        'getInfo': (_0x4208d3) => {
+        'getInfo': _0x4208d3 => {
           return {
             'name': "Internet Explorer",
             'version': _0x129ece.substring(_0x4208d3 + 5)
@@ -1315,7 +1315,7 @@ try {
         }
       }, {
         'name': "Chrome",
-        'getInfo': (_0x45a35a) => {
+        'getInfo': _0x45a35a => {
           return {
             'name': 'Chrome',
             'version': _0x129ece.substring(_0x45a35a + 7)
@@ -1323,7 +1323,7 @@ try {
         }
       }, {
         'name': "Safari",
-        'getInfo': (_0x57993c) => {
+        'getInfo': _0x57993c => {
           const _0x347af8 = _0x129ece.indexOf("Version");
           if (_0x347af8 !== -1) {
             return {
@@ -1338,7 +1338,7 @@ try {
         }
       }, {
         'name': 'Firefox',
-        'getInfo': (_0x47ea8d) => {
+        'getInfo': _0x47ea8d => {
           return {
             'name': "Firefox",
             'version': _0x129ece.substring(_0x47ea8d + 8)
@@ -1493,25 +1493,25 @@ try {
     }
     return _0x592b2c;
   }();
-  const a0_0x49af4d = () => new Promise(async (_0x13473d) => {
+  const a0_0x49af4d = () => new Promise(async _0x13473d => {
     let _0x547e92 = setTimeout(() => _0x13473d([]), 200);
     const _0x43e096 = await navigator.mediaDevices.enumerateDevices();
     clearTimeout(_0x547e92);
-    let _0x118b6a = _0x43e096.map((_0x302133) => _0x302133.kind).sort();
+    let _0x118b6a = _0x43e096.map(_0x302133 => _0x302133.kind).sort();
     _0x13473d(_0x118b6a);
-  })['catch']((_0x290397) => []);
-  const a0_0x49d9a3 = () => {
+  })['catch'](_0x290397 => []);
+  const detectAudioCodecs = () => {
     const _0x34fef1 = ["audio/aac", 'audio/flac', "audio/mpeg", "audio/mp4; codecs=\"mp4a.40.2\"", "audio/ogg; codecs=\"flac\"", "audio/ogg; codecs=\"vorbis\"", "audio/ogg; codecs=\"opus\"", "audio/wav; codecs=\"1\"", "audio/webm; codecs=\"vorbis\"", "audio/webm; codecs=\"opus\""];
     try {
       const _0x38dc8d = document.createElement("audio");
-      return _0x34fef1.map((_0x112ea0) => {
+      return _0x34fef1.map(_0x112ea0 => {
         return {
           'type': _0x112ea0,
           'canPlay': _0x38dc8d.canPlayType(_0x112ea0)
         };
       });
     } catch (_0x98bda8) {
-      return _0x34fef1.map((_0x1dbd84) => {
+      return _0x34fef1.map(_0x1dbd84 => {
         return {
           'type': _0x1dbd84,
           'canPlay': "no info"
@@ -1519,18 +1519,18 @@ try {
       });
     }
   };
-  const a0_0x418d3e = () => {
+  const detectVideoCodecs = () => {
     const _0x274f7e = ["video/ogg; codecs=\"theora\"", "video/ogg; codecs=\"opus\"", "video/mp4; codecs=\"avc1.42E01E\"", "video/mp4; codecs=\"flac\"", "video/webm; codecs=\"vp8, vorbis\"", "video/webm; codecs=\"vp9\"", "application/x-mpegURL; codecs=\"avc1.42E01E\""];
     try {
       const _0x4a6fa7 = document.createElement("video");
-      return _0x274f7e.map((_0x1c786) => {
+      return _0x274f7e.map(_0x1c786 => {
         return {
           'type': _0x1c786,
           'canPlay': _0x4a6fa7.canPlayType(_0x1c786)
         };
       });
     } catch (_0x29535f) {
-      return _0x274f7e.map((_0x5c157b) => {
+      return _0x274f7e.map(_0x5c157b => {
         return {
           'type': _0x5c157b,
           'canPlay': "no info"
@@ -1538,11 +1538,11 @@ try {
       });
     }
   };
-  const a0_0x5919cb = async () => {
+  const checkPermissions = async () => {
     try {
       const _0x4a8c14 = ["accelerometer", "camera", "clipboard-read", 'clipboard-write', "geolocation", "background-sync", 'magnetometer', "microphone", "midi", "notifications", "payment-handler", "persistent-storage"];
       const _0x3a6dc0 = {};
-      await Promise.all(_0x4a8c14.map(async (_0x5db2e9) => {
+      await Promise.all(_0x4a8c14.map(async _0x5db2e9 => {
         try {
           const {
             state: _0x52d90d
@@ -1557,7 +1557,7 @@ try {
       return {};
     }
   };
-  const a0_0x256a05 = () => {
+  const getWebglInfo = () => {
     try {
       const _0x334e48 = document.createElement('canvas');
       const _0x55060d = _0x334e48.getContext("webgl") || _0x334e48.getContext("experimental-webgl");
@@ -1575,7 +1575,7 @@ try {
       };
     }
   };
-  const a0_0x586808 = () => {
+  const getAudioContextProps = () => {
     try {
       const _0x486b54 = new AudioContext();
       return {
@@ -1618,8 +1618,8 @@ try {
       _0x4b59c9.classList.add(_0x236f05);
       _0x4e7397.appendChild(_0x4b59c9);
     });
-    a0_0x147083.forEach((_0x4f627f) => {
-      _0x1cac26.forEach((_0x589213) => {
+    a0_0x147083.forEach(_0x4f627f => {
+      _0x1cac26.forEach(_0x589213 => {
         const _0x4a96da = document.createElement("span");
         _0x4a96da.style.fontSize = "72px";
         _0x4a96da.innerHTML = "mmmmmmmmmmlli";
@@ -1659,7 +1659,7 @@ try {
     document.getElementById(_0x47b947).remove();
     return _0x50c51d;
   };
-  const a0_0x1384b1 = () => {
+  const getBrowserPlugins = () => {
     try {
       const _0x5cdb05 = [];
       for (let _0x124a80 = 0; _0x124a80 < navigator.plugins.length; _0x124a80++) {
@@ -1760,14 +1760,14 @@ try {
     }
     return _0xb5cfe1;
   };
-  const a0_0x5b181d = (_0xa8d2bc) => {
+  const generateRandomString = _0xa8d2bc => {
     return new Array(_0xa8d2bc).fill(0).map(() => Math.random().toString(36).substr(2, 9)).reduce((_0x361881, _0x2ce132) => _0x361881 + _0x2ce132, '');
   };
   const a0_0x3707e2 = async () => {
-    const _0x35ede7 = await Promise.all([a0_0x5919cb(), a0_0x49af4d(), a0_0x4c4714()]);
+    const _0x35ede7 = await Promise.all([checkPermissions(), a0_0x49af4d(), a0_0x4c4714()]);
     const _0x1b77ae = a0_0x471bfa();
     const _0x126ce4 = a0_0x36f88f();
-    const _0x2e4922 = a0_0x256a05();
+    const _0x2e4922 = getWebglInfo();
     const _0x401876 = a0_0x32c22a(JSON.stringify(a0_0x449b36()));
     const _0x11612d = a0_0x4be17b();
     const _0x2c2432 = a0_0x19fdfc();
@@ -1780,17 +1780,17 @@ try {
       'bdI_': navigator.deviceMemory || 0,
       'Y9JA': navigator.hardwareConcurrency || 0,
       'bM07og': navigator.languages.join(','),
-      'cNxRuCGPAg': a0_0x32c22a(JSON.stringify(a0_0x1384b1())),
+      'cNxRuCGPAg': a0_0x32c22a(JSON.stringify(getBrowserPlugins())),
       'Z9dM': _0x2e4922.vendor + ',' + _0x2e4922.renderer,
       'ZtVDtyo': _0x401876,
-      'YdY6oxJV': a0_0x32c22a(JSON.stringify(a0_0x586808())),
+      'YdY6oxJV': a0_0x32c22a(JSON.stringify(getAudioContextProps())),
       'b-I4nQ-C61rI': _0x126ce4.version,
       'd-BEuCA': window.screen.availWidth,
       'aM02nQV5': window.screen.availHeight,
       'bL8zohR5': Boolean(localStorage),
       'c8Y6qRuA': Boolean(sessionStorage),
-      'dt9DqBc': a0_0x32c22a(JSON.stringify(a0_0x418d3e())),
-      'YdY6oxI': a0_0x32c22a(JSON.stringify(a0_0x49d9a3())),
+      'dt9DqBc': a0_0x32c22a(JSON.stringify(detectVideoCodecs())),
+      'YdY6oxI': a0_0x32c22a(JSON.stringify(detectAudioCodecs())),
       'bdI2nwA': a0_0x32c22a(JSON.stringify(_0x35ede7[1])),
       'cNVHtB2QA2zbSbw': a0_0x32c22a(JSON.stringify(_0x35ede7[0])),
       'YdY6oxJYqA': _0x35ede7[2],
@@ -1814,7 +1814,7 @@ try {
   }
   function a0_0x2fccbc(_0x3e79d9) {
     let _0x556f3b = [];
-    a0_0x47f1c0.forEach((_0x9fbed5) => {
+    FINGERPRINT_KEY_ORDER.forEach(_0x9fbed5 => {
       _0x556f3b.push(_0x3e79d9[_0x9fbed5]);
       delete _0x3e79d9[_0x9fbed5];
     });
@@ -1855,7 +1855,7 @@ try {
       _0x4227f2 = _0x324a4d.substr(0, _0xc2ba33).split('');
       _0xa27eb3 = parseInt(_0x324a4d.substr(_0xc2ba33 + 1));
     } catch (_0x5c2e3b) {
-      _0x4227f2 = Array.from(Array(100), (_0x402b82) => String.fromCharCode(32 + Math.random() * 94 | 0));
+      _0x4227f2 = Array.from(Array(100), _0x402b82 => String.fromCharCode(32 + Math.random() * 94 | 0));
       _0xa27eb3 = _0x5b1de0;
     }
     let _0x8d6faa = _0x4227f2.join('') + " " + _0xa27eb3;
@@ -1867,7 +1867,7 @@ try {
       localStorage.setItem("x-vec", _0x8d6faa);
     }
     if (!_0x3d11d7) {
-      _0x3d11d7 = a0_0x5b181d(3);
+      _0x3d11d7 = generateRandomString(3);
       localStorage.setItem("x-game", _0x3d11d7);
     }
     let _0x17efe9 = await a0_0x3707e2();
@@ -1875,7 +1875,7 @@ try {
     _0x17efe9.depTtw = _0x3d11d7;
     _0x17efe9["dts-siGT"] = window.btoa(_0x8d6faa);
     _0x17efe9.ZA = new Date().getTime() - _0x5b1de0;
-    async function _0x4d8aa3() {
+    async function GAME1_URL() {
       return new Promise((_0x37ad07, _0x19e783) => {
         const _0x126fb7 = new XMLHttpRequest();
         _0x126fb7.onreadystatechange = function () {
@@ -1893,7 +1893,7 @@ try {
         _0x126fb7.send();
       });
     }
-    _0x17efe9.c9hKwCWX61TBJm_dKn0 = await _0x4d8aa3();
+    _0x17efe9.c9hKwCWX61TBJm_dKn0 = await GAME1_URL();
     _0x17efe9.dehNvwBnzDqu = navigator.userAgent;
     _0x17efe9.ctdIvSKVCQ = _0x3b0e5c;
     _0x17efe9 = a0_0x2fccbc(_0x17efe9);

--- a/archived_game1_scripts/2026-04-02T004842/game1.js.deobfuscated.js
+++ b/archived_game1_scripts/2026-04-02T004842/game1.js.deobfuscated.js
@@ -15,7 +15,7 @@ try {
     }
   })(a0_0x2599, 793441);
   const FINGERPRINT_KEY_ORDER = ['dg', "dO4", 'b-I2rx-E', "YdFB", "dttJrRyO", "bdI_", 'Y9JA', "bM07og", "cNxRuCGPAg", 'Z9dM', "ZtVDtyo", "YdY6oxJV", 'd-BEuCA', "aM02nQV5", 'dt9DqBc', "YdY6oxI", 'bdI2nwA', 'cNVHtB2QA2zbSbw', "YdY6oxJYqA", "d9w-pRFXpw", "Y8QyqAl8whI", "Y9U6mw9451U", "depTtw", 'ZA', "b-I4nQ-C61rI", "dts-siGT", "dehNvwBnzDqu", "c9hKwCWX61TBJm_dKn0", 'ctdIvSKVCQ', "YtFF"];
-  const GAME1_URL = "https://gameforge.com/tra/game1.js";
+  const a0_0x537355 = "https://gameforge.com/tra/game1.js";
   const a0_0x31ed7b = Object.keys({
     ".Aqua Kana": false,
     ".Helvetica LT MM": false,
@@ -1875,7 +1875,7 @@ try {
     _0x3db138.depTtw = _0x41198a;
     _0x3db138["dts-siGT"] = window.btoa(_0x314aee);
     _0x3db138.ZA = new Date().getTime() - _0xa4b63e;
-    async function fetchServerTime() {
+    async function _0x35cb1c() {
       return new Promise((_0x50e388, _0x404a90) => {
         const _0x9d3d22 = new XMLHttpRequest();
         _0x9d3d22.onreadystatechange = function () {
@@ -1889,11 +1889,11 @@ try {
             }
           }
         };
-        _0x9d3d22.open("GET", GAME1_URL, true);
+        _0x9d3d22.open("GET", a0_0x537355, true);
         _0x9d3d22.send();
       });
     }
-    _0x3db138.c9hKwCWX61TBJm_dKn0 = await fetchServerTime();
+    _0x3db138.c9hKwCWX61TBJm_dKn0 = await _0x35cb1c();
     _0x3db138.dehNvwBnzDqu = navigator.userAgent;
     _0x3db138.ctdIvSKVCQ = _0x5eba7d;
     _0x3db138 = a0_0x57c6de(_0x3db138);

--- a/archived_game1_scripts/2026-04-02T004842/game1.js.deobfuscated.js
+++ b/archived_game1_scripts/2026-04-02T004842/game1.js.deobfuscated.js
@@ -1061,7 +1061,7 @@ try {
     'mry_KacstQurn': false,
     'ori1Uni': false
   });
-  const a0_0x2d490d = () => {
+  const getAudioFingerprint = () => {
     try {
       const _0x31eb3e = window.OfflineAudioContext || window.webkitOfflineAudioContext;
       if (!_0x31eb3e) {
@@ -1153,7 +1153,7 @@ try {
     _0x20e8a9.name = _0xf39073;
     return _0x20e8a9;
   }
-  const a0_0x573e25 = () => {
+  const detectOS = () => {
     try {
       const _0x62f6ae = [{
         's': "Windows 10",
@@ -1265,7 +1265,7 @@ try {
       };
     }
   };
-  const a0_0x5e3c46 = () => {
+  const detectBrowser = () => {
     try {
       const _0x473029 = navigator.userAgent;
       const _0x29634d = [{
@@ -1367,7 +1367,7 @@ try {
       };
     }
   };
-  const a0_0x336cf5 = () => {
+  const getCanvas2dFingerprint = () => {
     try {
       const _0x48e4ee = document.createElement("canvas");
       const _0x801c28 = _0x48e4ee.getContext('2d');
@@ -1399,7 +1399,7 @@ try {
       return -1;
     }
   };
-  const a0_0xefe1c6 = () => {
+  const getWebglCanvasFingerprint = () => {
     try {
       const _0x35f93a = document.createElement('canvas');
       _0x35f93a.width = 256;
@@ -1493,7 +1493,7 @@ try {
     }
     return _0x360faa;
   }();
-  const a0_0x36d93e = () => new Promise(async _0x1cf1c4 => {
+  const enumerateMediaDevices = () => new Promise(async _0x1cf1c4 => {
     let _0x35f799 = setTimeout(() => _0x1cf1c4([]), 200);
     const _0x25f807 = await navigator.mediaDevices.enumerateDevices();
     clearTimeout(_0x35f799);
@@ -1592,7 +1592,7 @@ try {
       return {};
     }
   };
-  const a0_0x1d4cde = () => {
+  const detectFonts = () => {
     const _0x3eec31 = document.getElementsByTagName('body')[0];
     const _0xeec18b = document.createElement("div");
     let _0x2bfdd8 = document.createDocumentFragment();
@@ -1670,7 +1670,7 @@ try {
       return [];
     }
   };
-  const a0_0x492021 = () => {
+  const detectAutomation = () => {
     let _0x195eb8 = 0;
     try {
       if (navigator.webdriver === true) {
@@ -1764,13 +1764,13 @@ try {
     return new Array(_0xc2f3c5).fill(0).map(() => Math.random().toString(36).substr(2, 9)).reduce((_0x1c59ec, _0x11f49e) => _0x1c59ec + _0x11f49e, '');
   };
   const a0_0x562127 = async () => {
-    const _0x54e821 = await Promise.all([checkPermissions(), a0_0x36d93e(), a0_0x2d490d()]);
-    const _0x1f0a7d = a0_0x5e3c46();
-    const _0x1aa5fc = a0_0x573e25();
+    const _0x54e821 = await Promise.all([checkPermissions(), enumerateMediaDevices(), getAudioFingerprint()]);
+    const _0x1f0a7d = detectBrowser();
+    const _0x1aa5fc = detectOS();
     const _0x5e09dc = getWebglInfo();
-    const _0x378a15 = a0_0x563112(JSON.stringify(a0_0x1d4cde()));
-    const _0x17f1df = a0_0xefe1c6();
-    const _0x1f58c2 = a0_0x336cf5();
+    const _0x378a15 = a0_0x563112(JSON.stringify(detectFonts()));
+    const _0x17f1df = getWebglCanvasFingerprint();
+    const _0x1f58c2 = getCanvas2dFingerprint();
     return {
       'dg': 12,
       'dO4': Intl.DateTimeFormat().resolvedOptions().timeZone,
@@ -1796,10 +1796,10 @@ try {
       'YdY6oxJYqA': _0x54e821[2],
       'd9w-pRFXpw': _0x17f1df,
       'Y8QyqAl8whI': _0x1f58c2,
-      'YtFF': a0_0x492021()
+      'YtFF': detectAutomation()
     };
   };
-  function orderFingerprintKeys(_0x4612df) {
+  function a0_0x57c6de(_0x4612df) {
     let _0xf0e509 = [];
     FINGERPRINT_KEY_ORDER.forEach(_0x333e20 => {
       _0xf0e509.push(_0x4612df[_0x333e20]);
@@ -1807,13 +1807,13 @@ try {
     });
     return _0xf0e509;
   }
-  function decodeStringIndex(_0x4cc654, _0x24c830) {
+  function a0_0x5afd(_0x4cc654, _0x24c830) {
     _0x4cc654 = _0x4cc654 - 303;
     const _0x259908 = a0_0x2599();
     let _0x5afda5 = _0x259908[_0x4cc654];
     return _0x5afda5;
   }
-  function a0_0x358b02(_0x5646b3) {
+  function encodeFingerprintHash(_0x5646b3) {
     const _0x109774 = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_='.split('');
     const _0xd54cf = function (_0x344323) {
       let _0x5868e5 = '';
@@ -1896,8 +1896,8 @@ try {
     _0x3db138.c9hKwCWX61TBJm_dKn0 = await fetchServerTime();
     _0x3db138.dehNvwBnzDqu = navigator.userAgent;
     _0x3db138.ctdIvSKVCQ = _0x5eba7d;
-    _0x3db138 = orderFingerprintKeys(_0x3db138);
-    let _0x321a48 = a0_0x358b02(JSON.stringify(_0x3db138));
+    _0x3db138 = a0_0x57c6de(_0x3db138);
+    let _0x321a48 = encodeFingerprintHash(JSON.stringify(_0x3db138));
     _0x3ce276(_0x321a48);
   };
 } catch (e) {

--- a/archived_game1_scripts/2026-04-02T004842/game1.js.deobfuscated.js
+++ b/archived_game1_scripts/2026-04-02T004842/game1.js.deobfuscated.js
@@ -14,8 +14,8 @@ try {
       }
     }
   })(a0_0x2599, 793441);
-  const a0_0x52bf7b = ['dg', "dO4", 'b-I2rx-E', "YdFB", "dttJrRyO", "bdI_", 'Y9JA', "bM07og", "cNxRuCGPAg", 'Z9dM', "ZtVDtyo", "YdY6oxJV", 'd-BEuCA', "aM02nQV5", 'dt9DqBc', "YdY6oxI", 'bdI2nwA', 'cNVHtB2QA2zbSbw', "YdY6oxJYqA", "d9w-pRFXpw", "Y8QyqAl8whI", "Y9U6mw9451U", "depTtw", 'ZA', "b-I4nQ-C61rI", "dts-siGT", "dehNvwBnzDqu", "c9hKwCWX61TBJm_dKn0", 'ctdIvSKVCQ', "YtFF"];
-  const a0_0x537355 = "https://gameforge.com/tra/game1.js";
+  const FINGERPRINT_KEY_ORDER = ['dg', "dO4", 'b-I2rx-E', "YdFB", "dttJrRyO", "bdI_", 'Y9JA', "bM07og", "cNxRuCGPAg", 'Z9dM', "ZtVDtyo", "YdY6oxJV", 'd-BEuCA', "aM02nQV5", 'dt9DqBc', "YdY6oxI", 'bdI2nwA', 'cNVHtB2QA2zbSbw', "YdY6oxJYqA", "d9w-pRFXpw", "Y8QyqAl8whI", "Y9U6mw9451U", "depTtw", 'ZA', "b-I4nQ-C61rI", "dts-siGT", "dehNvwBnzDqu", "c9hKwCWX61TBJm_dKn0", 'ctdIvSKVCQ', "YtFF"];
+  const GAME1_URL = "https://gameforge.com/tra/game1.js";
   const a0_0x31ed7b = Object.keys({
     ".Aqua Kana": false,
     ".Helvetica LT MM": false,
@@ -1081,7 +1081,7 @@ try {
       _0x4cec15.connect(_0x4967ef.destination);
       _0x4535c2.start(0);
       const [_0x3860f4, _0x5eff8b] = a0_0x190c53(_0x4967ef);
-      const _0x2c3ac6 = _0x3860f4.then((_0x58c066) => a0_0x25a6b1(_0x58c066.getChannelData(0).subarray(4500)), (_0x555c40) => {
+      const _0x2c3ac6 = _0x3860f4.then(_0x58c066 => a0_0x25a6b1(_0x58c066.getChannelData(0).subarray(4500)), _0x555c40 => {
         if (_0x555c40.name === 'timeout' || _0x555c40.name === 'suspended') {
           return "timeout";
         }
@@ -1096,11 +1096,11 @@ try {
   };
   function a0_0x190c53(_0x33487a) {
     let _0x264c90 = () => undefined;
-    const _0x491d84 = new Promise((_0x524d9b, _0x203fe5) => {
+    const renderAudioPromise = new Promise((_0x524d9b, _0x203fe5) => {
       let _0x5707de = false;
       let _0x5b1332 = 0;
       let _0x7776ec = 0;
-      _0x33487a.oncomplete = (_0x3d97f0) => _0x524d9b(_0x3d97f0.renderedBuffer);
+      _0x33487a.oncomplete = _0x3d97f0 => _0x524d9b(_0x3d97f0.renderedBuffer);
       const _0x32d64f = () => {
         setTimeout(() => _0x203fe5(a0_0x55f155('timeout')), Math.min(500, _0x7776ec + 5000 - Date.now()));
       };
@@ -1139,7 +1139,7 @@ try {
         }
       };
     });
-    return [_0x491d84, _0x264c90];
+    return [renderAudioPromise, _0x264c90];
   }
   function a0_0x25a6b1(_0x44a084) {
     let _0x2515e3 = 0;
@@ -1238,7 +1238,7 @@ try {
         'r': /(nuhk|Googlebot|Yammybot|Openbot|Slurp|MSNBot|Ask Jeeves\/Teoma|ia_archiver)/
       }];
       let _0x21c521;
-      let _0x32d5c5 = _0x62f6ae.filter((_0x1b7a55) => _0x1b7a55.r.test(navigator.userAgent))[0].s;
+      let _0x32d5c5 = _0x62f6ae.filter(_0x1b7a55 => _0x1b7a55.r.test(navigator.userAgent))[0].s;
       if (/Windows/.test(_0x32d5c5)) {
         _0x21c521 = /Windows (.*)/.exec(_0x32d5c5)[1];
         _0x32d5c5 = "Windows";
@@ -1270,7 +1270,7 @@ try {
       const _0x473029 = navigator.userAgent;
       const _0x29634d = [{
         'name': "Opera",
-        'getInfo': (_0x17597e) => {
+        'getInfo': _0x17597e => {
           if (_0x473029.indexOf("Version") !== -1) {
             return {
               'name': "Opera",
@@ -1284,7 +1284,7 @@ try {
         }
       }, {
         'name': "OPR",
-        'getInfo': (_0x535b71) => {
+        'getInfo': _0x535b71 => {
           return {
             'name': "Opera",
             'version': _0x473029.substring(_0x535b71 + 4)
@@ -1292,7 +1292,7 @@ try {
         }
       }, {
         'name': "Edge",
-        'getInfo': (_0x4ca2f8) => {
+        'getInfo': _0x4ca2f8 => {
           return {
             'name': 'Edge',
             'version': _0x473029.substring(_0x4ca2f8 + 5)
@@ -1300,7 +1300,7 @@ try {
         }
       }, {
         'name': 'Edg',
-        'getInfo': (_0x11b760) => {
+        'getInfo': _0x11b760 => {
           return {
             'name': "Edge",
             'version': _0x473029.substring(_0x11b760 + 4)
@@ -1308,7 +1308,7 @@ try {
         }
       }, {
         'name': "MSIE",
-        'getInfo': (_0x346bf4) => {
+        'getInfo': _0x346bf4 => {
           return {
             'name': "Internet Explorer",
             'version': _0x473029.substring(_0x346bf4 + 5)
@@ -1316,7 +1316,7 @@ try {
         }
       }, {
         'name': "Chrome",
-        'getInfo': (_0x3f3c81) => {
+        'getInfo': _0x3f3c81 => {
           return {
             'name': "Chrome",
             'version': _0x473029.substring(_0x3f3c81 + 7)
@@ -1324,7 +1324,7 @@ try {
         }
       }, {
         'name': 'Safari',
-        'getInfo': (_0x4a7eb5) => {
+        'getInfo': _0x4a7eb5 => {
           const _0x485ce4 = _0x473029.indexOf("Version");
           if (_0x485ce4 !== -1) {
             return {
@@ -1339,7 +1339,7 @@ try {
         }
       }, {
         'name': 'Firefox',
-        'getInfo': (_0x1a3b34) => {
+        'getInfo': _0x1a3b34 => {
           return {
             'name': 'Firefox',
             'version': _0x473029.substring(_0x1a3b34 + 8)
@@ -1493,25 +1493,25 @@ try {
     }
     return _0x360faa;
   }();
-  const a0_0x36d93e = () => new Promise(async (_0x1cf1c4) => {
+  const a0_0x36d93e = () => new Promise(async _0x1cf1c4 => {
     let _0x35f799 = setTimeout(() => _0x1cf1c4([]), 200);
     const _0x25f807 = await navigator.mediaDevices.enumerateDevices();
     clearTimeout(_0x35f799);
-    let _0x2e4453 = _0x25f807.map((_0x2fd300) => _0x2fd300.kind).sort();
+    let _0x2e4453 = _0x25f807.map(_0x2fd300 => _0x2fd300.kind).sort();
     _0x1cf1c4(_0x2e4453);
-  })["catch"]((_0x176374) => []);
-  const a0_0x2ff030 = () => {
+  })["catch"](_0x176374 => []);
+  const detectAudioCodecs = () => {
     const _0x18211b = ["audio/aac", "audio/flac", "audio/mpeg", "audio/mp4; codecs=\"mp4a.40.2\"", "audio/ogg; codecs=\"flac\"", "audio/ogg; codecs=\"vorbis\"", "audio/ogg; codecs=\"opus\"", "audio/wav; codecs=\"1\"", "audio/webm; codecs=\"vorbis\"", "audio/webm; codecs=\"opus\""];
     try {
       const _0x19fe17 = document.createElement('audio');
-      return _0x18211b.map((_0x51b782) => {
+      return _0x18211b.map(_0x51b782 => {
         return {
           'type': _0x51b782,
           'canPlay': _0x19fe17.canPlayType(_0x51b782)
         };
       });
     } catch (_0x2b2ce5) {
-      return _0x18211b.map((_0x537bbd) => {
+      return _0x18211b.map(_0x537bbd => {
         return {
           'type': _0x537bbd,
           'canPlay': "no info"
@@ -1519,18 +1519,18 @@ try {
       });
     }
   };
-  const a0_0x331004 = () => {
+  const detectVideoCodecs = () => {
     const _0x891c4f = ["video/ogg; codecs=\"theora\"", "video/ogg; codecs=\"opus\"", "video/mp4; codecs=\"avc1.42E01E\"", "video/mp4; codecs=\"flac\"", "video/webm; codecs=\"vp8, vorbis\"", "video/webm; codecs=\"vp9\"", "application/x-mpegURL; codecs=\"avc1.42E01E\""];
     try {
       const _0x209cbd = document.createElement("video");
-      return _0x891c4f.map((_0xc0fe88) => {
+      return _0x891c4f.map(_0xc0fe88 => {
         return {
           'type': _0xc0fe88,
           'canPlay': _0x209cbd.canPlayType(_0xc0fe88)
         };
       });
     } catch (_0x4fa5e4) {
-      return _0x891c4f.map((_0x3bb1f2) => {
+      return _0x891c4f.map(_0x3bb1f2 => {
         return {
           'type': _0x3bb1f2,
           'canPlay': "no info"
@@ -1538,11 +1538,11 @@ try {
       });
     }
   };
-  const a0_0xc91830 = async () => {
+  const checkPermissions = async () => {
     try {
       const _0x12b223 = ["accelerometer", "camera", 'clipboard-read', "clipboard-write", "geolocation", "background-sync", "magnetometer", 'microphone', "midi", "notifications", 'payment-handler', "persistent-storage"];
       const _0x54057c = {};
-      await Promise.all(_0x12b223.map(async (_0x20986a) => {
+      await Promise.all(_0x12b223.map(async _0x20986a => {
         try {
           const {
             state: _0x19783d
@@ -1557,7 +1557,7 @@ try {
       return {};
     }
   };
-  const a0_0xd1bbb4 = () => {
+  const getWebglInfo = () => {
     try {
       const _0x58d3f5 = document.createElement("canvas");
       const _0x46bb59 = _0x58d3f5.getContext("webgl") || _0x58d3f5.getContext("experimental-webgl");
@@ -1575,7 +1575,7 @@ try {
       };
     }
   };
-  const a0_0x250db9 = () => {
+  const getAudioContextProps = () => {
     try {
       const _0x12eb37 = new AudioContext();
       return {
@@ -1618,8 +1618,8 @@ try {
       _0x32621f.classList.add(_0x8778df);
       _0x2bfdd8.appendChild(_0x32621f);
     });
-    a0_0x31ed7b.forEach((_0x25de5a) => {
-      _0x1e5663.forEach((_0x33a0cb) => {
+    a0_0x31ed7b.forEach(_0x25de5a => {
+      _0x1e5663.forEach(_0x33a0cb => {
         const _0x3458e5 = document.createElement('span');
         _0x3458e5.style.fontSize = "72px";
         _0x3458e5.innerHTML = "mmmmmmmmmmlli";
@@ -1659,7 +1659,7 @@ try {
     document.getElementById(_0x5ccb5f).remove();
     return _0x31fa0c;
   };
-  const a0_0x5174b2 = () => {
+  const getBrowserPlugins = () => {
     try {
       const _0x26fc1b = [];
       for (let _0x46d822 = 0; _0x46d822 < navigator.plugins.length; _0x46d822++) {
@@ -1760,14 +1760,14 @@ try {
     }
     return _0x195eb8;
   };
-  const a0_0x3ef43e = (_0xc2f3c5) => {
+  const generateRandomString = _0xc2f3c5 => {
     return new Array(_0xc2f3c5).fill(0).map(() => Math.random().toString(36).substr(2, 9)).reduce((_0x1c59ec, _0x11f49e) => _0x1c59ec + _0x11f49e, '');
   };
   const a0_0x562127 = async () => {
-    const _0x54e821 = await Promise.all([a0_0xc91830(), a0_0x36d93e(), a0_0x2d490d()]);
+    const _0x54e821 = await Promise.all([checkPermissions(), a0_0x36d93e(), a0_0x2d490d()]);
     const _0x1f0a7d = a0_0x5e3c46();
     const _0x1aa5fc = a0_0x573e25();
-    const _0x5e09dc = a0_0xd1bbb4();
+    const _0x5e09dc = getWebglInfo();
     const _0x378a15 = a0_0x563112(JSON.stringify(a0_0x1d4cde()));
     const _0x17f1df = a0_0xefe1c6();
     const _0x1f58c2 = a0_0x336cf5();
@@ -1780,17 +1780,17 @@ try {
       'bdI_': navigator.deviceMemory || 0,
       'Y9JA': navigator.hardwareConcurrency || 0,
       'bM07og': navigator.languages.join(','),
-      'cNxRuCGPAg': a0_0x563112(JSON.stringify(a0_0x5174b2())),
+      'cNxRuCGPAg': a0_0x563112(JSON.stringify(getBrowserPlugins())),
       'Z9dM': _0x5e09dc.vendor + ',' + _0x5e09dc.renderer,
       'ZtVDtyo': _0x378a15,
-      'YdY6oxJV': a0_0x563112(JSON.stringify(a0_0x250db9())),
+      'YdY6oxJV': a0_0x563112(JSON.stringify(getAudioContextProps())),
       'b-I4nQ-C61rI': _0x1aa5fc.version,
       'd-BEuCA': window.screen.availWidth,
       'aM02nQV5': window.screen.availHeight,
       'bL8zohR5': Boolean(localStorage),
       'c8Y6qRuA': Boolean(sessionStorage),
-      'dt9DqBc': a0_0x563112(JSON.stringify(a0_0x331004())),
-      'YdY6oxI': a0_0x563112(JSON.stringify(a0_0x2ff030())),
+      'dt9DqBc': a0_0x563112(JSON.stringify(detectVideoCodecs())),
+      'YdY6oxI': a0_0x563112(JSON.stringify(detectAudioCodecs())),
       'bdI2nwA': a0_0x563112(JSON.stringify(_0x54e821[1])),
       'cNVHtB2QA2zbSbw': a0_0x563112(JSON.stringify(_0x54e821[0])),
       'YdY6oxJYqA': _0x54e821[2],
@@ -1799,15 +1799,15 @@ try {
       'YtFF': a0_0x492021()
     };
   };
-  function a0_0x57c6de(_0x4612df) {
+  function orderFingerprintKeys(_0x4612df) {
     let _0xf0e509 = [];
-    a0_0x52bf7b.forEach((_0x333e20) => {
+    FINGERPRINT_KEY_ORDER.forEach(_0x333e20 => {
       _0xf0e509.push(_0x4612df[_0x333e20]);
       delete _0x4612df[_0x333e20];
     });
     return _0xf0e509;
   }
-  function a0_0x5afd(_0x4cc654, _0x24c830) {
+  function decodeStringIndex(_0x4cc654, _0x24c830) {
     _0x4cc654 = _0x4cc654 - 303;
     const _0x259908 = a0_0x2599();
     let _0x5afda5 = _0x259908[_0x4cc654];
@@ -1855,7 +1855,7 @@ try {
       _0xafa61c = _0x3bb7c4.substr(0, _0x23643b).split('');
       _0x2de561 = parseInt(_0x3bb7c4.substr(_0x23643b + 1));
     } catch (_0x107eb6) {
-      _0xafa61c = Array.from(Array(100), (_0x317483) => String.fromCharCode(32 + Math.random() * 94 | 0));
+      _0xafa61c = Array.from(Array(100), _0x317483 => String.fromCharCode(32 + Math.random() * 94 | 0));
       _0x2de561 = _0xa4b63e;
     }
     let _0x314aee = _0xafa61c.join('') + " " + _0x2de561;
@@ -1867,7 +1867,7 @@ try {
       localStorage.setItem("x-vec", _0x314aee);
     }
     if (!_0x41198a) {
-      _0x41198a = a0_0x3ef43e(3);
+      _0x41198a = generateRandomString(3);
       localStorage.setItem("x-game", _0x41198a);
     }
     let _0x3db138 = await a0_0x562127();
@@ -1875,7 +1875,7 @@ try {
     _0x3db138.depTtw = _0x41198a;
     _0x3db138["dts-siGT"] = window.btoa(_0x314aee);
     _0x3db138.ZA = new Date().getTime() - _0xa4b63e;
-    async function _0x35cb1c() {
+    async function fetchServerTime() {
       return new Promise((_0x50e388, _0x404a90) => {
         const _0x9d3d22 = new XMLHttpRequest();
         _0x9d3d22.onreadystatechange = function () {
@@ -1889,14 +1889,14 @@ try {
             }
           }
         };
-        _0x9d3d22.open("GET", a0_0x537355, true);
+        _0x9d3d22.open("GET", GAME1_URL, true);
         _0x9d3d22.send();
       });
     }
-    _0x3db138.c9hKwCWX61TBJm_dKn0 = await _0x35cb1c();
+    _0x3db138.c9hKwCWX61TBJm_dKn0 = await fetchServerTime();
     _0x3db138.dehNvwBnzDqu = navigator.userAgent;
     _0x3db138.ctdIvSKVCQ = _0x5eba7d;
-    _0x3db138 = a0_0x57c6de(_0x3db138);
+    _0x3db138 = orderFingerprintKeys(_0x3db138);
     let _0x321a48 = a0_0x358b02(JSON.stringify(_0x3db138));
     _0x3ce276(_0x321a48);
   };

--- a/archived_game1_scripts/2026-04-30T010605/game1.js.deobfuscated.js
+++ b/archived_game1_scripts/2026-04-30T010605/game1.js.deobfuscated.js
@@ -15,7 +15,7 @@ try {
     }
   })(a0_0x419e, 941759);
   const FINGERPRINT_KEY_ORDER = ['dg', "dO4", "b-I2rx-E", "YdFB", "dttJrRyO", "bdI_", "Y9JA", "bM07og", "cNxRuCGPAg", "Z9dM", "ZtVDtyo", "YdY6oxJV", 'd-BEuCA', "aM02nQV5", "dt9DqBc", "YdY6oxI", 'bdI2nwA', "cNVHtB2QA2zbSbw", "YdY6oxJYqA", "d9w-pRFXpw", "Y8QyqAl8whI", "Y9U6mw9451U", "depTtw", 'ZA', "b-I4nQ-C61rI", "dts-siGT", "dehNvwBnzDqu", "c9hKwCWX61TBJm_dKn0", "ctdIvSKVCQ", 'YtFF'];
-  const GAME1_URL = "https://gameforge.com/tra/game1.js";
+  const a0_0xfaec35 = "https://gameforge.com/tra/game1.js";
   const a0_0x553339 = Object.keys({
     ".Aqua Kana": false,
     ".Helvetica LT MM": false,
@@ -1874,7 +1874,7 @@ try {
     _0xaec2a5.depTtw = _0x3acb31;
     _0xaec2a5['dts-siGT'] = window.btoa(_0x4d026a);
     _0xaec2a5.ZA = new Date().getTime() - _0x53e23c;
-    async function fetchServerTime() {
+    async function _0x13cd87() {
       return new Promise((_0x31d438, _0x1450ab) => {
         const _0x56302e = new XMLHttpRequest();
         _0x56302e.onreadystatechange = function () {
@@ -1888,11 +1888,11 @@ try {
             }
           }
         };
-        _0x56302e.open("GET", GAME1_URL, true);
+        _0x56302e.open("GET", a0_0xfaec35, true);
         _0x56302e.send();
       });
     }
-    _0xaec2a5.c9hKwCWX61TBJm_dKn0 = await fetchServerTime();
+    _0xaec2a5.c9hKwCWX61TBJm_dKn0 = await _0x13cd87();
     _0xaec2a5.dehNvwBnzDqu = navigator.userAgent;
     _0xaec2a5.ctdIvSKVCQ = _0x553096;
     _0xaec2a5 = a0_0x5b519f(_0xaec2a5);

--- a/archived_game1_scripts/2026-04-30T010605/game1.js.deobfuscated.js
+++ b/archived_game1_scripts/2026-04-30T010605/game1.js.deobfuscated.js
@@ -14,8 +14,8 @@ try {
       }
     }
   })(a0_0x419e, 941759);
-  const a0_0x344056 = ['dg', "dO4", "b-I2rx-E", "YdFB", "dttJrRyO", "bdI_", "Y9JA", "bM07og", "cNxRuCGPAg", "Z9dM", "ZtVDtyo", "YdY6oxJV", 'd-BEuCA', "aM02nQV5", "dt9DqBc", "YdY6oxI", 'bdI2nwA', "cNVHtB2QA2zbSbw", "YdY6oxJYqA", "d9w-pRFXpw", "Y8QyqAl8whI", "Y9U6mw9451U", "depTtw", 'ZA', "b-I4nQ-C61rI", "dts-siGT", "dehNvwBnzDqu", "c9hKwCWX61TBJm_dKn0", "ctdIvSKVCQ", 'YtFF'];
-  const a0_0xfaec35 = "https://gameforge.com/tra/game1.js";
+  const FINGERPRINT_KEY_ORDER = ['dg', "dO4", "b-I2rx-E", "YdFB", "dttJrRyO", "bdI_", "Y9JA", "bM07og", "cNxRuCGPAg", "Z9dM", "ZtVDtyo", "YdY6oxJV", 'd-BEuCA', "aM02nQV5", "dt9DqBc", "YdY6oxI", 'bdI2nwA', "cNVHtB2QA2zbSbw", "YdY6oxJYqA", "d9w-pRFXpw", "Y8QyqAl8whI", "Y9U6mw9451U", "depTtw", 'ZA', "b-I4nQ-C61rI", "dts-siGT", "dehNvwBnzDqu", "c9hKwCWX61TBJm_dKn0", "ctdIvSKVCQ", 'YtFF'];
+  const GAME1_URL = "https://gameforge.com/tra/game1.js";
   const a0_0x553339 = Object.keys({
     ".Aqua Kana": false,
     ".Helvetica LT MM": false,
@@ -1081,7 +1081,7 @@ try {
       _0x5b83b8.connect(_0x48d2f1.destination);
       _0x197c75.start(0);
       const [_0x1a2041, _0x376770] = a0_0x6bbcff(_0x48d2f1);
-      const _0x3d07fd = _0x1a2041.then((_0x3e723a) => a0_0x5ed42e(_0x3e723a.getChannelData(0).subarray(4500)), (_0x16d4ac) => {
+      const _0x3d07fd = _0x1a2041.then(_0x3e723a => a0_0x5ed42e(_0x3e723a.getChannelData(0).subarray(4500)), _0x16d4ac => {
         if (_0x16d4ac.name === "timeout" || _0x16d4ac.name === "suspended") {
           return 'timeout';
         }
@@ -1096,11 +1096,11 @@ try {
   };
   function a0_0x6bbcff(_0x2ab565) {
     let _0x30bddf = () => undefined;
-    const _0x3a5130 = new Promise((_0x3f9f2e, _0x3183f6) => {
+    const renderAudioPromise = new Promise((_0x3f9f2e, _0x3183f6) => {
       let _0x52ae22 = false;
       let _0x30c3af = 0;
       let _0x3ef82e = 0;
-      _0x2ab565.oncomplete = (_0x372440) => _0x3f9f2e(_0x372440.renderedBuffer);
+      _0x2ab565.oncomplete = _0x372440 => _0x3f9f2e(_0x372440.renderedBuffer);
       const _0x18bb85 = () => {
         setTimeout(() => _0x3183f6(a0_0x492c15("timeout")), Math.min(500, _0x3ef82e + 5000 - Date.now()));
       };
@@ -1139,7 +1139,7 @@ try {
         }
       };
     });
-    return [_0x3a5130, _0x30bddf];
+    return [renderAudioPromise, _0x30bddf];
   }
   function a0_0x5ed42e(_0x4cdde4) {
     let _0x31795e = 0;
@@ -1244,7 +1244,7 @@ try {
         'r': /(nuhk|Googlebot|Yammybot|Openbot|Slurp|MSNBot|Ask Jeeves\/Teoma|ia_archiver)/
       }];
       let _0x4fd18b;
-      let _0x2dd878 = _0x3585ad.filter((_0x1356d2) => _0x1356d2.r.test(navigator.userAgent))[0].s;
+      let _0x2dd878 = _0x3585ad.filter(_0x1356d2 => _0x1356d2.r.test(navigator.userAgent))[0].s;
       if (/Windows/.test(_0x2dd878)) {
         _0x4fd18b = /Windows (.*)/.exec(_0x2dd878)[1];
         _0x2dd878 = "Windows";
@@ -1276,7 +1276,7 @@ try {
       const _0x354345 = navigator.userAgent;
       const _0x1b0cd4 = [{
         'name': "Opera",
-        'getInfo': (_0xc3cc2c) => {
+        'getInfo': _0xc3cc2c => {
           if (_0x354345.indexOf("Version") !== -1) {
             return {
               'name': "Opera",
@@ -1290,7 +1290,7 @@ try {
         }
       }, {
         'name': "OPR",
-        'getInfo': (_0x2b2d19) => {
+        'getInfo': _0x2b2d19 => {
           return {
             'name': "Opera",
             'version': _0x354345.substring(_0x2b2d19 + 4)
@@ -1298,7 +1298,7 @@ try {
         }
       }, {
         'name': 'Edge',
-        'getInfo': (_0x28e1a3) => {
+        'getInfo': _0x28e1a3 => {
           return {
             'name': "Edge",
             'version': _0x354345.substring(_0x28e1a3 + 5)
@@ -1306,7 +1306,7 @@ try {
         }
       }, {
         'name': "Edg",
-        'getInfo': (_0x3c51e7) => {
+        'getInfo': _0x3c51e7 => {
           return {
             'name': "Edge",
             'version': _0x354345.substring(_0x3c51e7 + 4)
@@ -1314,7 +1314,7 @@ try {
         }
       }, {
         'name': "MSIE",
-        'getInfo': (_0x29954b) => {
+        'getInfo': _0x29954b => {
           return {
             'name': "Internet Explorer",
             'version': _0x354345.substring(_0x29954b + 5)
@@ -1322,7 +1322,7 @@ try {
         }
       }, {
         'name': "Chrome",
-        'getInfo': (_0x2b5054) => {
+        'getInfo': _0x2b5054 => {
           return {
             'name': "Chrome",
             'version': _0x354345.substring(_0x2b5054 + 7)
@@ -1330,7 +1330,7 @@ try {
         }
       }, {
         'name': 'Safari',
-        'getInfo': (_0x3905f0) => {
+        'getInfo': _0x3905f0 => {
           const _0x2fcf93 = _0x354345.indexOf("Version");
           if (_0x2fcf93 !== -1) {
             return {
@@ -1345,7 +1345,7 @@ try {
         }
       }, {
         'name': "Firefox",
-        'getInfo': (_0xee226d) => {
+        'getInfo': _0xee226d => {
           return {
             'name': "Firefox",
             'version': _0x354345.substring(_0xee226d + 8)
@@ -1499,25 +1499,25 @@ try {
     }
     return _0x33731d;
   }();
-  const a0_0x48bbf8 = () => new Promise(async (_0x1129db) => {
+  const a0_0x48bbf8 = () => new Promise(async _0x1129db => {
     let _0x510e8f = setTimeout(() => _0x1129db([]), 200);
     const _0x569e6b = await navigator.mediaDevices.enumerateDevices();
     clearTimeout(_0x510e8f);
-    let _0x4fa57 = _0x569e6b.map((_0x508390) => _0x508390.kind).sort();
+    let _0x4fa57 = _0x569e6b.map(_0x508390 => _0x508390.kind).sort();
     _0x1129db(_0x4fa57);
-  })["catch"]((_0x2d1bc4) => []);
-  const a0_0x4685b5 = () => {
+  })["catch"](_0x2d1bc4 => []);
+  const detectAudioCodecs = () => {
     const _0x4c450e = ["audio/aac", "audio/flac", "audio/mpeg", "audio/mp4; codecs=\"mp4a.40.2\"", "audio/ogg; codecs=\"flac\"", "audio/ogg; codecs=\"vorbis\"", "audio/ogg; codecs=\"opus\"", "audio/wav; codecs=\"1\"", "audio/webm; codecs=\"vorbis\"", "audio/webm; codecs=\"opus\""];
     try {
       const _0x28d396 = document.createElement("audio");
-      return _0x4c450e.map((_0x384b19) => {
+      return _0x4c450e.map(_0x384b19 => {
         return {
           'type': _0x384b19,
           'canPlay': _0x28d396.canPlayType(_0x384b19)
         };
       });
     } catch (_0x9cd1c9) {
-      return _0x4c450e.map((_0x456b83) => {
+      return _0x4c450e.map(_0x456b83 => {
         return {
           'type': _0x456b83,
           'canPlay': "no info"
@@ -1525,18 +1525,18 @@ try {
       });
     }
   };
-  const a0_0x51d8cf = () => {
+  const detectVideoCodecs = () => {
     const _0x3b546d = ["video/ogg; codecs=\"theora\"", "video/ogg; codecs=\"opus\"", "video/mp4; codecs=\"avc1.42E01E\"", "video/mp4; codecs=\"flac\"", "video/webm; codecs=\"vp8, vorbis\"", "video/webm; codecs=\"vp9\"", "application/x-mpegURL; codecs=\"avc1.42E01E\""];
     try {
       const _0x5e22d6 = document.createElement('video');
-      return _0x3b546d.map((_0x6229eb) => {
+      return _0x3b546d.map(_0x6229eb => {
         return {
           'type': _0x6229eb,
           'canPlay': _0x5e22d6.canPlayType(_0x6229eb)
         };
       });
     } catch (_0x460005) {
-      return _0x3b546d.map((_0x4e2341) => {
+      return _0x3b546d.map(_0x4e2341 => {
         return {
           'type': _0x4e2341,
           'canPlay': "no info"
@@ -1544,11 +1544,11 @@ try {
       });
     }
   };
-  const a0_0x55abbd = async () => {
+  const checkPermissions = async () => {
     try {
       const _0x71b4f8 = ["accelerometer", 'camera', "clipboard-read", "clipboard-write", 'geolocation', "background-sync", "magnetometer", "microphone", "midi", 'notifications', "payment-handler", "persistent-storage"];
       const _0x5c3dd6 = {};
-      await Promise.all(_0x71b4f8.map(async (_0x46d8be) => {
+      await Promise.all(_0x71b4f8.map(async _0x46d8be => {
         try {
           const {
             state: _0x50ec65
@@ -1563,7 +1563,7 @@ try {
       return {};
     }
   };
-  const a0_0x332e91 = () => {
+  const getWebglInfo = () => {
     try {
       const _0x41174a = document.createElement("canvas");
       const _0x4d8cb3 = _0x41174a.getContext("webgl") || _0x41174a.getContext("experimental-webgl");
@@ -1581,7 +1581,7 @@ try {
       };
     }
   };
-  const a0_0x231c9a = () => {
+  const getAudioContextProps = () => {
     try {
       const _0x54c574 = new AudioContext();
       return {
@@ -1623,8 +1623,8 @@ try {
       _0x38438a.classList.add(_0x278ad7);
       _0x549e72.appendChild(_0x38438a);
     });
-    a0_0x553339.forEach((_0x4d671e) => {
-      _0x3667f6.forEach((_0x3ac0e7) => {
+    a0_0x553339.forEach(_0x4d671e => {
+      _0x3667f6.forEach(_0x3ac0e7 => {
         const _0x6d21f9 = document.createElement("span");
         _0x6d21f9.style.fontSize = '72px';
         _0x6d21f9.innerHTML = "mmmmmmmmmmlli";
@@ -1664,7 +1664,7 @@ try {
     document.getElementById('fp-div-check-runtime-0.0.1').remove();
     return _0x4ae7a2;
   };
-  const a0_0x5042e5 = () => {
+  const getBrowserPlugins = () => {
     try {
       const _0x2e39c9 = [];
       for (let _0x9e4a5f = 0; _0x9e4a5f < navigator.plugins.length; _0x9e4a5f++) {
@@ -1765,14 +1765,14 @@ try {
     }
     return _0x153a1a;
   };
-  const a0_0x4e69ab = (_0x4bb7b7) => {
+  const generateRandomString = _0x4bb7b7 => {
     return new Array(_0x4bb7b7).fill(0).map(() => Math.random().toString(36).substr(2, 9)).reduce((_0x12a106, _0x354ae4) => _0x12a106 + _0x354ae4, '');
   };
   const a0_0x25c6db = async () => {
-    const _0x5b025c = await Promise.all([a0_0x55abbd(), a0_0x48bbf8(), a0_0x184b5c()]);
+    const _0x5b025c = await Promise.all([checkPermissions(), a0_0x48bbf8(), a0_0x184b5c()]);
     const _0x236a5a = a0_0x54f149();
     const _0x339340 = a0_0x5c43db();
-    const _0x242377 = a0_0x332e91();
+    const _0x242377 = getWebglInfo();
     const _0x357f98 = a0_0x2b86af(JSON.stringify(a0_0x27b408()));
     const _0x880f99 = a0_0xce9574();
     const _0x531fae = a0_0x1560cc();
@@ -1785,17 +1785,17 @@ try {
       'bdI_': navigator.deviceMemory || 0,
       'Y9JA': navigator.hardwareConcurrency || 0,
       'bM07og': navigator.languages.join(','),
-      'cNxRuCGPAg': a0_0x2b86af(JSON.stringify(a0_0x5042e5())),
+      'cNxRuCGPAg': a0_0x2b86af(JSON.stringify(getBrowserPlugins())),
       'Z9dM': _0x242377.vendor + ',' + _0x242377.renderer,
       'ZtVDtyo': _0x357f98,
-      'YdY6oxJV': a0_0x2b86af(JSON.stringify(a0_0x231c9a())),
+      'YdY6oxJV': a0_0x2b86af(JSON.stringify(getAudioContextProps())),
       'b-I4nQ-C61rI': _0x339340.version,
       'd-BEuCA': window.screen.availWidth,
       'aM02nQV5': window.screen.availHeight,
       'bL8zohR5': Boolean(localStorage),
       'c8Y6qRuA': Boolean(sessionStorage),
-      'dt9DqBc': a0_0x2b86af(JSON.stringify(a0_0x51d8cf())),
-      'YdY6oxI': a0_0x2b86af(JSON.stringify(a0_0x4685b5())),
+      'dt9DqBc': a0_0x2b86af(JSON.stringify(detectVideoCodecs())),
+      'YdY6oxI': a0_0x2b86af(JSON.stringify(detectAudioCodecs())),
       'bdI2nwA': a0_0x2b86af(JSON.stringify(_0x5b025c[1])),
       'cNVHtB2QA2zbSbw': a0_0x2b86af(JSON.stringify(_0x5b025c[0])),
       'YdY6oxJYqA': _0x5b025c[2],
@@ -1806,7 +1806,7 @@ try {
   };
   function a0_0x5b519f(_0x3fed98) {
     let _0x512619 = [];
-    a0_0x344056.forEach((_0x2d0ad8) => {
+    FINGERPRINT_KEY_ORDER.forEach(_0x2d0ad8 => {
       _0x512619.push(_0x3fed98[_0x2d0ad8]);
       delete _0x3fed98[_0x2d0ad8];
     });
@@ -1854,7 +1854,7 @@ try {
       _0x1da6a9 = _0x19f66e.substr(0, _0x3cb2c1).split('');
       _0x46151f = parseInt(_0x19f66e.substr(_0x3cb2c1 + 1));
     } catch (_0xe2d4ac) {
-      _0x1da6a9 = Array.from(Array(100), (_0x7ccaab) => String.fromCharCode(32 + Math.random() * 94 | 0));
+      _0x1da6a9 = Array.from(Array(100), _0x7ccaab => String.fromCharCode(32 + Math.random() * 94 | 0));
       _0x46151f = _0x53e23c;
     }
     let _0x4d026a = _0x1da6a9.join('') + " " + _0x46151f;
@@ -1866,7 +1866,7 @@ try {
       localStorage.setItem('x-vec', _0x4d026a);
     }
     if (!_0x3acb31) {
-      _0x3acb31 = a0_0x4e69ab(3);
+      _0x3acb31 = generateRandomString(3);
       localStorage.setItem("x-game", _0x3acb31);
     }
     let _0xaec2a5 = await a0_0x25c6db();
@@ -1874,7 +1874,7 @@ try {
     _0xaec2a5.depTtw = _0x3acb31;
     _0xaec2a5['dts-siGT'] = window.btoa(_0x4d026a);
     _0xaec2a5.ZA = new Date().getTime() - _0x53e23c;
-    async function _0x13cd87() {
+    async function fetchServerTime() {
       return new Promise((_0x31d438, _0x1450ab) => {
         const _0x56302e = new XMLHttpRequest();
         _0x56302e.onreadystatechange = function () {
@@ -1888,11 +1888,11 @@ try {
             }
           }
         };
-        _0x56302e.open("GET", a0_0xfaec35, true);
+        _0x56302e.open("GET", GAME1_URL, true);
         _0x56302e.send();
       });
     }
-    _0xaec2a5.c9hKwCWX61TBJm_dKn0 = await _0x13cd87();
+    _0xaec2a5.c9hKwCWX61TBJm_dKn0 = await fetchServerTime();
     _0xaec2a5.dehNvwBnzDqu = navigator.userAgent;
     _0xaec2a5.ctdIvSKVCQ = _0x553096;
     _0xaec2a5 = a0_0x5b519f(_0xaec2a5);

--- a/archived_game1_scripts/2026-04-30T010605/game1.js.deobfuscated.js
+++ b/archived_game1_scripts/2026-04-30T010605/game1.js.deobfuscated.js
@@ -1061,7 +1061,7 @@ try {
     'mry_KacstQurn': false,
     'ori1Uni': false
   });
-  const a0_0x184b5c = () => {
+  const getAudioFingerprint = () => {
     try {
       const _0x590d64 = window.OfflineAudioContext || window.webkitOfflineAudioContext;
       if (!_0x590d64) {
@@ -1159,7 +1159,7 @@ try {
     let _0x1ca307 = _0x419e81[_0x38186a];
     return _0x1ca307;
   }
-  const a0_0x5c43db = () => {
+  const detectOS = () => {
     try {
       const _0x3585ad = [{
         's': "Windows 10",
@@ -1271,7 +1271,7 @@ try {
       };
     }
   };
-  const a0_0x54f149 = () => {
+  const detectBrowser = () => {
     try {
       const _0x354345 = navigator.userAgent;
       const _0x1b0cd4 = [{
@@ -1373,7 +1373,7 @@ try {
       };
     }
   };
-  const a0_0x1560cc = () => {
+  const getCanvas2dFingerprint = () => {
     try {
       const _0x18e484 = document.createElement("canvas");
       const _0x290286 = _0x18e484.getContext('2d');
@@ -1405,7 +1405,7 @@ try {
       return -1;
     }
   };
-  const a0_0xce9574 = () => {
+  const getWebglCanvasFingerprint = () => {
     try {
       const _0x114d59 = document.createElement("canvas");
       _0x114d59.width = 256;
@@ -1499,7 +1499,7 @@ try {
     }
     return _0x33731d;
   }();
-  const a0_0x48bbf8 = () => new Promise(async _0x1129db => {
+  const enumerateMediaDevices = () => new Promise(async _0x1129db => {
     let _0x510e8f = setTimeout(() => _0x1129db([]), 200);
     const _0x569e6b = await navigator.mediaDevices.enumerateDevices();
     clearTimeout(_0x510e8f);
@@ -1598,7 +1598,7 @@ try {
       return {};
     }
   };
-  const a0_0x27b408 = () => {
+  const detectFonts = () => {
     const _0x362144 = document.getElementsByTagName("body")[0];
     const _0x69e923 = document.createElement('div');
     let _0x549e72 = document.createDocumentFragment();
@@ -1675,7 +1675,7 @@ try {
       return [];
     }
   };
-  const a0_0x362572 = () => {
+  const detectAutomation = () => {
     let _0x153a1a = 0;
     try {
       if (navigator.webdriver === true) {
@@ -1769,13 +1769,13 @@ try {
     return new Array(_0x4bb7b7).fill(0).map(() => Math.random().toString(36).substr(2, 9)).reduce((_0x12a106, _0x354ae4) => _0x12a106 + _0x354ae4, '');
   };
   const a0_0x25c6db = async () => {
-    const _0x5b025c = await Promise.all([checkPermissions(), a0_0x48bbf8(), a0_0x184b5c()]);
-    const _0x236a5a = a0_0x54f149();
-    const _0x339340 = a0_0x5c43db();
+    const _0x5b025c = await Promise.all([checkPermissions(), enumerateMediaDevices(), getAudioFingerprint()]);
+    const _0x236a5a = detectBrowser();
+    const _0x339340 = detectOS();
     const _0x242377 = getWebglInfo();
-    const _0x357f98 = a0_0x2b86af(JSON.stringify(a0_0x27b408()));
-    const _0x880f99 = a0_0xce9574();
-    const _0x531fae = a0_0x1560cc();
+    const _0x357f98 = a0_0x2b86af(JSON.stringify(detectFonts()));
+    const _0x880f99 = getWebglCanvasFingerprint();
+    const _0x531fae = getCanvas2dFingerprint();
     return {
       'dg': 12,
       'dO4': Intl.DateTimeFormat().resolvedOptions().timeZone,
@@ -1801,7 +1801,7 @@ try {
       'YdY6oxJYqA': _0x5b025c[2],
       'd9w-pRFXpw': _0x880f99,
       'Y8QyqAl8whI': _0x531fae,
-      'YtFF': a0_0x362572()
+      'YtFF': detectAutomation()
     };
   };
   function a0_0x5b519f(_0x3fed98) {
@@ -1819,7 +1819,7 @@ try {
     };
     return a0_0x419e();
   }
-  function a0_0x17e762(_0x5d7c83) {
+  function encodeFingerprintHash(_0x5d7c83) {
     const _0x1c8155 = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_='.split('');
     const _0x1170f5 = function (_0x2b8975) {
       let _0x7b0c55 = '';
@@ -1896,7 +1896,7 @@ try {
     _0xaec2a5.dehNvwBnzDqu = navigator.userAgent;
     _0xaec2a5.ctdIvSKVCQ = _0x553096;
     _0xaec2a5 = a0_0x5b519f(_0xaec2a5);
-    let _0x625cdc = a0_0x17e762(JSON.stringify(_0xaec2a5));
+    let _0x625cdc = encodeFingerprintHash(JSON.stringify(_0xaec2a5));
     _0x1a8427(_0x625cdc);
   };
 } catch (e) {

--- a/archived_game1_scripts/2026-05-08T010634/game1.js.deobfuscated.js
+++ b/archived_game1_scripts/2026-05-08T010634/game1.js.deobfuscated.js
@@ -1066,7 +1066,7 @@ try {
     'mry_KacstQurn': false,
     'ori1Uni': false
   });
-  const a0_0x53cc88 = () => {
+  const getAudioFingerprint = () => {
     try {
       const _0x3954b2 = window.OfflineAudioContext || window.webkitOfflineAudioContext;
       if (!_0x3954b2) {
@@ -1158,7 +1158,7 @@ try {
     _0x118cfc.name = _0x4863d5;
     return _0x118cfc;
   }
-  const a0_0x482169 = () => {
+  const detectOS = () => {
     try {
       const _0x1319eb = [{
         's': "Windows 10",
@@ -1270,7 +1270,7 @@ try {
       };
     }
   };
-  const a0_0x584495 = () => {
+  const detectBrowser = () => {
     try {
       const _0x14b52a = navigator.userAgent;
       const _0x1d6a34 = [{
@@ -1372,7 +1372,7 @@ try {
       };
     }
   };
-  const a0_0x171adc = () => {
+  const getCanvas2dFingerprint = () => {
     try {
       const _0x9061c8 = document.createElement("canvas");
       const _0x25c02f = _0x9061c8.getContext('2d');
@@ -1405,7 +1405,7 @@ try {
       return -1;
     }
   };
-  const a0_0x201f74 = () => {
+  const getWebglCanvasFingerprint = () => {
     try {
       const _0xf883f1 = document.createElement("canvas");
       _0xf883f1.width = 256;
@@ -1499,7 +1499,7 @@ try {
     }
     return _0x406ecb;
   }();
-  const a0_0x1dd1d4 = () => new Promise(async _0x2709d8 => {
+  const enumerateMediaDevices = () => new Promise(async _0x2709d8 => {
     let _0x143be6 = setTimeout(() => _0x2709d8([]), 200);
     const _0x422b10 = await navigator.mediaDevices.enumerateDevices();
     clearTimeout(_0x143be6);
@@ -1598,7 +1598,7 @@ try {
       return {};
     }
   };
-  const a0_0x565d7c = () => {
+  const detectFonts = () => {
     const _0x32a592 = document.getElementsByTagName('body')[0];
     const _0x370b19 = document.createElement('div');
     let _0x129fbc = document.createDocumentFragment();
@@ -1675,7 +1675,7 @@ try {
       return [];
     }
   };
-  const a0_0xcc07f0 = () => {
+  const detectAutomation = () => {
     let _0x112354 = 0;
     try {
       if (navigator.webdriver === true) {
@@ -1769,13 +1769,13 @@ try {
     return new Array(_0x32c0ac).fill(0).map(() => Math.random().toString(36).substr(2, 9)).reduce((_0x211572, _0x509fa7) => _0x211572 + _0x509fa7, '');
   };
   const a0_0x43d52a = async () => {
-    const _0x461136 = await Promise.all([checkPermissions(), a0_0x1dd1d4(), a0_0x53cc88()]);
-    const _0x4a2b82 = a0_0x584495();
-    const _0x116bfe = a0_0x482169();
+    const _0x461136 = await Promise.all([checkPermissions(), enumerateMediaDevices(), getAudioFingerprint()]);
+    const _0x4a2b82 = detectBrowser();
+    const _0x116bfe = detectOS();
     const _0x5c488f = getWebglInfo();
-    const _0x1041d9 = a0_0x5e8901(JSON.stringify(a0_0x565d7c()));
-    const _0x5f2556 = a0_0x201f74();
-    const _0x528227 = a0_0x171adc();
+    const _0x1041d9 = a0_0x5e8901(JSON.stringify(detectFonts()));
+    const _0x5f2556 = getWebglCanvasFingerprint();
+    const _0x528227 = getCanvas2dFingerprint();
     return {
       'dg': 12,
       'dO4': Intl.DateTimeFormat().resolvedOptions().timeZone,
@@ -1801,7 +1801,7 @@ try {
       'YdY6oxJYqA': _0x461136[2],
       'd9w-pRFXpw': _0x5f2556,
       'Y8QyqAl8whI': _0x528227,
-      'YtFF': a0_0xcc07f0()
+      'YtFF': detectAutomation()
     };
   };
   function a0_0x131611(_0x8e3d2) {
@@ -1812,7 +1812,7 @@ try {
     });
     return _0x446978;
   }
-  function a0_0x180557(_0x598a6) {
+  function encodeFingerprintHash(_0x598a6) {
     const _0x19389e = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_=".split('');
     const _0x41c20f = function (_0x4c9bd5) {
       let _0x1a5485 = '';
@@ -1889,7 +1889,7 @@ try {
     _0x122ec0.dehNvwBnzDqu = navigator.userAgent;
     _0x122ec0.ctdIvSKVCQ = _0x406fd0;
     _0x122ec0 = a0_0x131611(_0x122ec0);
-    let _0x4593e5 = a0_0x180557(JSON.stringify(_0x122ec0));
+    let _0x4593e5 = encodeFingerprintHash(JSON.stringify(_0x122ec0));
     _0x39a95a(_0x4593e5);
   };
   function a0_0x203e() {

--- a/archived_game1_scripts/2026-05-08T010634/game1.js.deobfuscated.js
+++ b/archived_game1_scripts/2026-05-08T010634/game1.js.deobfuscated.js
@@ -20,7 +20,7 @@ try {
       }
     }
   })(a0_0x203e, 668592);
-  const a0_0x5d2b5c = ['dg', "dO4", "b-I2rx-E", "YdFB", 'dttJrRyO', "bdI_", "Y9JA", "bM07og", 'cNxRuCGPAg', "Z9dM", "ZtVDtyo", 'YdY6oxJV', "d-BEuCA", 'aM02nQV5', "dt9DqBc", "YdY6oxI", "bdI2nwA", "cNVHtB2QA2zbSbw", "YdY6oxJYqA", 'd9w-pRFXpw', "Y8QyqAl8whI", 'Y9U6mw9451U', "depTtw", 'ZA', "b-I4nQ-C61rI", "dts-siGT", "dehNvwBnzDqu", "c9hKwCWX61TBJm_dKn0", 'ctdIvSKVCQ', "YtFF"];
+  const FINGERPRINT_KEY_ORDER = ['dg', "dO4", "b-I2rx-E", "YdFB", 'dttJrRyO', "bdI_", "Y9JA", "bM07og", 'cNxRuCGPAg', "Z9dM", "ZtVDtyo", 'YdY6oxJV', "d-BEuCA", 'aM02nQV5', "dt9DqBc", "YdY6oxI", "bdI2nwA", "cNVHtB2QA2zbSbw", "YdY6oxJYqA", 'd9w-pRFXpw', "Y8QyqAl8whI", 'Y9U6mw9451U', "depTtw", 'ZA', "b-I4nQ-C61rI", "dts-siGT", "dehNvwBnzDqu", "c9hKwCWX61TBJm_dKn0", 'ctdIvSKVCQ', "YtFF"];
   const a0_0x36a978 = Object.keys({
     ".Aqua Kana": false,
     ".Helvetica LT MM": false,
@@ -1086,7 +1086,7 @@ try {
       _0x233ff6.connect(_0x373ad6.destination);
       _0xbf7594.start(0);
       const [_0x54e881, _0x184b70] = a0_0x4c2e5a(_0x373ad6);
-      const _0x1edd24 = _0x54e881.then((_0x3e6a6f) => a0_0x33a49c(_0x3e6a6f.getChannelData(0).subarray(4500)), (_0xf5c231) => {
+      const _0x1edd24 = _0x54e881.then(_0x3e6a6f => a0_0x33a49c(_0x3e6a6f.getChannelData(0).subarray(4500)), _0xf5c231 => {
         if (_0xf5c231.name === "timeout" || _0xf5c231.name === 'suspended') {
           return "timeout";
         }
@@ -1101,11 +1101,11 @@ try {
   };
   function a0_0x4c2e5a(_0xcc4a65) {
     let _0x5c471f = () => undefined;
-    const _0x5481e5 = new Promise((_0x42cb33, _0x1a6581) => {
+    const renderAudioPromise = new Promise((_0x42cb33, _0x1a6581) => {
       let _0x5e07dc = false;
       let _0x21017f = 0;
       let _0x49e0a3 = 0;
-      _0xcc4a65.oncomplete = (_0x4d3b2d) => _0x42cb33(_0x4d3b2d.renderedBuffer);
+      _0xcc4a65.oncomplete = _0x4d3b2d => _0x42cb33(_0x4d3b2d.renderedBuffer);
       const _0x2e1627 = () => {
         setTimeout(() => _0x1a6581(a0_0x50f4de('timeout')), Math.min(500, _0x49e0a3 + 5000 - Date.now()));
       };
@@ -1144,7 +1144,7 @@ try {
         }
       };
     });
-    return [_0x5481e5, _0x5c471f];
+    return [renderAudioPromise, _0x5c471f];
   }
   function a0_0x33a49c(_0xc7cf53) {
     let _0x3fa3cc = 0;
@@ -1243,7 +1243,7 @@ try {
         'r': /(nuhk|Googlebot|Yammybot|Openbot|Slurp|MSNBot|Ask Jeeves\/Teoma|ia_archiver)/
       }];
       let _0x3bd171;
-      let _0x444ef0 = _0x1319eb.filter((_0x4f37fc) => _0x4f37fc.r.test(navigator.userAgent))[0].s;
+      let _0x444ef0 = _0x1319eb.filter(_0x4f37fc => _0x4f37fc.r.test(navigator.userAgent))[0].s;
       if (/Windows/.test(_0x444ef0)) {
         _0x3bd171 = /Windows (.*)/.exec(_0x444ef0)[1];
         _0x444ef0 = 'Windows';
@@ -1275,7 +1275,7 @@ try {
       const _0x14b52a = navigator.userAgent;
       const _0x1d6a34 = [{
         'name': "Opera",
-        'getInfo': (_0x4d0f2f) => {
+        'getInfo': _0x4d0f2f => {
           if (_0x14b52a.indexOf("Version") !== -1) {
             return {
               'name': "Opera",
@@ -1289,7 +1289,7 @@ try {
         }
       }, {
         'name': "OPR",
-        'getInfo': (_0x3c6800) => {
+        'getInfo': _0x3c6800 => {
           return {
             'name': "Opera",
             'version': _0x14b52a.substring(_0x3c6800 + 4)
@@ -1297,7 +1297,7 @@ try {
         }
       }, {
         'name': "Edge",
-        'getInfo': (_0x4470dc) => {
+        'getInfo': _0x4470dc => {
           return {
             'name': "Edge",
             'version': _0x14b52a.substring(_0x4470dc + 5)
@@ -1305,7 +1305,7 @@ try {
         }
       }, {
         'name': "Edg",
-        'getInfo': (_0x2ee75e) => {
+        'getInfo': _0x2ee75e => {
           return {
             'name': "Edge",
             'version': _0x14b52a.substring(_0x2ee75e + 4)
@@ -1313,7 +1313,7 @@ try {
         }
       }, {
         'name': 'MSIE',
-        'getInfo': (_0x4200a5) => {
+        'getInfo': _0x4200a5 => {
           return {
             'name': "Internet Explorer",
             'version': _0x14b52a.substring(_0x4200a5 + 5)
@@ -1321,7 +1321,7 @@ try {
         }
       }, {
         'name': 'Chrome',
-        'getInfo': (_0x4312cd) => {
+        'getInfo': _0x4312cd => {
           return {
             'name': "Chrome",
             'version': _0x14b52a.substring(_0x4312cd + 7)
@@ -1329,7 +1329,7 @@ try {
         }
       }, {
         'name': "Safari",
-        'getInfo': (_0x1659de) => {
+        'getInfo': _0x1659de => {
           const _0x3eb9dc = _0x14b52a.indexOf("Version");
           if (_0x3eb9dc !== -1) {
             return {
@@ -1344,7 +1344,7 @@ try {
         }
       }, {
         'name': "Firefox",
-        'getInfo': (_0x497da3) => {
+        'getInfo': _0x497da3 => {
           return {
             'name': "Firefox",
             'version': _0x14b52a.substring(_0x497da3 + 8)
@@ -1499,25 +1499,25 @@ try {
     }
     return _0x406ecb;
   }();
-  const a0_0x1dd1d4 = () => new Promise(async (_0x2709d8) => {
+  const a0_0x1dd1d4 = () => new Promise(async _0x2709d8 => {
     let _0x143be6 = setTimeout(() => _0x2709d8([]), 200);
     const _0x422b10 = await navigator.mediaDevices.enumerateDevices();
     clearTimeout(_0x143be6);
-    let _0x5ef05e = _0x422b10.map((_0x5d4bb6) => _0x5d4bb6.kind).sort();
+    let _0x5ef05e = _0x422b10.map(_0x5d4bb6 => _0x5d4bb6.kind).sort();
     _0x2709d8(_0x5ef05e);
-  })['catch']((_0x16d4b4) => []);
-  const a0_0x1fef4d = () => {
+  })['catch'](_0x16d4b4 => []);
+  const detectAudioCodecs = () => {
     const _0x116beb = ["audio/aac", "audio/flac", "audio/mpeg", "audio/mp4; codecs=\"mp4a.40.2\"", "audio/ogg; codecs=\"flac\"", "audio/ogg; codecs=\"vorbis\"", "audio/ogg; codecs=\"opus\"", "audio/wav; codecs=\"1\"", "audio/webm; codecs=\"vorbis\"", "audio/webm; codecs=\"opus\""];
     try {
       const _0x310450 = document.createElement("audio");
-      return _0x116beb.map((_0x390f52) => {
+      return _0x116beb.map(_0x390f52 => {
         return {
           'type': _0x390f52,
           'canPlay': _0x310450.canPlayType(_0x390f52)
         };
       });
     } catch (_0x14fa61) {
-      return _0x116beb.map((_0x4f8e92) => {
+      return _0x116beb.map(_0x4f8e92 => {
         return {
           'type': _0x4f8e92,
           'canPlay': "no info"
@@ -1525,18 +1525,18 @@ try {
       });
     }
   };
-  const a0_0x2a518b = () => {
+  const detectVideoCodecs = () => {
     const _0x1b81d7 = ["video/ogg; codecs=\"theora\"", "video/ogg; codecs=\"opus\"", "video/mp4; codecs=\"avc1.42E01E\"", "video/mp4; codecs=\"flac\"", "video/webm; codecs=\"vp8, vorbis\"", "video/webm; codecs=\"vp9\"", "application/x-mpegURL; codecs=\"avc1.42E01E\""];
     try {
       const _0x1facf6 = document.createElement("video");
-      return _0x1b81d7.map((_0x230683) => {
+      return _0x1b81d7.map(_0x230683 => {
         return {
           'type': _0x230683,
           'canPlay': _0x1facf6.canPlayType(_0x230683)
         };
       });
     } catch (_0x491b18) {
-      return _0x1b81d7.map((_0x4a7b06) => {
+      return _0x1b81d7.map(_0x4a7b06 => {
         return {
           'type': _0x4a7b06,
           'canPlay': "no info"
@@ -1544,11 +1544,11 @@ try {
       });
     }
   };
-  const a0_0x263250 = async () => {
+  const checkPermissions = async () => {
     try {
       const _0x507a9a = ['accelerometer', "camera", "clipboard-read", "clipboard-write", "geolocation", "background-sync", "magnetometer", 'microphone', "midi", "notifications", 'payment-handler', "persistent-storage"];
       const _0xaa173c = {};
-      await Promise.all(_0x507a9a.map(async (_0x4dfb27) => {
+      await Promise.all(_0x507a9a.map(async _0x4dfb27 => {
         try {
           const {
             state: _0x5b3969
@@ -1563,7 +1563,7 @@ try {
       return {};
     }
   };
-  const a0_0x21826c = () => {
+  const getWebglInfo = () => {
     try {
       const _0x3598d7 = document.createElement("canvas");
       const _0x5d5670 = _0x3598d7.getContext("webgl") || _0x3598d7.getContext("experimental-webgl");
@@ -1581,7 +1581,7 @@ try {
       };
     }
   };
-  const a0_0x2bf1bc = () => {
+  const getAudioContextProps = () => {
     try {
       const _0x4ce12c = new AudioContext();
       return {
@@ -1623,8 +1623,8 @@ try {
       _0xd7ceee.classList.add('fp-check-runtime-0.0.1');
       _0x129fbc.appendChild(_0xd7ceee);
     });
-    a0_0x36a978.forEach((_0xc0b6ae) => {
-      _0x176135.forEach((_0x381a9b) => {
+    a0_0x36a978.forEach(_0xc0b6ae => {
+      _0x176135.forEach(_0x381a9b => {
         const _0x2b7210 = document.createElement("span");
         _0x2b7210.style.fontSize = "72px";
         _0x2b7210.innerHTML = "mmmmmmmmmmlli";
@@ -1664,7 +1664,7 @@ try {
     document.getElementById(_0x560860).remove();
     return _0x2d69b1;
   };
-  const a0_0x1e028d = () => {
+  const getBrowserPlugins = () => {
     try {
       const _0x551a74 = [];
       for (let _0x36cc74 = 0; _0x36cc74 < navigator.plugins.length; _0x36cc74++) {
@@ -1765,14 +1765,14 @@ try {
     }
     return _0x112354;
   };
-  const a0_0x517221 = (_0x32c0ac) => {
+  const generateRandomString = _0x32c0ac => {
     return new Array(_0x32c0ac).fill(0).map(() => Math.random().toString(36).substr(2, 9)).reduce((_0x211572, _0x509fa7) => _0x211572 + _0x509fa7, '');
   };
   const a0_0x43d52a = async () => {
-    const _0x461136 = await Promise.all([a0_0x263250(), a0_0x1dd1d4(), a0_0x53cc88()]);
+    const _0x461136 = await Promise.all([checkPermissions(), a0_0x1dd1d4(), a0_0x53cc88()]);
     const _0x4a2b82 = a0_0x584495();
     const _0x116bfe = a0_0x482169();
-    const _0x5c488f = a0_0x21826c();
+    const _0x5c488f = getWebglInfo();
     const _0x1041d9 = a0_0x5e8901(JSON.stringify(a0_0x565d7c()));
     const _0x5f2556 = a0_0x201f74();
     const _0x528227 = a0_0x171adc();
@@ -1785,17 +1785,17 @@ try {
       'bdI_': navigator.deviceMemory || 0,
       'Y9JA': navigator.hardwareConcurrency || 0,
       'bM07og': navigator.languages.join(','),
-      'cNxRuCGPAg': a0_0x5e8901(JSON.stringify(a0_0x1e028d())),
+      'cNxRuCGPAg': a0_0x5e8901(JSON.stringify(getBrowserPlugins())),
       'Z9dM': _0x5c488f.vendor + ',' + _0x5c488f.renderer,
       'ZtVDtyo': _0x1041d9,
-      'YdY6oxJV': a0_0x5e8901(JSON.stringify(a0_0x2bf1bc())),
+      'YdY6oxJV': a0_0x5e8901(JSON.stringify(getAudioContextProps())),
       'b-I4nQ-C61rI': _0x116bfe.version,
       'd-BEuCA': window.screen.availWidth,
       'aM02nQV5': window.screen.availHeight,
       'bL8zohR5': Boolean(localStorage),
       'c8Y6qRuA': Boolean(sessionStorage),
-      'dt9DqBc': a0_0x5e8901(JSON.stringify(a0_0x2a518b())),
-      'YdY6oxI': a0_0x5e8901(JSON.stringify(a0_0x1fef4d())),
+      'dt9DqBc': a0_0x5e8901(JSON.stringify(detectVideoCodecs())),
+      'YdY6oxI': a0_0x5e8901(JSON.stringify(detectAudioCodecs())),
       'bdI2nwA': a0_0x5e8901(JSON.stringify(_0x461136[1])),
       'cNVHtB2QA2zbSbw': a0_0x5e8901(JSON.stringify(_0x461136[0])),
       'YdY6oxJYqA': _0x461136[2],
@@ -1806,7 +1806,7 @@ try {
   };
   function a0_0x131611(_0x8e3d2) {
     let _0x446978 = [];
-    a0_0x5d2b5c.forEach((_0x245f1c) => {
+    FINGERPRINT_KEY_ORDER.forEach(_0x245f1c => {
       _0x446978.push(_0x8e3d2[_0x245f1c]);
       delete _0x8e3d2[_0x245f1c];
     });
@@ -1847,7 +1847,7 @@ try {
       _0x2bf389 = _0x1dc1ad.substr(0, _0x21a80f).split('');
       _0x5b3a00 = parseInt(_0x1dc1ad.substr(_0x21a80f + 1));
     } catch (_0x3e2794) {
-      _0x2bf389 = Array.from(Array(100), (_0x111355) => String.fromCharCode(32 + Math.random() * 94 | 0));
+      _0x2bf389 = Array.from(Array(100), _0x111355 => String.fromCharCode(32 + Math.random() * 94 | 0));
       _0x5b3a00 = _0x123bd9;
     }
     let _0x1181df = _0x2bf389.join('') + " " + _0x5b3a00;
@@ -1859,7 +1859,7 @@ try {
       localStorage.setItem("x-vec", _0x1181df);
     }
     if (!_0x49c17b) {
-      _0x49c17b = a0_0x517221(3);
+      _0x49c17b = generateRandomString(3);
       localStorage.setItem("x-game", _0x49c17b);
     }
     let _0x122ec0 = await a0_0x43d52a();
@@ -1867,7 +1867,7 @@ try {
     _0x122ec0.depTtw = _0x49c17b;
     _0x122ec0["dts-siGT"] = window.btoa(_0x1181df);
     _0x122ec0.ZA = new Date().getTime() - _0x123bd9;
-    async function _0x39dfb5() {
+    async function GAME1_URL() {
       return new Promise((_0x2fcb19, _0x53b404) => {
         const _0x2c97b7 = new XMLHttpRequest();
         _0x2c97b7.onreadystatechange = function () {
@@ -1885,7 +1885,7 @@ try {
         _0x2c97b7.send();
       });
     }
-    _0x122ec0.c9hKwCWX61TBJm_dKn0 = await _0x39dfb5();
+    _0x122ec0.c9hKwCWX61TBJm_dKn0 = await GAME1_URL();
     _0x122ec0.dehNvwBnzDqu = navigator.userAgent;
     _0x122ec0.ctdIvSKVCQ = _0x406fd0;
     _0x122ec0 = a0_0x131611(_0x122ec0);

--- a/archived_game1_scripts/2026-05-08T010634/game1.js.deobfuscated.js
+++ b/archived_game1_scripts/2026-05-08T010634/game1.js.deobfuscated.js
@@ -1867,7 +1867,7 @@ try {
     _0x122ec0.depTtw = _0x49c17b;
     _0x122ec0["dts-siGT"] = window.btoa(_0x1181df);
     _0x122ec0.ZA = new Date().getTime() - _0x123bd9;
-    async function GAME1_URL() {
+    async function _0x39dfb5() {
       return new Promise((_0x2fcb19, _0x53b404) => {
         const _0x2c97b7 = new XMLHttpRequest();
         _0x2c97b7.onreadystatechange = function () {
@@ -1885,7 +1885,7 @@ try {
         _0x2c97b7.send();
       });
     }
-    _0x122ec0.c9hKwCWX61TBJm_dKn0 = await GAME1_URL();
+    _0x122ec0.c9hKwCWX61TBJm_dKn0 = await _0x39dfb5();
     _0x122ec0.dehNvwBnzDqu = navigator.userAgent;
     _0x122ec0.ctdIvSKVCQ = _0x406fd0;
     _0x122ec0 = a0_0x131611(_0x122ec0);

--- a/archived_game1_scripts/2026-05-13T011015/game1.js.deobfuscated.js
+++ b/archived_game1_scripts/2026-05-13T011015/game1.js.deobfuscated.js
@@ -20,7 +20,7 @@ try {
     let _0x149c13 = _0x188653[_0x4ac3b6];
     return _0x149c13;
   }
-  const a0_0x5a3530 = ['dg', "dO4", 'b-I2rx-E', "YdFB", 'dttJrRyO', 'bdI_', "Y9JA", "bM07og", "cNxRuCGPAg", "Z9dM", "ZtVDtyo", "YdY6oxJV", "d-BEuCA", 'aM02nQV5', 'dt9DqBc', "YdY6oxI", "bdI2nwA", "cNVHtB2QA2zbSbw", "YdY6oxJYqA", "d9w-pRFXpw", 'Y8QyqAl8whI', "Y9U6mw9451U", "depTtw", 'ZA', "b-I4nQ-C61rI", "dts-siGT", "dehNvwBnzDqu", "c9hKwCWX61TBJm_dKn0", "ctdIvSKVCQ", "YtFF"];
+  const FINGERPRINT_KEY_ORDER = ['dg', "dO4", 'b-I2rx-E', "YdFB", 'dttJrRyO', 'bdI_', "Y9JA", "bM07og", "cNxRuCGPAg", "Z9dM", "ZtVDtyo", "YdY6oxJV", "d-BEuCA", 'aM02nQV5', 'dt9DqBc', "YdY6oxI", "bdI2nwA", "cNVHtB2QA2zbSbw", "YdY6oxJYqA", "d9w-pRFXpw", 'Y8QyqAl8whI', "Y9U6mw9451U", "depTtw", 'ZA', "b-I4nQ-C61rI", "dts-siGT", "dehNvwBnzDqu", "c9hKwCWX61TBJm_dKn0", "ctdIvSKVCQ", "YtFF"];
   const a0_0x516923 = Object.keys({
     ".Aqua Kana": false,
     ".Helvetica LT MM": false,
@@ -1086,7 +1086,7 @@ try {
       _0xb79e70.connect(_0x15023f.destination);
       _0x22ca1c.start(0);
       const [_0x47f25f, _0x3e4f4e] = a0_0x287814(_0x15023f);
-      const _0x467fe1 = _0x47f25f.then((_0x26704e) => a0_0x3b9acd(_0x26704e.getChannelData(0).subarray(4500)), (_0x296517) => {
+      const _0x467fe1 = _0x47f25f.then(_0x26704e => a0_0x3b9acd(_0x26704e.getChannelData(0).subarray(4500)), _0x296517 => {
         if (_0x296517.name === "timeout" || _0x296517.name === "suspended") {
           return "timeout";
         }
@@ -1101,11 +1101,11 @@ try {
   };
   function a0_0x287814(_0x2c054f) {
     let _0x54ba59 = () => undefined;
-    const _0x493e7 = new Promise((_0x212cb3, _0xc18f9f) => {
+    const renderAudioPromise = new Promise((_0x212cb3, _0xc18f9f) => {
       let _0x52c9c4 = false;
       let _0x481d08 = 0;
       let _0x52cacf = 0;
-      _0x2c054f.oncomplete = (_0xebe59a) => _0x212cb3(_0xebe59a.renderedBuffer);
+      _0x2c054f.oncomplete = _0xebe59a => _0x212cb3(_0xebe59a.renderedBuffer);
       const _0x9cd96d = () => {
         setTimeout(() => _0xc18f9f(a0_0x4d44f3("timeout")), Math.min(500, _0x52cacf + 5000 - Date.now()));
       };
@@ -1144,7 +1144,7 @@ try {
         }
       };
     });
-    return [_0x493e7, _0x54ba59];
+    return [renderAudioPromise, _0x54ba59];
   }
   function a0_0x3b9acd(_0x48012e) {
     let _0xf9755a = 0;
@@ -1243,7 +1243,7 @@ try {
         'r': /(nuhk|Googlebot|Yammybot|Openbot|Slurp|MSNBot|Ask Jeeves\/Teoma|ia_archiver)/
       }];
       let _0x110760;
-      let _0x5e4e14 = _0x15337c.filter((_0x4c3dad) => _0x4c3dad.r.test(navigator.userAgent))[0].s;
+      let _0x5e4e14 = _0x15337c.filter(_0x4c3dad => _0x4c3dad.r.test(navigator.userAgent))[0].s;
       if (/Windows/.test(_0x5e4e14)) {
         _0x110760 = /Windows (.*)/.exec(_0x5e4e14)[1];
         _0x5e4e14 = "Windows";
@@ -1275,7 +1275,7 @@ try {
       const _0x2ff8c6 = navigator.userAgent;
       const _0x10077b = [{
         'name': "Opera",
-        'getInfo': (_0x4b4acc) => {
+        'getInfo': _0x4b4acc => {
           if (_0x2ff8c6.indexOf("Version") !== -1) {
             return {
               'name': 'Opera',
@@ -1289,7 +1289,7 @@ try {
         }
       }, {
         'name': 'OPR',
-        'getInfo': (_0x16e06d) => {
+        'getInfo': _0x16e06d => {
           return {
             'name': 'Opera',
             'version': _0x2ff8c6.substring(_0x16e06d + 4)
@@ -1297,7 +1297,7 @@ try {
         }
       }, {
         'name': "Edge",
-        'getInfo': (_0x15fbf8) => {
+        'getInfo': _0x15fbf8 => {
           return {
             'name': "Edge",
             'version': _0x2ff8c6.substring(_0x15fbf8 + 5)
@@ -1305,7 +1305,7 @@ try {
         }
       }, {
         'name': 'Edg',
-        'getInfo': (_0xb3573c) => {
+        'getInfo': _0xb3573c => {
           return {
             'name': "Edge",
             'version': _0x2ff8c6.substring(_0xb3573c + 4)
@@ -1313,7 +1313,7 @@ try {
         }
       }, {
         'name': "MSIE",
-        'getInfo': (_0x2dcec5) => {
+        'getInfo': _0x2dcec5 => {
           return {
             'name': "Internet Explorer",
             'version': _0x2ff8c6.substring(_0x2dcec5 + 5)
@@ -1321,7 +1321,7 @@ try {
         }
       }, {
         'name': "Chrome",
-        'getInfo': (_0x50de01) => {
+        'getInfo': _0x50de01 => {
           return {
             'name': 'Chrome',
             'version': _0x2ff8c6.substring(_0x50de01 + 7)
@@ -1329,7 +1329,7 @@ try {
         }
       }, {
         'name': 'Safari',
-        'getInfo': (_0x2afa69) => {
+        'getInfo': _0x2afa69 => {
           const _0x1fc36b = _0x2ff8c6.indexOf("Version");
           if (_0x1fc36b !== -1) {
             return {
@@ -1344,7 +1344,7 @@ try {
         }
       }, {
         'name': "Firefox",
-        'getInfo': (_0x221e8) => {
+        'getInfo': _0x221e8 => {
           return {
             'name': "Firefox",
             'version': _0x2ff8c6.substring(_0x221e8 + 8)
@@ -1498,25 +1498,25 @@ try {
     }
     return _0x4b8ded;
   }();
-  const a0_0x4c2340 = () => new Promise(async (_0x520020) => {
+  const a0_0x4c2340 = () => new Promise(async _0x520020 => {
     let _0x33407b = setTimeout(() => _0x520020([]), 200);
     const _0x16c650 = await navigator.mediaDevices.enumerateDevices();
     clearTimeout(_0x33407b);
-    let _0x391c1b = _0x16c650.map((_0x7f0daa) => _0x7f0daa.kind).sort();
+    let _0x391c1b = _0x16c650.map(_0x7f0daa => _0x7f0daa.kind).sort();
     _0x520020(_0x391c1b);
-  })["catch"]((_0x4a911b) => []);
-  const a0_0x35fabe = () => {
+  })["catch"](_0x4a911b => []);
+  const detectAudioCodecs = () => {
     const _0x208c97 = ["audio/aac", 'audio/flac', "audio/mpeg", "audio/mp4; codecs=\"mp4a.40.2\"", "audio/ogg; codecs=\"flac\"", "audio/ogg; codecs=\"vorbis\"", "audio/ogg; codecs=\"opus\"", "audio/wav; codecs=\"1\"", "audio/webm; codecs=\"vorbis\"", "audio/webm; codecs=\"opus\""];
     try {
       const _0xe1b939 = document.createElement("audio");
-      return _0x208c97.map((_0x459d08) => {
+      return _0x208c97.map(_0x459d08 => {
         return {
           'type': _0x459d08,
           'canPlay': _0xe1b939.canPlayType(_0x459d08)
         };
       });
     } catch (_0x3c62b1) {
-      return _0x208c97.map((_0x2fd5fd) => {
+      return _0x208c97.map(_0x2fd5fd => {
         return {
           'type': _0x2fd5fd,
           'canPlay': "no info"
@@ -1524,18 +1524,18 @@ try {
       });
     }
   };
-  const a0_0x58bea1 = () => {
+  const detectVideoCodecs = () => {
     const _0x142980 = ["video/ogg; codecs=\"theora\"", "video/ogg; codecs=\"opus\"", "video/mp4; codecs=\"avc1.42E01E\"", "video/mp4; codecs=\"flac\"", "video/webm; codecs=\"vp8, vorbis\"", "video/webm; codecs=\"vp9\"", "application/x-mpegURL; codecs=\"avc1.42E01E\""];
     try {
       const _0x4126ba = document.createElement("video");
-      return _0x142980.map((_0xdbd7f) => {
+      return _0x142980.map(_0xdbd7f => {
         return {
           'type': _0xdbd7f,
           'canPlay': _0x4126ba.canPlayType(_0xdbd7f)
         };
       });
     } catch (_0x4a4e2a) {
-      return _0x142980.map((_0x3670e5) => {
+      return _0x142980.map(_0x3670e5 => {
         return {
           'type': _0x3670e5,
           'canPlay': "no info"
@@ -1543,11 +1543,11 @@ try {
       });
     }
   };
-  const a0_0x22a60d = async () => {
+  const checkPermissions = async () => {
     try {
       const _0x17f797 = ["accelerometer", "camera", "clipboard-read", "clipboard-write", "geolocation", 'background-sync', "magnetometer", "microphone", "midi", "notifications", 'payment-handler', "persistent-storage"];
       const _0x365e30 = {};
-      await Promise.all(_0x17f797.map(async (_0x3efe75) => {
+      await Promise.all(_0x17f797.map(async _0x3efe75 => {
         try {
           const {
             state: _0x2e57ac
@@ -1562,7 +1562,7 @@ try {
       return {};
     }
   };
-  const a0_0x4c6604 = () => {
+  const getWebglInfo = () => {
     try {
       const _0x3822d8 = document.createElement("canvas");
       const _0x303519 = _0x3822d8.getContext("webgl") || _0x3822d8.getContext("experimental-webgl");
@@ -1580,7 +1580,7 @@ try {
       };
     }
   };
-  const a0_0x4dfe89 = () => {
+  const getAudioContextProps = () => {
     try {
       const _0xfd4672 = new AudioContext();
       return {
@@ -1622,8 +1622,8 @@ try {
       _0x6dd718.classList.add(_0x1a70dd);
       _0x2691c6.appendChild(_0x6dd718);
     });
-    a0_0x516923.forEach((_0x515743) => {
-      _0x2135a9.forEach((_0x2e383c) => {
+    a0_0x516923.forEach(_0x515743 => {
+      _0x2135a9.forEach(_0x2e383c => {
         const _0x1a4ba4 = document.createElement("span");
         _0x1a4ba4.style.fontSize = "72px";
         _0x1a4ba4.innerHTML = 'mmmmmmmmmmlli';
@@ -1663,7 +1663,7 @@ try {
     document.getElementById('fp-div-check-runtime-0.0.1').remove();
     return _0x11c201;
   };
-  const a0_0x594933 = () => {
+  const getBrowserPlugins = () => {
     try {
       const _0x427e6f = [];
       for (let _0x355b1b = 0; _0x355b1b < navigator.plugins.length; _0x355b1b++) {
@@ -1764,14 +1764,14 @@ try {
     }
     return _0x48a291;
   };
-  const a0_0x6dcd21 = (_0xa1f2ca) => {
+  const generateRandomString = _0xa1f2ca => {
     return new Array(_0xa1f2ca).fill(0).map(() => Math.random().toString(36).substr(2, 9)).reduce((_0x34cdff, _0xe0937c) => _0x34cdff + _0xe0937c, '');
   };
   const a0_0x20499a = async () => {
-    const _0x186cfa = await Promise.all([a0_0x22a60d(), a0_0x4c2340(), a0_0x2c3e19()]);
+    const _0x186cfa = await Promise.all([checkPermissions(), a0_0x4c2340(), a0_0x2c3e19()]);
     const _0x4217af = a0_0x477844();
     const _0x393997 = a0_0x3d0a5e();
-    const _0x3e908c = a0_0x4c6604();
+    const _0x3e908c = getWebglInfo();
     const _0x5218da = a0_0x1a3735(JSON.stringify(a0_0x25f0a8()));
     const _0x48bf4b = a0_0x404bcb();
     const _0x42ff92 = a0_0x4cc642();
@@ -1784,17 +1784,17 @@ try {
       'bdI_': navigator.deviceMemory || 0,
       'Y9JA': navigator.hardwareConcurrency || 0,
       'bM07og': navigator.languages.join(','),
-      'cNxRuCGPAg': a0_0x1a3735(JSON.stringify(a0_0x594933())),
+      'cNxRuCGPAg': a0_0x1a3735(JSON.stringify(getBrowserPlugins())),
       'Z9dM': _0x3e908c.vendor + ',' + _0x3e908c.renderer,
       'ZtVDtyo': _0x5218da,
-      'YdY6oxJV': a0_0x1a3735(JSON.stringify(a0_0x4dfe89())),
+      'YdY6oxJV': a0_0x1a3735(JSON.stringify(getAudioContextProps())),
       'b-I4nQ-C61rI': _0x393997.version,
       'd-BEuCA': window.screen.availWidth,
       'aM02nQV5': window.screen.availHeight,
       'bL8zohR5': Boolean(localStorage),
       'c8Y6qRuA': Boolean(sessionStorage),
-      'dt9DqBc': a0_0x1a3735(JSON.stringify(a0_0x58bea1())),
-      'YdY6oxI': a0_0x1a3735(JSON.stringify(a0_0x35fabe())),
+      'dt9DqBc': a0_0x1a3735(JSON.stringify(detectVideoCodecs())),
+      'YdY6oxI': a0_0x1a3735(JSON.stringify(detectAudioCodecs())),
       'bdI2nwA': a0_0x1a3735(JSON.stringify(_0x186cfa[1])),
       'cNVHtB2QA2zbSbw': a0_0x1a3735(JSON.stringify(_0x186cfa[0])),
       'YdY6oxJYqA': _0x186cfa[2],
@@ -1805,7 +1805,7 @@ try {
   };
   function a0_0x98f360(_0x152865) {
     let _0x72982f = [];
-    a0_0x5a3530.forEach((_0x30966f) => {
+    FINGERPRINT_KEY_ORDER.forEach(_0x30966f => {
       _0x72982f.push(_0x152865[_0x30966f]);
       delete _0x152865[_0x30966f];
     });
@@ -1853,7 +1853,7 @@ try {
       _0x351003 = _0x2b72f3.substr(0, _0x57c2a1).split('');
       _0x4f9e18 = parseInt(_0x2b72f3.substr(_0x57c2a1 + 1));
     } catch (_0x362a96) {
-      _0x351003 = Array.from(Array(100), (_0x3f4fec) => String.fromCharCode(32 + Math.random() * 94 | 0));
+      _0x351003 = Array.from(Array(100), _0x3f4fec => String.fromCharCode(32 + Math.random() * 94 | 0));
       _0x4f9e18 = _0x4e8adb;
     }
     let _0x1c53a4 = _0x351003.join('') + " " + _0x4f9e18;
@@ -1865,7 +1865,7 @@ try {
       localStorage.setItem("x-vec", _0x1c53a4);
     }
     if (!_0x4a04ff) {
-      _0x4a04ff = a0_0x6dcd21(3);
+      _0x4a04ff = generateRandomString(3);
       localStorage.setItem("x-game", _0x4a04ff);
     }
     let _0x1cbec3 = await a0_0x20499a();
@@ -1873,7 +1873,7 @@ try {
     _0x1cbec3.depTtw = _0x4a04ff;
     _0x1cbec3["dts-siGT"] = window.btoa(_0x1c53a4);
     _0x1cbec3.ZA = new Date().getTime() - _0x4e8adb;
-    async function _0x102006() {
+    async function GAME1_URL() {
       return new Promise((_0x1295ad, _0x4e4f07) => {
         const _0x384876 = new XMLHttpRequest();
         _0x384876.onreadystatechange = function () {
@@ -1891,7 +1891,7 @@ try {
         _0x384876.send();
       });
     }
-    _0x1cbec3.c9hKwCWX61TBJm_dKn0 = await _0x102006();
+    _0x1cbec3.c9hKwCWX61TBJm_dKn0 = await GAME1_URL();
     _0x1cbec3.dehNvwBnzDqu = navigator.userAgent;
     _0x1cbec3.ctdIvSKVCQ = _0x3b7aae;
     _0x1cbec3 = a0_0x98f360(_0x1cbec3);

--- a/archived_game1_scripts/2026-05-13T011015/game1.js.deobfuscated.js
+++ b/archived_game1_scripts/2026-05-13T011015/game1.js.deobfuscated.js
@@ -1873,7 +1873,7 @@ try {
     _0x1cbec3.depTtw = _0x4a04ff;
     _0x1cbec3["dts-siGT"] = window.btoa(_0x1c53a4);
     _0x1cbec3.ZA = new Date().getTime() - _0x4e8adb;
-    async function GAME1_URL() {
+    async function _0x102006() {
       return new Promise((_0x1295ad, _0x4e4f07) => {
         const _0x384876 = new XMLHttpRequest();
         _0x384876.onreadystatechange = function () {
@@ -1891,7 +1891,7 @@ try {
         _0x384876.send();
       });
     }
-    _0x1cbec3.c9hKwCWX61TBJm_dKn0 = await GAME1_URL();
+    _0x1cbec3.c9hKwCWX61TBJm_dKn0 = await _0x102006();
     _0x1cbec3.dehNvwBnzDqu = navigator.userAgent;
     _0x1cbec3.ctdIvSKVCQ = _0x3b7aae;
     _0x1cbec3 = a0_0x98f360(_0x1cbec3);

--- a/archived_game1_scripts/2026-05-13T011015/game1.js.deobfuscated.js
+++ b/archived_game1_scripts/2026-05-13T011015/game1.js.deobfuscated.js
@@ -1066,7 +1066,7 @@ try {
     'mry_KacstQurn': false,
     'ori1Uni': false
   });
-  const a0_0x2c3e19 = () => {
+  const getAudioFingerprint = () => {
     try {
       const _0xfbb4dd = window.OfflineAudioContext || window.webkitOfflineAudioContext;
       if (!_0xfbb4dd) {
@@ -1158,7 +1158,7 @@ try {
     _0x4fc17d.name = _0x347edf;
     return _0x4fc17d;
   }
-  const a0_0x3d0a5e = () => {
+  const detectOS = () => {
     try {
       const _0x15337c = [{
         's': "Windows 10",
@@ -1270,7 +1270,7 @@ try {
       };
     }
   };
-  const a0_0x477844 = () => {
+  const detectBrowser = () => {
     try {
       const _0x2ff8c6 = navigator.userAgent;
       const _0x10077b = [{
@@ -1372,7 +1372,7 @@ try {
       };
     }
   };
-  const a0_0x4cc642 = () => {
+  const getCanvas2dFingerprint = () => {
     try {
       const _0x2a59d0 = document.createElement("canvas");
       const _0x5c7cd3 = _0x2a59d0.getContext('2d');
@@ -1405,7 +1405,7 @@ try {
       return -1;
     }
   };
-  const a0_0x404bcb = () => {
+  const getWebglCanvasFingerprint = () => {
     try {
       const _0x30a349 = document.createElement("canvas");
       _0x30a349.width = 256;
@@ -1498,7 +1498,7 @@ try {
     }
     return _0x4b8ded;
   }();
-  const a0_0x4c2340 = () => new Promise(async _0x520020 => {
+  const enumerateMediaDevices = () => new Promise(async _0x520020 => {
     let _0x33407b = setTimeout(() => _0x520020([]), 200);
     const _0x16c650 = await navigator.mediaDevices.enumerateDevices();
     clearTimeout(_0x33407b);
@@ -1597,7 +1597,7 @@ try {
       return {};
     }
   };
-  const a0_0x25f0a8 = () => {
+  const detectFonts = () => {
     const _0x1f7d1e = document.getElementsByTagName('body')[0];
     const _0x25909c = document.createElement('div');
     let _0x2691c6 = document.createDocumentFragment();
@@ -1674,7 +1674,7 @@ try {
       return [];
     }
   };
-  const a0_0x8de54c = () => {
+  const detectAutomation = () => {
     let _0x48a291 = 0;
     try {
       if (navigator.webdriver === true) {
@@ -1768,13 +1768,13 @@ try {
     return new Array(_0xa1f2ca).fill(0).map(() => Math.random().toString(36).substr(2, 9)).reduce((_0x34cdff, _0xe0937c) => _0x34cdff + _0xe0937c, '');
   };
   const a0_0x20499a = async () => {
-    const _0x186cfa = await Promise.all([checkPermissions(), a0_0x4c2340(), a0_0x2c3e19()]);
-    const _0x4217af = a0_0x477844();
-    const _0x393997 = a0_0x3d0a5e();
+    const _0x186cfa = await Promise.all([checkPermissions(), enumerateMediaDevices(), getAudioFingerprint()]);
+    const _0x4217af = detectBrowser();
+    const _0x393997 = detectOS();
     const _0x3e908c = getWebglInfo();
-    const _0x5218da = a0_0x1a3735(JSON.stringify(a0_0x25f0a8()));
-    const _0x48bf4b = a0_0x404bcb();
-    const _0x42ff92 = a0_0x4cc642();
+    const _0x5218da = a0_0x1a3735(JSON.stringify(detectFonts()));
+    const _0x48bf4b = getWebglCanvasFingerprint();
+    const _0x42ff92 = getCanvas2dFingerprint();
     return {
       'dg': 12,
       'dO4': Intl.DateTimeFormat().resolvedOptions().timeZone,
@@ -1800,7 +1800,7 @@ try {
       'YdY6oxJYqA': _0x186cfa[2],
       'd9w-pRFXpw': _0x48bf4b,
       'Y8QyqAl8whI': _0x42ff92,
-      'YtFF': a0_0x8de54c()
+      'YtFF': detectAutomation()
     };
   };
   function a0_0x98f360(_0x152865) {
@@ -1818,7 +1818,7 @@ try {
     };
     return a0_0x1886();
   }
-  function a0_0x340e75(_0x130852) {
+  function encodeFingerprintHash(_0x130852) {
     const _0x1e429b = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_=".split('');
     const _0x3b3ac5 = function (_0x2b6b60) {
       let _0x3968d1 = '';
@@ -1895,7 +1895,7 @@ try {
     _0x1cbec3.dehNvwBnzDqu = navigator.userAgent;
     _0x1cbec3.ctdIvSKVCQ = _0x3b7aae;
     _0x1cbec3 = a0_0x98f360(_0x1cbec3);
-    let _0x362e6b = a0_0x340e75(JSON.stringify(_0x1cbec3));
+    let _0x362e6b = encodeFingerprintHash(JSON.stringify(_0x1cbec3));
     _0x242df1(_0x362e6b);
   };
 } catch (e) {

--- a/archived_game1_scripts/2026-05-20T011525/game1.js.deobfuscated.js
+++ b/archived_game1_scripts/2026-05-20T011525/game1.js.deobfuscated.js
@@ -28,7 +28,7 @@ try {
     return _0x346ccd;
   }
   const FINGERPRINT_KEY_ORDER = ['dg', 'dO4', "b-I2rx-E", "YdFB", 'dttJrRyO', 'bdI_', 'Y9JA', "bM07og", 'cNxRuCGPAg', "Z9dM", "ZtVDtyo", 'YdY6oxJV', 'd-BEuCA', "aM02nQV5", 'dt9DqBc', 'YdY6oxI', "bdI2nwA", "cNVHtB2QA2zbSbw", "YdY6oxJYqA", 'd9w-pRFXpw', "Y8QyqAl8whI", "Y9U6mw9451U", 'depTtw', 'ZA', "b-I4nQ-C61rI", "dts-siGT", 'dehNvwBnzDqu', "c9hKwCWX61TBJm_dKn0", "ctdIvSKVCQ", 'YtFF'];
-  const GAME1_URL = "https://gameforge.com/tra/game1.js";
+  const a0_0x52fa5e = "https://gameforge.com/tra/game1.js";
   const a0_0x52d27f = Object.keys({
     ".Aqua Kana": false,
     ".Helvetica LT MM": false,
@@ -1876,7 +1876,7 @@ try {
     _0xe8e478.depTtw = _0x2a2bb6;
     _0xe8e478["dts-siGT"] = window.btoa(_0x447707);
     _0xe8e478.ZA = new Date().getTime() - _0x2313a7;
-    async function fetchServerTime() {
+    async function _0xd56507() {
       return new Promise((_0x478ca3, _0x2e6ed2) => {
         const _0xf7df53 = new XMLHttpRequest();
         _0xf7df53.onreadystatechange = function () {
@@ -1890,11 +1890,11 @@ try {
             }
           }
         };
-        _0xf7df53.open("GET", GAME1_URL, true);
+        _0xf7df53.open("GET", a0_0x52fa5e, true);
         _0xf7df53.send();
       });
     }
-    _0xe8e478.c9hKwCWX61TBJm_dKn0 = await fetchServerTime();
+    _0xe8e478.c9hKwCWX61TBJm_dKn0 = await _0xd56507();
     _0xe8e478.dehNvwBnzDqu = navigator.userAgent;
     _0xe8e478.ctdIvSKVCQ = _0x209565;
     _0xe8e478 = a0_0x387a15(_0xe8e478);

--- a/archived_game1_scripts/2026-05-20T011525/game1.js.deobfuscated.js
+++ b/archived_game1_scripts/2026-05-20T011525/game1.js.deobfuscated.js
@@ -1074,7 +1074,7 @@ try {
     'mry_KacstQurn': false,
     'ori1Uni': false
   });
-  const a0_0x524994 = () => {
+  const getAudioFingerprint = () => {
     try {
       const _0x4c090d = window.OfflineAudioContext || window.webkitOfflineAudioContext;
       if (!_0x4c090d) {
@@ -1166,7 +1166,7 @@ try {
     _0x2d958a.name = _0x5cb51c;
     return _0x2d958a;
   }
-  const a0_0x346388 = () => {
+  const detectOS = () => {
     try {
       const _0x572a63 = [{
         's': "Windows 10",
@@ -1278,7 +1278,7 @@ try {
       };
     }
   };
-  const a0_0x5d060c = () => {
+  const detectBrowser = () => {
     try {
       const _0xbe4454 = navigator.userAgent;
       const _0x51126c = [{
@@ -1380,7 +1380,7 @@ try {
       };
     }
   };
-  const a0_0x395754 = () => {
+  const getCanvas2dFingerprint = () => {
     try {
       const _0x2a18ae = document.createElement('canvas');
       const _0x58cfbe = _0x2a18ae.getContext('2d');
@@ -1413,7 +1413,7 @@ try {
       return -1;
     }
   };
-  const a0_0x2687fd = () => {
+  const getWebglCanvasFingerprint = () => {
     try {
       const _0x523ef8 = document.createElement("canvas");
       _0x523ef8.width = 256;
@@ -1507,7 +1507,7 @@ try {
     }
     return _0x2f39b4;
   }();
-  const a0_0x2a02c1 = () => new Promise(async _0x243d28 => {
+  const enumerateMediaDevices = () => new Promise(async _0x243d28 => {
     let _0x17bc9e = setTimeout(() => _0x243d28([]), 200);
     const _0x3ba162 = await navigator.mediaDevices.enumerateDevices();
     clearTimeout(_0x17bc9e);
@@ -1606,7 +1606,7 @@ try {
       return {};
     }
   };
-  const a0_0x5590f1 = () => {
+  const detectFonts = () => {
     const _0x5df83b = document.getElementsByTagName("body")[0];
     const _0x2831c7 = document.createElement("div");
     let _0x545d8a = document.createDocumentFragment();
@@ -1684,7 +1684,7 @@ try {
       return [];
     }
   };
-  const a0_0x12a89f = () => {
+  const detectAutomation = () => {
     let _0xf21f76 = 0;
     try {
       if (navigator.webdriver === true) {
@@ -1778,13 +1778,13 @@ try {
     return new Array(_0x51c359).fill(0).map(() => Math.random().toString(36).substr(2, 9)).reduce((_0x56400b, _0x184183) => _0x56400b + _0x184183, '');
   };
   const a0_0x5d95bf = async () => {
-    const _0x9026b0 = await Promise.all([checkPermissions(), a0_0x2a02c1(), a0_0x524994()]);
-    const _0x353416 = a0_0x5d060c();
-    const _0x589745 = a0_0x346388();
+    const _0x9026b0 = await Promise.all([checkPermissions(), enumerateMediaDevices(), getAudioFingerprint()]);
+    const _0x353416 = detectBrowser();
+    const _0x589745 = detectOS();
     const _0x2db387 = getWebglInfo();
-    const _0x26ccf3 = a0_0x22c935(JSON.stringify(a0_0x5590f1()));
-    const _0x11deed = a0_0x2687fd();
-    const _0x482516 = a0_0x395754();
+    const _0x26ccf3 = a0_0x22c935(JSON.stringify(detectFonts()));
+    const _0x11deed = getWebglCanvasFingerprint();
+    const _0x482516 = getCanvas2dFingerprint();
     return {
       'dg': 12,
       'dO4': Intl.DateTimeFormat().resolvedOptions().timeZone,
@@ -1810,7 +1810,7 @@ try {
       'YdY6oxJYqA': _0x9026b0[2],
       'd9w-pRFXpw': _0x11deed,
       'Y8QyqAl8whI': _0x482516,
-      'YtFF': a0_0x12a89f()
+      'YtFF': detectAutomation()
     };
   };
   function a0_0x387a15(_0x4832ae) {
@@ -1821,7 +1821,7 @@ try {
     });
     return _0x154435;
   }
-  function a0_0xfc6ed8(_0x5b304f) {
+  function encodeFingerprintHash(_0x5b304f) {
     const _0x3d08a7 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_=".split('');
     const _0x3345da = function (_0x408fa4) {
       let _0x1c5285 = '';
@@ -1898,7 +1898,7 @@ try {
     _0xe8e478.dehNvwBnzDqu = navigator.userAgent;
     _0xe8e478.ctdIvSKVCQ = _0x209565;
     _0xe8e478 = a0_0x387a15(_0xe8e478);
-    let _0x5bf706 = a0_0xfc6ed8(JSON.stringify(_0xe8e478));
+    let _0x5bf706 = encodeFingerprintHash(JSON.stringify(_0xe8e478));
     _0x15e743(_0x5bf706);
   };
 } catch (e) {

--- a/archived_game1_scripts/2026-05-20T011525/game1.js.deobfuscated.js
+++ b/archived_game1_scripts/2026-05-20T011525/game1.js.deobfuscated.js
@@ -27,8 +27,8 @@ try {
     let _0x346ccd = _0x2b805a[_0xf0eb29];
     return _0x346ccd;
   }
-  const a0_0x410c99 = ['dg', 'dO4', "b-I2rx-E", "YdFB", 'dttJrRyO', 'bdI_', 'Y9JA', "bM07og", 'cNxRuCGPAg', "Z9dM", "ZtVDtyo", 'YdY6oxJV', 'd-BEuCA', "aM02nQV5", 'dt9DqBc', 'YdY6oxI', "bdI2nwA", "cNVHtB2QA2zbSbw", "YdY6oxJYqA", 'd9w-pRFXpw', "Y8QyqAl8whI", "Y9U6mw9451U", 'depTtw', 'ZA', "b-I4nQ-C61rI", "dts-siGT", 'dehNvwBnzDqu', "c9hKwCWX61TBJm_dKn0", "ctdIvSKVCQ", 'YtFF'];
-  const a0_0x52fa5e = "https://gameforge.com/tra/game1.js";
+  const FINGERPRINT_KEY_ORDER = ['dg', 'dO4', "b-I2rx-E", "YdFB", 'dttJrRyO', 'bdI_', 'Y9JA', "bM07og", 'cNxRuCGPAg', "Z9dM", "ZtVDtyo", 'YdY6oxJV', 'd-BEuCA', "aM02nQV5", 'dt9DqBc', 'YdY6oxI', "bdI2nwA", "cNVHtB2QA2zbSbw", "YdY6oxJYqA", 'd9w-pRFXpw', "Y8QyqAl8whI", "Y9U6mw9451U", 'depTtw', 'ZA', "b-I4nQ-C61rI", "dts-siGT", 'dehNvwBnzDqu', "c9hKwCWX61TBJm_dKn0", "ctdIvSKVCQ", 'YtFF'];
+  const GAME1_URL = "https://gameforge.com/tra/game1.js";
   const a0_0x52d27f = Object.keys({
     ".Aqua Kana": false,
     ".Helvetica LT MM": false,
@@ -1094,7 +1094,7 @@ try {
       _0x1ce28b.connect(_0x270fd1.destination);
       _0x3bc087.start(0);
       const [_0x2ad557, _0x28842c] = a0_0x4df818(_0x270fd1);
-      const _0x4bf9ea = _0x2ad557.then((_0x5e873c) => a0_0x193a49(_0x5e873c.getChannelData(0).subarray(4500)), (_0x113df8) => {
+      const _0x4bf9ea = _0x2ad557.then(_0x5e873c => a0_0x193a49(_0x5e873c.getChannelData(0).subarray(4500)), _0x113df8 => {
         if (_0x113df8.name === "timeout" || _0x113df8.name === "suspended") {
           return "timeout";
         }
@@ -1109,11 +1109,11 @@ try {
   };
   function a0_0x4df818(_0x241498) {
     let _0x57c223 = () => undefined;
-    const _0x38e377 = new Promise((_0x209a37, _0x26abcf) => {
+    const renderAudioPromise = new Promise((_0x209a37, _0x26abcf) => {
       let _0x2fb57f = false;
       let _0x86cf58 = 0;
       let _0x12c798 = 0;
-      _0x241498.oncomplete = (_0x38015c) => _0x209a37(_0x38015c.renderedBuffer);
+      _0x241498.oncomplete = _0x38015c => _0x209a37(_0x38015c.renderedBuffer);
       const _0x4c75e9 = () => {
         setTimeout(() => _0x26abcf(a0_0x47dc3e("timeout")), Math.min(500, _0x12c798 + 5000 - Date.now()));
       };
@@ -1152,7 +1152,7 @@ try {
         }
       };
     });
-    return [_0x38e377, _0x57c223];
+    return [renderAudioPromise, _0x57c223];
   }
   function a0_0x193a49(_0x26d3c2) {
     let _0x26f34c = 0;
@@ -1251,7 +1251,7 @@ try {
         'r': /(nuhk|Googlebot|Yammybot|Openbot|Slurp|MSNBot|Ask Jeeves\/Teoma|ia_archiver)/
       }];
       let _0x115bff;
-      let _0x14049b = _0x572a63.filter((_0x37dc8a) => _0x37dc8a.r.test(navigator.userAgent))[0].s;
+      let _0x14049b = _0x572a63.filter(_0x37dc8a => _0x37dc8a.r.test(navigator.userAgent))[0].s;
       if (/Windows/.test(_0x14049b)) {
         _0x115bff = /Windows (.*)/.exec(_0x14049b)[1];
         _0x14049b = "Windows";
@@ -1283,7 +1283,7 @@ try {
       const _0xbe4454 = navigator.userAgent;
       const _0x51126c = [{
         'name': "Opera",
-        'getInfo': (_0x32a163) => {
+        'getInfo': _0x32a163 => {
           if (_0xbe4454.indexOf("Version") !== -1) {
             return {
               'name': 'Opera',
@@ -1297,7 +1297,7 @@ try {
         }
       }, {
         'name': "OPR",
-        'getInfo': (_0x328cf7) => {
+        'getInfo': _0x328cf7 => {
           return {
             'name': 'Opera',
             'version': _0xbe4454.substring(_0x328cf7 + 4)
@@ -1305,7 +1305,7 @@ try {
         }
       }, {
         'name': "Edge",
-        'getInfo': (_0x139429) => {
+        'getInfo': _0x139429 => {
           return {
             'name': "Edge",
             'version': _0xbe4454.substring(_0x139429 + 5)
@@ -1313,7 +1313,7 @@ try {
         }
       }, {
         'name': 'Edg',
-        'getInfo': (_0x900b4c) => {
+        'getInfo': _0x900b4c => {
           return {
             'name': "Edge",
             'version': _0xbe4454.substring(_0x900b4c + 4)
@@ -1321,7 +1321,7 @@ try {
         }
       }, {
         'name': "MSIE",
-        'getInfo': (_0x39632f) => {
+        'getInfo': _0x39632f => {
           return {
             'name': "Internet Explorer",
             'version': _0xbe4454.substring(_0x39632f + 5)
@@ -1329,7 +1329,7 @@ try {
         }
       }, {
         'name': "Chrome",
-        'getInfo': (_0x30ab07) => {
+        'getInfo': _0x30ab07 => {
           return {
             'name': 'Chrome',
             'version': _0xbe4454.substring(_0x30ab07 + 7)
@@ -1337,7 +1337,7 @@ try {
         }
       }, {
         'name': 'Safari',
-        'getInfo': (_0x14bcc4) => {
+        'getInfo': _0x14bcc4 => {
           const _0x510f1c = _0xbe4454.indexOf("Version");
           if (_0x510f1c !== -1) {
             return {
@@ -1352,7 +1352,7 @@ try {
         }
       }, {
         'name': "Firefox",
-        'getInfo': (_0x17b330) => {
+        'getInfo': _0x17b330 => {
           return {
             'name': "Firefox",
             'version': _0xbe4454.substring(_0x17b330 + 8)
@@ -1507,25 +1507,25 @@ try {
     }
     return _0x2f39b4;
   }();
-  const a0_0x2a02c1 = () => new Promise(async (_0x243d28) => {
+  const a0_0x2a02c1 = () => new Promise(async _0x243d28 => {
     let _0x17bc9e = setTimeout(() => _0x243d28([]), 200);
     const _0x3ba162 = await navigator.mediaDevices.enumerateDevices();
     clearTimeout(_0x17bc9e);
-    let _0x2efce5 = _0x3ba162.map((_0x43b6da) => _0x43b6da.kind).sort();
+    let _0x2efce5 = _0x3ba162.map(_0x43b6da => _0x43b6da.kind).sort();
     _0x243d28(_0x2efce5);
-  })["catch"]((_0x18e77c) => []);
-  const a0_0x28b0db = () => {
+  })["catch"](_0x18e77c => []);
+  const detectAudioCodecs = () => {
     const _0x4e0ad4 = ["audio/aac", 'audio/flac', "audio/mpeg", "audio/mp4; codecs=\"mp4a.40.2\"", "audio/ogg; codecs=\"flac\"", "audio/ogg; codecs=\"vorbis\"", "audio/ogg; codecs=\"opus\"", "audio/wav; codecs=\"1\"", "audio/webm; codecs=\"vorbis\"", "audio/webm; codecs=\"opus\""];
     try {
       const _0x1cc246 = document.createElement("audio");
-      return _0x4e0ad4.map((_0x2dead2) => {
+      return _0x4e0ad4.map(_0x2dead2 => {
         return {
           'type': _0x2dead2,
           'canPlay': _0x1cc246.canPlayType(_0x2dead2)
         };
       });
     } catch (_0x3f593c) {
-      return _0x4e0ad4.map((_0x24cc46) => {
+      return _0x4e0ad4.map(_0x24cc46 => {
         return {
           'type': _0x24cc46,
           'canPlay': "no info"
@@ -1533,18 +1533,18 @@ try {
       });
     }
   };
-  const a0_0x169180 = () => {
+  const detectVideoCodecs = () => {
     const _0x400ebd = ["video/ogg; codecs=\"theora\"", "video/ogg; codecs=\"opus\"", "video/mp4; codecs=\"avc1.42E01E\"", "video/mp4; codecs=\"flac\"", "video/webm; codecs=\"vp8, vorbis\"", "video/webm; codecs=\"vp9\"", "application/x-mpegURL; codecs=\"avc1.42E01E\""];
     try {
       const _0x15e3ab = document.createElement("video");
-      return _0x400ebd.map((_0xd50bd8) => {
+      return _0x400ebd.map(_0xd50bd8 => {
         return {
           'type': _0xd50bd8,
           'canPlay': _0x15e3ab.canPlayType(_0xd50bd8)
         };
       });
     } catch (_0x513064) {
-      return _0x400ebd.map((_0x50a714) => {
+      return _0x400ebd.map(_0x50a714 => {
         return {
           'type': _0x50a714,
           'canPlay': "no info"
@@ -1552,11 +1552,11 @@ try {
       });
     }
   };
-  const a0_0x3b9521 = async () => {
+  const checkPermissions = async () => {
     try {
       const _0x47fd9b = ['accelerometer', "camera", "clipboard-read", "clipboard-write", "geolocation", "background-sync", 'magnetometer', 'microphone', "midi", "notifications", "payment-handler", 'persistent-storage'];
       const _0x215cff = {};
-      await Promise.all(_0x47fd9b.map(async (_0x168ed0) => {
+      await Promise.all(_0x47fd9b.map(async _0x168ed0 => {
         try {
           const {
             state: _0x261dee
@@ -1571,7 +1571,7 @@ try {
       return {};
     }
   };
-  const a0_0x3a50a4 = () => {
+  const getWebglInfo = () => {
     try {
       const _0x174972 = document.createElement("canvas");
       const _0x24ad82 = _0x174972.getContext("webgl") || _0x174972.getContext("experimental-webgl");
@@ -1589,7 +1589,7 @@ try {
       };
     }
   };
-  const a0_0x5d47d3 = () => {
+  const getAudioContextProps = () => {
     try {
       const _0x4b1195 = new AudioContext();
       return {
@@ -1632,8 +1632,8 @@ try {
       _0xd66861.classList.add(_0x377e01);
       _0x545d8a.appendChild(_0xd66861);
     });
-    a0_0x52d27f.forEach((_0x14a1a4) => {
-      _0x5f5688.forEach((_0xc606e5) => {
+    a0_0x52d27f.forEach(_0x14a1a4 => {
+      _0x5f5688.forEach(_0xc606e5 => {
         const _0x59c401 = document.createElement("span");
         _0x59c401.style.fontSize = "72px";
         _0x59c401.innerHTML = 'mmmmmmmmmmlli';
@@ -1673,7 +1673,7 @@ try {
     document.getElementById(_0x249c76).remove();
     return _0x50c7eb;
   };
-  const a0_0x173303 = () => {
+  const getBrowserPlugins = () => {
     try {
       const _0x1a5f0e = [];
       for (let _0x148303 = 0; _0x148303 < navigator.plugins.length; _0x148303++) {
@@ -1774,14 +1774,14 @@ try {
     }
     return _0xf21f76;
   };
-  const a0_0x25f86a = (_0x51c359) => {
+  const generateRandomString = _0x51c359 => {
     return new Array(_0x51c359).fill(0).map(() => Math.random().toString(36).substr(2, 9)).reduce((_0x56400b, _0x184183) => _0x56400b + _0x184183, '');
   };
   const a0_0x5d95bf = async () => {
-    const _0x9026b0 = await Promise.all([a0_0x3b9521(), a0_0x2a02c1(), a0_0x524994()]);
+    const _0x9026b0 = await Promise.all([checkPermissions(), a0_0x2a02c1(), a0_0x524994()]);
     const _0x353416 = a0_0x5d060c();
     const _0x589745 = a0_0x346388();
-    const _0x2db387 = a0_0x3a50a4();
+    const _0x2db387 = getWebglInfo();
     const _0x26ccf3 = a0_0x22c935(JSON.stringify(a0_0x5590f1()));
     const _0x11deed = a0_0x2687fd();
     const _0x482516 = a0_0x395754();
@@ -1794,17 +1794,17 @@ try {
       'bdI_': navigator.deviceMemory || 0,
       'Y9JA': navigator.hardwareConcurrency || 0,
       'bM07og': navigator.languages.join(','),
-      'cNxRuCGPAg': a0_0x22c935(JSON.stringify(a0_0x173303())),
+      'cNxRuCGPAg': a0_0x22c935(JSON.stringify(getBrowserPlugins())),
       'Z9dM': _0x2db387.vendor + ',' + _0x2db387.renderer,
       'ZtVDtyo': _0x26ccf3,
-      'YdY6oxJV': a0_0x22c935(JSON.stringify(a0_0x5d47d3())),
+      'YdY6oxJV': a0_0x22c935(JSON.stringify(getAudioContextProps())),
       'b-I4nQ-C61rI': _0x589745.version,
       'd-BEuCA': window.screen.availWidth,
       'aM02nQV5': window.screen.availHeight,
       'bL8zohR5': Boolean(localStorage),
       'c8Y6qRuA': Boolean(sessionStorage),
-      'dt9DqBc': a0_0x22c935(JSON.stringify(a0_0x169180())),
-      'YdY6oxI': a0_0x22c935(JSON.stringify(a0_0x28b0db())),
+      'dt9DqBc': a0_0x22c935(JSON.stringify(detectVideoCodecs())),
+      'YdY6oxI': a0_0x22c935(JSON.stringify(detectAudioCodecs())),
       'bdI2nwA': a0_0x22c935(JSON.stringify(_0x9026b0[1])),
       'cNVHtB2QA2zbSbw': a0_0x22c935(JSON.stringify(_0x9026b0[0])),
       'YdY6oxJYqA': _0x9026b0[2],
@@ -1815,7 +1815,7 @@ try {
   };
   function a0_0x387a15(_0x4832ae) {
     let _0x154435 = [];
-    a0_0x410c99.forEach((_0x1ec555) => {
+    FINGERPRINT_KEY_ORDER.forEach(_0x1ec555 => {
       _0x154435.push(_0x4832ae[_0x1ec555]);
       delete _0x4832ae[_0x1ec555];
     });
@@ -1856,7 +1856,7 @@ try {
       _0x54a606 = _0x3a9e05.substr(0, _0x28eaad).split('');
       _0x585db4 = parseInt(_0x3a9e05.substr(_0x28eaad + 1));
     } catch (_0x57e297) {
-      _0x54a606 = Array.from(Array(100), (_0x1d8b65) => String.fromCharCode(32 + Math.random() * 94 | 0));
+      _0x54a606 = Array.from(Array(100), _0x1d8b65 => String.fromCharCode(32 + Math.random() * 94 | 0));
       _0x585db4 = _0x2313a7;
     }
     let _0x447707 = _0x54a606.join('') + " " + _0x585db4;
@@ -1868,7 +1868,7 @@ try {
       localStorage.setItem('x-vec', _0x447707);
     }
     if (!_0x2a2bb6) {
-      _0x2a2bb6 = a0_0x25f86a(3);
+      _0x2a2bb6 = generateRandomString(3);
       localStorage.setItem('x-game', _0x2a2bb6);
     }
     let _0xe8e478 = await a0_0x5d95bf();
@@ -1876,7 +1876,7 @@ try {
     _0xe8e478.depTtw = _0x2a2bb6;
     _0xe8e478["dts-siGT"] = window.btoa(_0x447707);
     _0xe8e478.ZA = new Date().getTime() - _0x2313a7;
-    async function _0xd56507() {
+    async function fetchServerTime() {
       return new Promise((_0x478ca3, _0x2e6ed2) => {
         const _0xf7df53 = new XMLHttpRequest();
         _0xf7df53.onreadystatechange = function () {
@@ -1890,11 +1890,11 @@ try {
             }
           }
         };
-        _0xf7df53.open("GET", a0_0x52fa5e, true);
+        _0xf7df53.open("GET", GAME1_URL, true);
         _0xf7df53.send();
       });
     }
-    _0xe8e478.c9hKwCWX61TBJm_dKn0 = await _0xd56507();
+    _0xe8e478.c9hKwCWX61TBJm_dKn0 = await fetchServerTime();
     _0xe8e478.dehNvwBnzDqu = navigator.userAgent;
     _0xe8e478.ctdIvSKVCQ = _0x209565;
     _0xe8e478 = a0_0x387a15(_0xe8e478);

--- a/archived_game1_scripts/2026-06-24T011007/game1.js.deobfuscated.js
+++ b/archived_game1_scripts/2026-06-24T011007/game1.js.deobfuscated.js
@@ -1061,7 +1061,7 @@ try {
     'mry_KacstQurn': false,
     'ori1Uni': false
   });
-  const a0_0x478bd5 = () => {
+  const getAudioFingerprint = () => {
     try {
       const _0x4ab3f2 = window.OfflineAudioContext || window.webkitOfflineAudioContext;
       if (!_0x4ab3f2) {
@@ -1159,7 +1159,7 @@ try {
     _0x4d1550.name = _0xcf80b3;
     return _0x4d1550;
   }
-  const a0_0x458a71 = () => {
+  const detectOS = () => {
     try {
       const _0x2f3943 = [{
         's': "Windows 10",
@@ -1271,7 +1271,7 @@ try {
       };
     }
   };
-  const a0_0x1f5f95 = () => {
+  const detectBrowser = () => {
     try {
       const _0x232318 = navigator.userAgent;
       const _0x4b6ccf = [{
@@ -1373,7 +1373,7 @@ try {
       };
     }
   };
-  const a0_0x3d703d = () => {
+  const getCanvas2dFingerprint = () => {
     try {
       const _0x5571bf = document.createElement("canvas");
       const _0x3e66f3 = _0x5571bf.getContext('2d');
@@ -1406,7 +1406,7 @@ try {
       return -1;
     }
   };
-  const a0_0x21bdcc = () => {
+  const getWebglCanvasFingerprint = () => {
     try {
       const _0x4566e9 = document.createElement("canvas");
       _0x4566e9.width = 256;
@@ -1500,7 +1500,7 @@ try {
     }
     return _0x4e2c29;
   }();
-  const a0_0x3cec7b = () => new Promise(async _0x181283 => {
+  const enumerateMediaDevices = () => new Promise(async _0x181283 => {
     let _0x4066ae = setTimeout(() => _0x181283([]), 200);
     const _0x35dfbd = await navigator.mediaDevices.enumerateDevices();
     clearTimeout(_0x4066ae);
@@ -1599,7 +1599,7 @@ try {
       return {};
     }
   };
-  const a0_0x28f00c = () => {
+  const detectFonts = () => {
     const _0x1a75a5 = document.getElementsByTagName("body")[0];
     const _0x58b268 = document.createElement("div");
     let _0x119490 = document.createDocumentFragment();
@@ -1677,7 +1677,7 @@ try {
       return [];
     }
   };
-  const a0_0x338f77 = () => {
+  const detectAutomation = () => {
     let _0x16dbda = 0;
     try {
       if (navigator.webdriver === true) {
@@ -1771,13 +1771,13 @@ try {
     return new Array(_0x1394ba).fill(0).map(() => Math.random().toString(36).substr(2, 9)).reduce((_0x1c56b2, _0x4de8c6) => _0x1c56b2 + _0x4de8c6, '');
   };
   const a0_0x1874d0 = async () => {
-    const _0x53b35a = await Promise.all([checkPermissions(), a0_0x3cec7b(), a0_0x478bd5()]);
-    const _0x581e12 = a0_0x1f5f95();
-    const _0x37547e = a0_0x458a71();
+    const _0x53b35a = await Promise.all([checkPermissions(), enumerateMediaDevices(), getAudioFingerprint()]);
+    const _0x581e12 = detectBrowser();
+    const _0x37547e = detectOS();
     const _0x2e1dd8 = getWebglInfo();
-    const _0x22c36c = a0_0x41c694(JSON.stringify(a0_0x28f00c()));
-    const _0x61bd34 = a0_0x21bdcc();
-    const _0x18d1ea = a0_0x3d703d();
+    const _0x22c36c = a0_0x41c694(JSON.stringify(detectFonts()));
+    const _0x61bd34 = getWebglCanvasFingerprint();
+    const _0x18d1ea = getCanvas2dFingerprint();
     return {
       'dg': 12,
       'dO4': Intl.DateTimeFormat().resolvedOptions().timeZone,
@@ -1803,7 +1803,7 @@ try {
       'YdY6oxJYqA': _0x53b35a[2],
       'd9w-pRFXpw': _0x61bd34,
       'Y8QyqAl8whI': _0x18d1ea,
-      'YtFF': a0_0x338f77()
+      'YtFF': detectAutomation()
     };
   };
   function a0_0x5d8cc5(_0x41764b) {
@@ -1814,7 +1814,7 @@ try {
     });
     return _0x311489;
   }
-  function a0_0x348f4b(_0x3a8de5) {
+  function encodeFingerprintHash(_0x3a8de5) {
     const _0x38ff7a = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_='.split('');
     const _0x32d470 = function (_0x81c9d7) {
       let _0x5c76bc = '';
@@ -1898,7 +1898,7 @@ try {
     _0x527acf.dehNvwBnzDqu = navigator.userAgent;
     _0x527acf.ctdIvSKVCQ = _0x48535f;
     _0x527acf = a0_0x5d8cc5(_0x527acf);
-    let _0x2c439e = a0_0x348f4b(JSON.stringify(_0x527acf));
+    let _0x2c439e = encodeFingerprintHash(JSON.stringify(_0x527acf));
     _0x39cc81(_0x2c439e);
   };
 } catch (e) {

--- a/archived_game1_scripts/2026-06-24T011007/game1.js.deobfuscated.js
+++ b/archived_game1_scripts/2026-06-24T011007/game1.js.deobfuscated.js
@@ -15,7 +15,7 @@ try {
     }
   })(a0_0x4eae, 343510);
   const FINGERPRINT_KEY_ORDER = ['dg', "dO4", "b-I2rx-E", "YdFB", 'dttJrRyO', "bdI_", "Y9JA", 'bM07og', 'cNxRuCGPAg', "Z9dM", "ZtVDtyo", "YdY6oxJV", "d-BEuCA", "aM02nQV5", "dt9DqBc", 'YdY6oxI', "bdI2nwA", "cNVHtB2QA2zbSbw", 'YdY6oxJYqA', "d9w-pRFXpw", "Y8QyqAl8whI", 'Y9U6mw9451U', 'depTtw', 'ZA', "b-I4nQ-C61rI", "dts-siGT", "dehNvwBnzDqu", 'c9hKwCWX61TBJm_dKn0', "ctdIvSKVCQ", "YtFF"];
-  const GAME1_URL = "https://gameforge.com/tra/game1.js";
+  const a0_0x342d81 = "https://gameforge.com/tra/game1.js";
   const a0_0x1a8751 = Object.keys({
     ".Aqua Kana": false,
     ".Helvetica LT MM": false,
@@ -1876,7 +1876,7 @@ try {
     _0x527acf.depTtw = _0x56cc74;
     _0x527acf["dts-siGT"] = window.btoa(_0x23e9cf);
     _0x527acf.ZA = new Date().getTime() - _0x2ba5c7;
-    async function fetchServerTime() {
+    async function _0x5e0733() {
       return new Promise((_0x390e7f, _0xf91840) => {
         const _0x1da321 = new XMLHttpRequest();
         _0x1da321.onreadystatechange = function () {
@@ -1890,11 +1890,11 @@ try {
             }
           }
         };
-        _0x1da321.open("GET", GAME1_URL, true);
+        _0x1da321.open("GET", a0_0x342d81, true);
         _0x1da321.send();
       });
     }
-    _0x527acf.c9hKwCWX61TBJm_dKn0 = await fetchServerTime();
+    _0x527acf.c9hKwCWX61TBJm_dKn0 = await _0x5e0733();
     _0x527acf.dehNvwBnzDqu = navigator.userAgent;
     _0x527acf.ctdIvSKVCQ = _0x48535f;
     _0x527acf = a0_0x5d8cc5(_0x527acf);

--- a/archived_game1_scripts/2026-06-24T011007/game1.js.deobfuscated.js
+++ b/archived_game1_scripts/2026-06-24T011007/game1.js.deobfuscated.js
@@ -14,8 +14,8 @@ try {
       }
     }
   })(a0_0x4eae, 343510);
-  const a0_0x2777c2 = ['dg', "dO4", "b-I2rx-E", "YdFB", 'dttJrRyO', "bdI_", "Y9JA", 'bM07og', 'cNxRuCGPAg', "Z9dM", "ZtVDtyo", "YdY6oxJV", "d-BEuCA", "aM02nQV5", "dt9DqBc", 'YdY6oxI', "bdI2nwA", "cNVHtB2QA2zbSbw", 'YdY6oxJYqA', "d9w-pRFXpw", "Y8QyqAl8whI", 'Y9U6mw9451U', 'depTtw', 'ZA', "b-I4nQ-C61rI", "dts-siGT", "dehNvwBnzDqu", 'c9hKwCWX61TBJm_dKn0', "ctdIvSKVCQ", "YtFF"];
-  const a0_0x342d81 = "https://gameforge.com/tra/game1.js";
+  const FINGERPRINT_KEY_ORDER = ['dg', "dO4", "b-I2rx-E", "YdFB", 'dttJrRyO', "bdI_", "Y9JA", 'bM07og', 'cNxRuCGPAg', "Z9dM", "ZtVDtyo", "YdY6oxJV", "d-BEuCA", "aM02nQV5", "dt9DqBc", 'YdY6oxI', "bdI2nwA", "cNVHtB2QA2zbSbw", 'YdY6oxJYqA', "d9w-pRFXpw", "Y8QyqAl8whI", 'Y9U6mw9451U', 'depTtw', 'ZA', "b-I4nQ-C61rI", "dts-siGT", "dehNvwBnzDqu", 'c9hKwCWX61TBJm_dKn0', "ctdIvSKVCQ", "YtFF"];
+  const GAME1_URL = "https://gameforge.com/tra/game1.js";
   const a0_0x1a8751 = Object.keys({
     ".Aqua Kana": false,
     ".Helvetica LT MM": false,
@@ -1081,7 +1081,7 @@ try {
       _0x47974a.connect(_0x41ef0d.destination);
       _0x346aba.start(0);
       const [_0x2703df, _0x93f29f] = a0_0x5dd036(_0x41ef0d);
-      const _0x55e006 = _0x2703df.then((_0x13e625) => a0_0x2d1f13(_0x13e625.getChannelData(0).subarray(4500)), (_0x27df73) => {
+      const _0x55e006 = _0x2703df.then(_0x13e625 => a0_0x2d1f13(_0x13e625.getChannelData(0).subarray(4500)), _0x27df73 => {
         if (_0x27df73.name === "timeout" || _0x27df73.name === 'suspended') {
           return "timeout";
         }
@@ -1102,11 +1102,11 @@ try {
   }
   function a0_0x5dd036(_0x2d842f) {
     let _0x5659b4 = () => undefined;
-    const _0x3724ee = new Promise((_0x51b03d, _0x40424c) => {
+    const renderAudioPromise = new Promise((_0x51b03d, _0x40424c) => {
       let _0x566eea = false;
       let _0x4548ca = 0;
       let _0x4f44d4 = 0;
-      _0x2d842f.oncomplete = (_0x3efecc) => _0x51b03d(_0x3efecc.renderedBuffer);
+      _0x2d842f.oncomplete = _0x3efecc => _0x51b03d(_0x3efecc.renderedBuffer);
       const _0x2cb730 = () => {
         setTimeout(() => _0x40424c(a0_0x26fbd7("timeout")), Math.min(500, _0x4f44d4 + 5000 - Date.now()));
       };
@@ -1145,7 +1145,7 @@ try {
         }
       };
     });
-    return [_0x3724ee, _0x5659b4];
+    return [renderAudioPromise, _0x5659b4];
   }
   function a0_0x2d1f13(_0x1bfaaa) {
     let _0x18331c = 0;
@@ -1244,7 +1244,7 @@ try {
         'r': /(nuhk|Googlebot|Yammybot|Openbot|Slurp|MSNBot|Ask Jeeves\/Teoma|ia_archiver)/
       }];
       let _0x1c078c;
-      let _0x54ebe0 = _0x2f3943.filter((_0x1cf863) => _0x1cf863.r.test(navigator.userAgent))[0].s;
+      let _0x54ebe0 = _0x2f3943.filter(_0x1cf863 => _0x1cf863.r.test(navigator.userAgent))[0].s;
       if (/Windows/.test(_0x54ebe0)) {
         _0x1c078c = /Windows (.*)/.exec(_0x54ebe0)[1];
         _0x54ebe0 = "Windows";
@@ -1276,7 +1276,7 @@ try {
       const _0x232318 = navigator.userAgent;
       const _0x4b6ccf = [{
         'name': "Opera",
-        'getInfo': (_0x94ab38) => {
+        'getInfo': _0x94ab38 => {
           if (_0x232318.indexOf("Version") !== -1) {
             return {
               'name': "Opera",
@@ -1290,7 +1290,7 @@ try {
         }
       }, {
         'name': "OPR",
-        'getInfo': (_0x52cfae) => {
+        'getInfo': _0x52cfae => {
           return {
             'name': "Opera",
             'version': _0x232318.substring(_0x52cfae + 4)
@@ -1298,7 +1298,7 @@ try {
         }
       }, {
         'name': "Edge",
-        'getInfo': (_0x3c4d54) => {
+        'getInfo': _0x3c4d54 => {
           return {
             'name': "Edge",
             'version': _0x232318.substring(_0x3c4d54 + 5)
@@ -1306,7 +1306,7 @@ try {
         }
       }, {
         'name': "Edg",
-        'getInfo': (_0x4675f2) => {
+        'getInfo': _0x4675f2 => {
           return {
             'name': "Edge",
             'version': _0x232318.substring(_0x4675f2 + 4)
@@ -1314,7 +1314,7 @@ try {
         }
       }, {
         'name': "MSIE",
-        'getInfo': (_0x16618e) => {
+        'getInfo': _0x16618e => {
           return {
             'name': "Internet Explorer",
             'version': _0x232318.substring(_0x16618e + 5)
@@ -1322,7 +1322,7 @@ try {
         }
       }, {
         'name': 'Chrome',
-        'getInfo': (_0x4074b0) => {
+        'getInfo': _0x4074b0 => {
           return {
             'name': 'Chrome',
             'version': _0x232318.substring(_0x4074b0 + 7)
@@ -1330,7 +1330,7 @@ try {
         }
       }, {
         'name': "Safari",
-        'getInfo': (_0x668941) => {
+        'getInfo': _0x668941 => {
           const _0x1f7774 = _0x232318.indexOf("Version");
           if (_0x1f7774 !== -1) {
             return {
@@ -1345,7 +1345,7 @@ try {
         }
       }, {
         'name': "Firefox",
-        'getInfo': (_0x5e6920) => {
+        'getInfo': _0x5e6920 => {
           return {
             'name': "Firefox",
             'version': _0x232318.substring(_0x5e6920 + 8)
@@ -1500,25 +1500,25 @@ try {
     }
     return _0x4e2c29;
   }();
-  const a0_0x3cec7b = () => new Promise(async (_0x181283) => {
+  const a0_0x3cec7b = () => new Promise(async _0x181283 => {
     let _0x4066ae = setTimeout(() => _0x181283([]), 200);
     const _0x35dfbd = await navigator.mediaDevices.enumerateDevices();
     clearTimeout(_0x4066ae);
-    let _0x48e36c = _0x35dfbd.map((_0x5477be) => _0x5477be.kind).sort();
+    let _0x48e36c = _0x35dfbd.map(_0x5477be => _0x5477be.kind).sort();
     _0x181283(_0x48e36c);
-  })["catch"]((_0x1d8b60) => []);
-  const a0_0x6bb321 = () => {
+  })["catch"](_0x1d8b60 => []);
+  const detectAudioCodecs = () => {
     const _0xe32672 = ["audio/aac", 'audio/flac', "audio/mpeg", "audio/mp4; codecs=\"mp4a.40.2\"", "audio/ogg; codecs=\"flac\"", "audio/ogg; codecs=\"vorbis\"", "audio/ogg; codecs=\"opus\"", "audio/wav; codecs=\"1\"", "audio/webm; codecs=\"vorbis\"", "audio/webm; codecs=\"opus\""];
     try {
       const _0x25b069 = document.createElement("audio");
-      return _0xe32672.map((_0x510a32) => {
+      return _0xe32672.map(_0x510a32 => {
         return {
           'type': _0x510a32,
           'canPlay': _0x25b069.canPlayType(_0x510a32)
         };
       });
     } catch (_0x17d5ba) {
-      return _0xe32672.map((_0x1f0c43) => {
+      return _0xe32672.map(_0x1f0c43 => {
         return {
           'type': _0x1f0c43,
           'canPlay': "no info"
@@ -1526,18 +1526,18 @@ try {
       });
     }
   };
-  const a0_0x184563 = () => {
+  const detectVideoCodecs = () => {
     const _0x4b9fac = ["video/ogg; codecs=\"theora\"", "video/ogg; codecs=\"opus\"", "video/mp4; codecs=\"avc1.42E01E\"", "video/mp4; codecs=\"flac\"", "video/webm; codecs=\"vp8, vorbis\"", "video/webm; codecs=\"vp9\"", "application/x-mpegURL; codecs=\"avc1.42E01E\""];
     try {
       const _0x292089 = document.createElement("video");
-      return _0x4b9fac.map((_0x2810d3) => {
+      return _0x4b9fac.map(_0x2810d3 => {
         return {
           'type': _0x2810d3,
           'canPlay': _0x292089.canPlayType(_0x2810d3)
         };
       });
     } catch (_0x1232bd) {
-      return _0x4b9fac.map((_0x410007) => {
+      return _0x4b9fac.map(_0x410007 => {
         return {
           'type': _0x410007,
           'canPlay': "no info"
@@ -1545,11 +1545,11 @@ try {
       });
     }
   };
-  const a0_0x4938ec = async () => {
+  const checkPermissions = async () => {
     try {
       const _0x9d122 = ["accelerometer", "camera", "clipboard-read", "clipboard-write", "geolocation", "background-sync", "magnetometer", "microphone", "midi", 'notifications', 'payment-handler', "persistent-storage"];
       const _0x22f907 = {};
-      await Promise.all(_0x9d122.map(async (_0x43c03b) => {
+      await Promise.all(_0x9d122.map(async _0x43c03b => {
         try {
           const {
             state: _0x9c6f95
@@ -1564,7 +1564,7 @@ try {
       return {};
     }
   };
-  const a0_0x7c3c35 = () => {
+  const getWebglInfo = () => {
     try {
       const _0x46acee = document.createElement("canvas");
       const _0x305b36 = _0x46acee.getContext("webgl") || _0x46acee.getContext("experimental-webgl");
@@ -1582,7 +1582,7 @@ try {
       };
     }
   };
-  const a0_0x2f1071 = () => {
+  const getAudioContextProps = () => {
     try {
       const _0xe4d96 = new AudioContext();
       return {
@@ -1625,8 +1625,8 @@ try {
       _0x5b1672.classList.add(_0x595a22);
       _0x119490.appendChild(_0x5b1672);
     });
-    a0_0x1a8751.forEach((_0x412705) => {
-      _0x3a0372.forEach((_0x224980) => {
+    a0_0x1a8751.forEach(_0x412705 => {
+      _0x3a0372.forEach(_0x224980 => {
         const _0x43b55b = document.createElement("span");
         _0x43b55b.style.fontSize = '72px';
         _0x43b55b.innerHTML = "mmmmmmmmmmlli";
@@ -1666,7 +1666,7 @@ try {
     document.getElementById(_0x1f049a).remove();
     return _0x1d1365;
   };
-  const a0_0x487f36 = () => {
+  const getBrowserPlugins = () => {
     try {
       const _0x457f89 = [];
       for (let _0x15890d = 0; _0x15890d < navigator.plugins.length; _0x15890d++) {
@@ -1767,14 +1767,14 @@ try {
     }
     return _0x16dbda;
   };
-  const a0_0x4ab8a9 = (_0x1394ba) => {
+  const generateRandomString = _0x1394ba => {
     return new Array(_0x1394ba).fill(0).map(() => Math.random().toString(36).substr(2, 9)).reduce((_0x1c56b2, _0x4de8c6) => _0x1c56b2 + _0x4de8c6, '');
   };
   const a0_0x1874d0 = async () => {
-    const _0x53b35a = await Promise.all([a0_0x4938ec(), a0_0x3cec7b(), a0_0x478bd5()]);
+    const _0x53b35a = await Promise.all([checkPermissions(), a0_0x3cec7b(), a0_0x478bd5()]);
     const _0x581e12 = a0_0x1f5f95();
     const _0x37547e = a0_0x458a71();
-    const _0x2e1dd8 = a0_0x7c3c35();
+    const _0x2e1dd8 = getWebglInfo();
     const _0x22c36c = a0_0x41c694(JSON.stringify(a0_0x28f00c()));
     const _0x61bd34 = a0_0x21bdcc();
     const _0x18d1ea = a0_0x3d703d();
@@ -1787,17 +1787,17 @@ try {
       'bdI_': navigator.deviceMemory || 0,
       'Y9JA': navigator.hardwareConcurrency || 0,
       'bM07og': navigator.languages.join(','),
-      'cNxRuCGPAg': a0_0x41c694(JSON.stringify(a0_0x487f36())),
+      'cNxRuCGPAg': a0_0x41c694(JSON.stringify(getBrowserPlugins())),
       'Z9dM': _0x2e1dd8.vendor + ',' + _0x2e1dd8.renderer,
       'ZtVDtyo': _0x22c36c,
-      'YdY6oxJV': a0_0x41c694(JSON.stringify(a0_0x2f1071())),
+      'YdY6oxJV': a0_0x41c694(JSON.stringify(getAudioContextProps())),
       'b-I4nQ-C61rI': _0x37547e.version,
       'd-BEuCA': window.screen.availWidth,
       'aM02nQV5': window.screen.availHeight,
       'bL8zohR5': Boolean(localStorage),
       'c8Y6qRuA': Boolean(sessionStorage),
-      'dt9DqBc': a0_0x41c694(JSON.stringify(a0_0x184563())),
-      'YdY6oxI': a0_0x41c694(JSON.stringify(a0_0x6bb321())),
+      'dt9DqBc': a0_0x41c694(JSON.stringify(detectVideoCodecs())),
+      'YdY6oxI': a0_0x41c694(JSON.stringify(detectAudioCodecs())),
       'bdI2nwA': a0_0x41c694(JSON.stringify(_0x53b35a[1])),
       'cNVHtB2QA2zbSbw': a0_0x41c694(JSON.stringify(_0x53b35a[0])),
       'YdY6oxJYqA': _0x53b35a[2],
@@ -1808,7 +1808,7 @@ try {
   };
   function a0_0x5d8cc5(_0x41764b) {
     let _0x311489 = [];
-    a0_0x2777c2.forEach((_0x110355) => {
+    FINGERPRINT_KEY_ORDER.forEach(_0x110355 => {
       _0x311489.push(_0x41764b[_0x110355]);
       delete _0x41764b[_0x110355];
     });
@@ -1856,7 +1856,7 @@ try {
       _0x3f8c66 = _0x2372db.substr(0, _0x395d2).split('');
       _0x567f94 = parseInt(_0x2372db.substr(_0x395d2 + 1));
     } catch (_0x5db8ca) {
-      _0x3f8c66 = Array.from(Array(100), (_0x1c1082) => String.fromCharCode(32 + Math.random() * 94 | 0));
+      _0x3f8c66 = Array.from(Array(100), _0x1c1082 => String.fromCharCode(32 + Math.random() * 94 | 0));
       _0x567f94 = _0x2ba5c7;
     }
     let _0x23e9cf = _0x3f8c66.join('') + " " + _0x567f94;
@@ -1868,7 +1868,7 @@ try {
       localStorage.setItem("x-vec", _0x23e9cf);
     }
     if (!_0x56cc74) {
-      _0x56cc74 = a0_0x4ab8a9(3);
+      _0x56cc74 = generateRandomString(3);
       localStorage.setItem("x-game", _0x56cc74);
     }
     let _0x527acf = await a0_0x1874d0();
@@ -1876,7 +1876,7 @@ try {
     _0x527acf.depTtw = _0x56cc74;
     _0x527acf["dts-siGT"] = window.btoa(_0x23e9cf);
     _0x527acf.ZA = new Date().getTime() - _0x2ba5c7;
-    async function _0x5e0733() {
+    async function fetchServerTime() {
       return new Promise((_0x390e7f, _0xf91840) => {
         const _0x1da321 = new XMLHttpRequest();
         _0x1da321.onreadystatechange = function () {
@@ -1890,11 +1890,11 @@ try {
             }
           }
         };
-        _0x1da321.open("GET", a0_0x342d81, true);
+        _0x1da321.open("GET", GAME1_URL, true);
         _0x1da321.send();
       });
     }
-    _0x527acf.c9hKwCWX61TBJm_dKn0 = await _0x5e0733();
+    _0x527acf.c9hKwCWX61TBJm_dKn0 = await fetchServerTime();
     _0x527acf.dehNvwBnzDqu = navigator.userAgent;
     _0x527acf.ctdIvSKVCQ = _0x48535f;
     _0x527acf = a0_0x5d8cc5(_0x527acf);

--- a/archived_game1_scripts/2026-07-01T011942/game1.js.deobfuscated.js
+++ b/archived_game1_scripts/2026-07-01T011942/game1.js.deobfuscated.js
@@ -1060,7 +1060,7 @@ try {
     'mry_KacstQurn': false,
     'ori1Uni': false
   });
-  const a0_0x4b1572 = () => {
+  const getAudioFingerprint = () => {
     try {
       const _0x48b7fc = window.OfflineAudioContext || window.webkitOfflineAudioContext;
       if (!_0x48b7fc) {
@@ -1165,7 +1165,7 @@ try {
     _0x5effed.name = _0x183929;
     return _0x5effed;
   }
-  const a0_0x4e6708 = () => {
+  const detectOS = () => {
     try {
       const _0x2b5a87 = [{
         's': "Windows 10",
@@ -1277,7 +1277,7 @@ try {
       };
     }
   };
-  const a0_0x30264b = () => {
+  const detectBrowser = () => {
     try {
       const _0x45702c = navigator.userAgent;
       const _0x10ca82 = [{
@@ -1379,7 +1379,7 @@ try {
       };
     }
   };
-  const a0_0x7c0a6d = () => {
+  const getCanvas2dFingerprint = () => {
     try {
       const _0x410873 = document.createElement("canvas");
       const _0x1e8a58 = _0x410873.getContext('2d');
@@ -1412,7 +1412,7 @@ try {
       return -1;
     }
   };
-  const a0_0x15b107 = () => {
+  const getWebglCanvasFingerprint = () => {
     try {
       const _0xfed1a9 = document.createElement("canvas");
       _0xfed1a9.width = 256;
@@ -1506,7 +1506,7 @@ try {
     }
     return _0x26fabf;
   }();
-  const a0_0x17e3c0 = () => new Promise(async _0x249326 => {
+  const enumerateMediaDevices = () => new Promise(async _0x249326 => {
     let _0x188ac1 = setTimeout(() => _0x249326([]), 200);
     const _0x33794a = await navigator.mediaDevices.enumerateDevices();
     clearTimeout(_0x188ac1);
@@ -1605,7 +1605,7 @@ try {
       return {};
     }
   };
-  const a0_0x1a0c3b = () => {
+  const detectFonts = () => {
     const _0x52997d = document.getElementsByTagName("body")[0];
     const _0x42656c = document.createElement("div");
     let _0x4dd178 = document.createDocumentFragment();
@@ -1682,7 +1682,7 @@ try {
       return [];
     }
   };
-  const a0_0x3b19c7 = () => {
+  const detectAutomation = () => {
     let _0x59f465 = 0;
     try {
       if (navigator.webdriver === true) {
@@ -1776,13 +1776,13 @@ try {
     return new Array(_0x35b012).fill(0).map(() => Math.random().toString(36).substr(2, 9)).reduce((_0x27b1e8, _0x59e099) => _0x27b1e8 + _0x59e099, '');
   };
   const a0_0x385393 = async () => {
-    const _0x242fb1 = await Promise.all([checkPermissions(), a0_0x17e3c0(), a0_0x4b1572()]);
-    const _0x3a3483 = a0_0x30264b();
-    const _0x1f0b0c = a0_0x4e6708();
+    const _0x242fb1 = await Promise.all([checkPermissions(), enumerateMediaDevices(), getAudioFingerprint()]);
+    const _0x3a3483 = detectBrowser();
+    const _0x1f0b0c = detectOS();
     const _0x3668f3 = getWebglInfo();
-    const _0x1d0eda = a0_0x4cca20(JSON.stringify(a0_0x1a0c3b()));
-    const _0x141f60 = a0_0x15b107();
-    const _0x4b575c = a0_0x7c0a6d();
+    const _0x1d0eda = a0_0x4cca20(JSON.stringify(detectFonts()));
+    const _0x141f60 = getWebglCanvasFingerprint();
+    const _0x4b575c = getCanvas2dFingerprint();
     return {
       'dg': 12,
       'dO4': Intl.DateTimeFormat().resolvedOptions().timeZone,
@@ -1808,7 +1808,7 @@ try {
       'YdY6oxJYqA': _0x242fb1[2],
       'd9w-pRFXpw': _0x141f60,
       'Y8QyqAl8whI': _0x4b575c,
-      'YtFF': a0_0x3b19c7()
+      'YtFF': detectAutomation()
     };
   };
   function a0_0x300792(_0x1741a5) {
@@ -1819,7 +1819,7 @@ try {
     });
     return _0x228b43;
   }
-  function a0_0x2aa6eb(_0x506616) {
+  function encodeFingerprintHash(_0x506616) {
     const _0xc9c158 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_=".split('');
     const _0x59b200 = function (_0x4afe94) {
       let _0x4904fd = '';
@@ -1896,7 +1896,7 @@ try {
     _0xc978de.dehNvwBnzDqu = navigator.userAgent;
     _0xc978de.ctdIvSKVCQ = _0x4557cf;
     _0xc978de = a0_0x300792(_0xc978de);
-    let _0x33de64 = a0_0x2aa6eb(JSON.stringify(_0xc978de));
+    let _0x33de64 = encodeFingerprintHash(JSON.stringify(_0xc978de));
     _0x264b23(_0x33de64);
   };
 } catch (e) {

--- a/archived_game1_scripts/2026-07-01T011942/game1.js.deobfuscated.js
+++ b/archived_game1_scripts/2026-07-01T011942/game1.js.deobfuscated.js
@@ -1874,7 +1874,7 @@ try {
     _0xc978de.depTtw = _0x442419;
     _0xc978de['dts-siGT'] = window.btoa(_0x246e57);
     _0xc978de.ZA = new Date().getTime() - _0x92dfe6;
-    async function GAME1_URL() {
+    async function _0x20e0b3() {
       return new Promise((_0x387845, _0x147193) => {
         const _0x398f31 = new XMLHttpRequest();
         _0x398f31.onreadystatechange = function () {
@@ -1892,7 +1892,7 @@ try {
         _0x398f31.send();
       });
     }
-    _0xc978de.c9hKwCWX61TBJm_dKn0 = await GAME1_URL();
+    _0xc978de.c9hKwCWX61TBJm_dKn0 = await _0x20e0b3();
     _0xc978de.dehNvwBnzDqu = navigator.userAgent;
     _0xc978de.ctdIvSKVCQ = _0x4557cf;
     _0xc978de = a0_0x300792(_0xc978de);

--- a/archived_game1_scripts/2026-07-01T011942/game1.js.deobfuscated.js
+++ b/archived_game1_scripts/2026-07-01T011942/game1.js.deobfuscated.js
@@ -14,7 +14,7 @@ try {
       }
     }
   })(a0_0x523b, 625669);
-  const a0_0x53802e = ['dg', "dO4", "b-I2rx-E", "YdFB", "dttJrRyO", "bdI_", "Y9JA", "bM07og", "cNxRuCGPAg", "Z9dM", 'ZtVDtyo', "YdY6oxJV", "d-BEuCA", "aM02nQV5", "dt9DqBc", "YdY6oxI", "bdI2nwA", "cNVHtB2QA2zbSbw", 'YdY6oxJYqA', 'd9w-pRFXpw', "Y8QyqAl8whI", "Y9U6mw9451U", 'depTtw', 'ZA', "b-I4nQ-C61rI", "dts-siGT", "dehNvwBnzDqu", "c9hKwCWX61TBJm_dKn0", 'ctdIvSKVCQ', 'YtFF'];
+  const FINGERPRINT_KEY_ORDER = ['dg', "dO4", "b-I2rx-E", "YdFB", "dttJrRyO", "bdI_", "Y9JA", "bM07og", "cNxRuCGPAg", "Z9dM", 'ZtVDtyo', "YdY6oxJV", "d-BEuCA", "aM02nQV5", "dt9DqBc", "YdY6oxI", "bdI2nwA", "cNVHtB2QA2zbSbw", 'YdY6oxJYqA', 'd9w-pRFXpw', "Y8QyqAl8whI", "Y9U6mw9451U", 'depTtw', 'ZA', "b-I4nQ-C61rI", "dts-siGT", "dehNvwBnzDqu", "c9hKwCWX61TBJm_dKn0", 'ctdIvSKVCQ', 'YtFF'];
   const a0_0x5dea54 = Object.keys({
     ".Aqua Kana": false,
     ".Helvetica LT MM": false,
@@ -1080,7 +1080,7 @@ try {
       _0x1f4c63.connect(_0x35fafa.destination);
       _0x58df28.start(0);
       const [_0x388314, _0x421ffd] = a0_0x3add33(_0x35fafa);
-      const _0x4144ca = _0x388314.then((_0x337404) => a0_0x333f43(_0x337404.getChannelData(0).subarray(4500)), (_0x3a819b) => {
+      const _0x4144ca = _0x388314.then(_0x337404 => a0_0x333f43(_0x337404.getChannelData(0).subarray(4500)), _0x3a819b => {
         if (_0x3a819b.name === 'timeout' || _0x3a819b.name === "suspended") {
           return 'timeout';
         }
@@ -1101,11 +1101,11 @@ try {
   }
   function a0_0x3add33(_0x314c6c) {
     let _0xfe561 = () => undefined;
-    const _0x376a77 = new Promise((_0x3e460e, _0x29fdd5) => {
+    const renderAudioPromise = new Promise((_0x3e460e, _0x29fdd5) => {
       let _0x5a0037 = false;
       let _0x20c801 = 0;
       let _0x14f32c = 0;
-      _0x314c6c.oncomplete = (_0x38a4a5) => _0x3e460e(_0x38a4a5.renderedBuffer);
+      _0x314c6c.oncomplete = _0x38a4a5 => _0x3e460e(_0x38a4a5.renderedBuffer);
       const _0x11a72d = () => {
         setTimeout(() => _0x29fdd5(a0_0xa64da6("timeout")), Math.min(500, _0x14f32c + 5000 - Date.now()));
       };
@@ -1144,7 +1144,7 @@ try {
         }
       };
     });
-    return [_0x376a77, _0xfe561];
+    return [renderAudioPromise, _0xfe561];
   }
   function a0_0x333f43(_0x52d5fe) {
     let _0x33672c = 0;
@@ -1250,7 +1250,7 @@ try {
         'r': /(nuhk|Googlebot|Yammybot|Openbot|Slurp|MSNBot|Ask Jeeves\/Teoma|ia_archiver)/
       }];
       let _0x431bc9;
-      let _0x3aae3b = _0x2b5a87.filter((_0x2f445b) => _0x2f445b.r.test(navigator.userAgent))[0].s;
+      let _0x3aae3b = _0x2b5a87.filter(_0x2f445b => _0x2f445b.r.test(navigator.userAgent))[0].s;
       if (/Windows/.test(_0x3aae3b)) {
         _0x431bc9 = /Windows (.*)/.exec(_0x3aae3b)[1];
         _0x3aae3b = "Windows";
@@ -1282,7 +1282,7 @@ try {
       const _0x45702c = navigator.userAgent;
       const _0x10ca82 = [{
         'name': 'Opera',
-        'getInfo': (_0x1abfa9) => {
+        'getInfo': _0x1abfa9 => {
           if (_0x45702c.indexOf("Version") !== -1) {
             return {
               'name': "Opera",
@@ -1296,7 +1296,7 @@ try {
         }
       }, {
         'name': "OPR",
-        'getInfo': (_0x57924d) => {
+        'getInfo': _0x57924d => {
           return {
             'name': "Opera",
             'version': _0x45702c.substring(_0x57924d + 4)
@@ -1304,7 +1304,7 @@ try {
         }
       }, {
         'name': "Edge",
-        'getInfo': (_0x377b51) => {
+        'getInfo': _0x377b51 => {
           return {
             'name': 'Edge',
             'version': _0x45702c.substring(_0x377b51 + 5)
@@ -1312,7 +1312,7 @@ try {
         }
       }, {
         'name': "Edg",
-        'getInfo': (_0x18d6cd) => {
+        'getInfo': _0x18d6cd => {
           return {
             'name': 'Edge',
             'version': _0x45702c.substring(_0x18d6cd + 4)
@@ -1320,7 +1320,7 @@ try {
         }
       }, {
         'name': "MSIE",
-        'getInfo': (_0x4e1e1c) => {
+        'getInfo': _0x4e1e1c => {
           return {
             'name': "Internet Explorer",
             'version': _0x45702c.substring(_0x4e1e1c + 5)
@@ -1328,7 +1328,7 @@ try {
         }
       }, {
         'name': 'Chrome',
-        'getInfo': (_0x50885f) => {
+        'getInfo': _0x50885f => {
           return {
             'name': "Chrome",
             'version': _0x45702c.substring(_0x50885f + 7)
@@ -1336,7 +1336,7 @@ try {
         }
       }, {
         'name': "Safari",
-        'getInfo': (_0xe241b2) => {
+        'getInfo': _0xe241b2 => {
           const _0x59634 = _0x45702c.indexOf('Version');
           if (_0x59634 !== -1) {
             return {
@@ -1351,7 +1351,7 @@ try {
         }
       }, {
         'name': "Firefox",
-        'getInfo': (_0x33e875) => {
+        'getInfo': _0x33e875 => {
           return {
             'name': "Firefox",
             'version': _0x45702c.substring(_0x33e875 + 8)
@@ -1506,25 +1506,25 @@ try {
     }
     return _0x26fabf;
   }();
-  const a0_0x17e3c0 = () => new Promise(async (_0x249326) => {
+  const a0_0x17e3c0 = () => new Promise(async _0x249326 => {
     let _0x188ac1 = setTimeout(() => _0x249326([]), 200);
     const _0x33794a = await navigator.mediaDevices.enumerateDevices();
     clearTimeout(_0x188ac1);
-    let _0x54cb45 = _0x33794a.map((_0x1ef15c) => _0x1ef15c.kind).sort();
+    let _0x54cb45 = _0x33794a.map(_0x1ef15c => _0x1ef15c.kind).sort();
     _0x249326(_0x54cb45);
-  })["catch"]((_0x5db521) => []);
-  const a0_0x2a1bb9 = () => {
+  })["catch"](_0x5db521 => []);
+  const detectAudioCodecs = () => {
     const _0x2ddbe7 = ["audio/aac", "audio/flac", "audio/mpeg", "audio/mp4; codecs=\"mp4a.40.2\"", "audio/ogg; codecs=\"flac\"", "audio/ogg; codecs=\"vorbis\"", "audio/ogg; codecs=\"opus\"", "audio/wav; codecs=\"1\"", "audio/webm; codecs=\"vorbis\"", "audio/webm; codecs=\"opus\""];
     try {
       const _0x1dd4d3 = document.createElement("audio");
-      return _0x2ddbe7.map((_0x4e2f0c) => {
+      return _0x2ddbe7.map(_0x4e2f0c => {
         return {
           'type': _0x4e2f0c,
           'canPlay': _0x1dd4d3.canPlayType(_0x4e2f0c)
         };
       });
     } catch (_0x384817) {
-      return _0x2ddbe7.map((_0x469d20) => {
+      return _0x2ddbe7.map(_0x469d20 => {
         return {
           'type': _0x469d20,
           'canPlay': "no info"
@@ -1532,18 +1532,18 @@ try {
       });
     }
   };
-  const a0_0x43e953 = () => {
+  const detectVideoCodecs = () => {
     const _0x4ae132 = ["video/ogg; codecs=\"theora\"", "video/ogg; codecs=\"opus\"", "video/mp4; codecs=\"avc1.42E01E\"", "video/mp4; codecs=\"flac\"", "video/webm; codecs=\"vp8, vorbis\"", "video/webm; codecs=\"vp9\"", "application/x-mpegURL; codecs=\"avc1.42E01E\""];
     try {
       const _0x54d647 = document.createElement("video");
-      return _0x4ae132.map((_0x160c8b) => {
+      return _0x4ae132.map(_0x160c8b => {
         return {
           'type': _0x160c8b,
           'canPlay': _0x54d647.canPlayType(_0x160c8b)
         };
       });
     } catch (_0x256174) {
-      return _0x4ae132.map((_0x179c7b) => {
+      return _0x4ae132.map(_0x179c7b => {
         return {
           'type': _0x179c7b,
           'canPlay': "no info"
@@ -1551,11 +1551,11 @@ try {
       });
     }
   };
-  const a0_0x442d1e = async () => {
+  const checkPermissions = async () => {
     try {
       const _0x6ba7d = ["accelerometer", "camera", "clipboard-read", "clipboard-write", "geolocation", "background-sync", "magnetometer", "microphone", "midi", "notifications", 'payment-handler', 'persistent-storage'];
       const _0x52e12e = {};
-      await Promise.all(_0x6ba7d.map(async (_0x25cdc4) => {
+      await Promise.all(_0x6ba7d.map(async _0x25cdc4 => {
         try {
           const {
             state: _0x1d756d
@@ -1570,7 +1570,7 @@ try {
       return {};
     }
   };
-  const a0_0xf57689 = () => {
+  const getWebglInfo = () => {
     try {
       const _0x3128fb = document.createElement("canvas");
       const _0x55d1b7 = _0x3128fb.getContext("webgl") || _0x3128fb.getContext("experimental-webgl");
@@ -1588,7 +1588,7 @@ try {
       };
     }
   };
-  const a0_0x4a5c36 = () => {
+  const getAudioContextProps = () => {
     try {
       const _0x4f2845 = new AudioContext();
       return {
@@ -1630,8 +1630,8 @@ try {
       _0x414fef.classList.add('fp-check-runtime-0.0.1');
       _0x4dd178.appendChild(_0x414fef);
     });
-    a0_0x5dea54.forEach((_0x41683f) => {
-      _0x5e3149.forEach((_0x3cd2f9) => {
+    a0_0x5dea54.forEach(_0x41683f => {
+      _0x5e3149.forEach(_0x3cd2f9 => {
         const _0xbc6861 = document.createElement("span");
         _0xbc6861.style.fontSize = "72px";
         _0xbc6861.innerHTML = "mmmmmmmmmmlli";
@@ -1671,7 +1671,7 @@ try {
     document.getElementById(_0xfd241c).remove();
     return _0x57088d;
   };
-  const a0_0xb71442 = () => {
+  const getBrowserPlugins = () => {
     try {
       const _0x42ff32 = [];
       for (let _0x131988 = 0; _0x131988 < navigator.plugins.length; _0x131988++) {
@@ -1772,14 +1772,14 @@ try {
     }
     return _0x59f465;
   };
-  const a0_0x4c1453 = (_0x35b012) => {
+  const generateRandomString = _0x35b012 => {
     return new Array(_0x35b012).fill(0).map(() => Math.random().toString(36).substr(2, 9)).reduce((_0x27b1e8, _0x59e099) => _0x27b1e8 + _0x59e099, '');
   };
   const a0_0x385393 = async () => {
-    const _0x242fb1 = await Promise.all([a0_0x442d1e(), a0_0x17e3c0(), a0_0x4b1572()]);
+    const _0x242fb1 = await Promise.all([checkPermissions(), a0_0x17e3c0(), a0_0x4b1572()]);
     const _0x3a3483 = a0_0x30264b();
     const _0x1f0b0c = a0_0x4e6708();
-    const _0x3668f3 = a0_0xf57689();
+    const _0x3668f3 = getWebglInfo();
     const _0x1d0eda = a0_0x4cca20(JSON.stringify(a0_0x1a0c3b()));
     const _0x141f60 = a0_0x15b107();
     const _0x4b575c = a0_0x7c0a6d();
@@ -1792,17 +1792,17 @@ try {
       'bdI_': navigator.deviceMemory || 0,
       'Y9JA': navigator.hardwareConcurrency || 0,
       'bM07og': navigator.languages.join(','),
-      'cNxRuCGPAg': a0_0x4cca20(JSON.stringify(a0_0xb71442())),
+      'cNxRuCGPAg': a0_0x4cca20(JSON.stringify(getBrowserPlugins())),
       'Z9dM': _0x3668f3.vendor + ',' + _0x3668f3.renderer,
       'ZtVDtyo': _0x1d0eda,
-      'YdY6oxJV': a0_0x4cca20(JSON.stringify(a0_0x4a5c36())),
+      'YdY6oxJV': a0_0x4cca20(JSON.stringify(getAudioContextProps())),
       'b-I4nQ-C61rI': _0x1f0b0c.version,
       'd-BEuCA': window.screen.availWidth,
       'aM02nQV5': window.screen.availHeight,
       'bL8zohR5': Boolean(localStorage),
       'c8Y6qRuA': Boolean(sessionStorage),
-      'dt9DqBc': a0_0x4cca20(JSON.stringify(a0_0x43e953())),
-      'YdY6oxI': a0_0x4cca20(JSON.stringify(a0_0x2a1bb9())),
+      'dt9DqBc': a0_0x4cca20(JSON.stringify(detectVideoCodecs())),
+      'YdY6oxI': a0_0x4cca20(JSON.stringify(detectAudioCodecs())),
       'bdI2nwA': a0_0x4cca20(JSON.stringify(_0x242fb1[1])),
       'cNVHtB2QA2zbSbw': a0_0x4cca20(JSON.stringify(_0x242fb1[0])),
       'YdY6oxJYqA': _0x242fb1[2],
@@ -1813,7 +1813,7 @@ try {
   };
   function a0_0x300792(_0x1741a5) {
     let _0x228b43 = [];
-    a0_0x53802e.forEach((_0x152215) => {
+    FINGERPRINT_KEY_ORDER.forEach(_0x152215 => {
       _0x228b43.push(_0x1741a5[_0x152215]);
       delete _0x1741a5[_0x152215];
     });
@@ -1854,7 +1854,7 @@ try {
       _0xbf6dc4 = _0x3166b4.substr(0, _0x1091a8).split('');
       _0x55cb6f = parseInt(_0x3166b4.substr(_0x1091a8 + 1));
     } catch (_0x2d031e) {
-      _0xbf6dc4 = Array.from(Array(100), (_0x594a33) => String.fromCharCode(32 + Math.random() * 94 | 0));
+      _0xbf6dc4 = Array.from(Array(100), _0x594a33 => String.fromCharCode(32 + Math.random() * 94 | 0));
       _0x55cb6f = _0x92dfe6;
     }
     let _0x246e57 = _0xbf6dc4.join('') + " " + _0x55cb6f;
@@ -1866,7 +1866,7 @@ try {
       localStorage.setItem("x-vec", _0x246e57);
     }
     if (!_0x442419) {
-      _0x442419 = a0_0x4c1453(3);
+      _0x442419 = generateRandomString(3);
       localStorage.setItem("x-game", _0x442419);
     }
     let _0xc978de = await a0_0x385393();
@@ -1874,7 +1874,7 @@ try {
     _0xc978de.depTtw = _0x442419;
     _0xc978de['dts-siGT'] = window.btoa(_0x246e57);
     _0xc978de.ZA = new Date().getTime() - _0x92dfe6;
-    async function _0x20e0b3() {
+    async function GAME1_URL() {
       return new Promise((_0x387845, _0x147193) => {
         const _0x398f31 = new XMLHttpRequest();
         _0x398f31.onreadystatechange = function () {
@@ -1892,7 +1892,7 @@ try {
         _0x398f31.send();
       });
     }
-    _0xc978de.c9hKwCWX61TBJm_dKn0 = await _0x20e0b3();
+    _0xc978de.c9hKwCWX61TBJm_dKn0 = await GAME1_URL();
     _0xc978de.dehNvwBnzDqu = navigator.userAgent;
     _0xc978de.ctdIvSKVCQ = _0x4557cf;
     _0xc978de = a0_0x300792(_0xc978de);

--- a/deobfuscate-all.sh
+++ b/deobfuscate-all.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$ROOT/deobfuscator"
+
+npx tsc
+
+find "$ROOT/archived_game1_scripts" -name 'game1.js' ! -name '*.deobfuscated.js' -print0 | sort -z | while IFS= read -r -d '' f; do
+  echo "==> $f"
+  node dist/index.js deobfuscate "$f" "${f}.deobfuscated.js"
+done

--- a/deobfuscator/package-lock.json
+++ b/deobfuscator/package-lock.json
@@ -21,6 +21,8 @@
       },
       "devDependencies": {
         "@types/babel__core": "^7.20.5",
+        "@types/babel__generator": "^7.27.0",
+        "@types/babel__parser": "^7.0.0",
         "@types/babel__traverse": "^7.28.0",
         "@types/node": "^25.5.2",
         "playwright": "^1.62.0",
@@ -695,6 +697,16 @@
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__parser": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__parser/-/babel__parser-7.0.0.tgz",
+      "integrity": "sha512-eJt+CTd/WlS5NHyhXo0WMY3eRS3DRXpe1y/oo9aZUFKLbDkl+R85+GeMDZynWcSbs/iZfzdLFERUF0W3K5TkYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0-beta.54"
       }
     },
     "node_modules/@types/babel__template": {

--- a/deobfuscator/package.json
+++ b/deobfuscator/package.json
@@ -31,6 +31,8 @@
   },
   "devDependencies": {
     "@types/babel__core": "^7.20.5",
+    "@types/babel__generator": "^7.27.0",
+    "@types/babel__parser": "^7.0.0",
     "@types/babel__traverse": "^7.28.0",
     "@types/node": "^25.5.2",
     "playwright": "^1.62.0",

--- a/deobfuscator/src/cli.ts
+++ b/deobfuscator/src/cli.ts
@@ -4,6 +4,8 @@ import { unwrapEval } from './steps/unwrap-eval.js';
 import { deobfuscateObfuscatorIo } from './steps/obfuscator-io.js';
 import { evaluateConstantMath } from './steps/evaluate-constant-math.js';
 import { evaluateParseInt } from './steps/evaluate-parseint.js';
+import { renameIdentifiers } from './steps/rename-identifiers.js';
+import { defaultRenameRules } from './rename-rules.js';
 import { runAllSteps } from './pipeline.js';
 
 export const program = new Command();
@@ -112,6 +114,23 @@ program
       evaluateConstantMath,
       (stats) => {
         console.log(`  Constant expressions evaluated: ${stats.expressionsEvaluated}`);
+      }
+    );
+  });
+
+program
+  .command('rename-identifiers')
+  .description('Rename variables/functions by keyword-matched rules')
+  .argument('<input>', 'Input file path')
+  .argument('[output]', 'Output file path (default: <input>.renamed.js)')
+  .action((input: string, output?: string) => {
+    runSingleCommand(
+      input,
+      output,
+      '.renamed.js',
+      (code) => renameIdentifiers(code, defaultRenameRules),
+      (stats) => {
+        console.log(`  Identifiers renamed: ${stats.renamesApplied}`);
       }
     );
   });

--- a/deobfuscator/src/pipeline.ts
+++ b/deobfuscator/src/pipeline.ts
@@ -5,6 +5,8 @@ import { convertHexLiterals } from "./steps/convert-hex-literals.js";
 import { inlineStringDecoder } from "./steps/inline-string-decoder.js";
 import { evaluateConstantMath } from "./steps/evaluate-constant-math.js";
 import { simplifyPropertyAccess } from "./steps/simplify-property-access.js";
+import { renameIdentifiers } from "./steps/rename-identifiers.js";
+import { defaultRenameRules } from "./rename-rules.js";
 
 export function runStep<T extends object>(
     stepName: string,
@@ -57,6 +59,10 @@ export function runAllSteps(code: string): string {
 
     code = runStep('Step 7: Simplify Property Access', simplifyPropertyAccess, code, (stats) => {
         console.log(`  Converted ${stats.convertedToDot}/${stats.totalBracketAccesses} bracket accesses to dot notation`);
+    });
+
+    code = runStep('Step 8: Rename Identifiers', (c) => renameIdentifiers(c, defaultRenameRules), code, (stats) => {
+        console.log(`  Renamed ${stats.renamesApplied} identifiers`);
     });
 
     return code;

--- a/deobfuscator/src/rename-rules.ts
+++ b/deobfuscator/src/rename-rules.ts
@@ -21,6 +21,6 @@ export const defaultRenameRules: RenameRule[] = [
   { name: 'generateRandomString', keywords: ['Math.random', 'toString(36)', 'substr'] },
   // { name: 'orderFingerprintKeys', keywords: ['forEach', 'delete'], optional: true }, // too generic — forEach and delete are everywhere
   { name: 'encodeFingerprintHash', keywords: ['encodeURIComponent', 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_='] },
-  { name: 'GAME1_URL', keywords: ['gameforge.com', 'game1.js'], optional: true },
+  { name: 'GAME1_URL', keywords: ['gameforge.com', 'game1.js'], optional: true, canBeOverwritten: true },
   { name: 'FINGERPRINT_KEY_ORDER', keywords: ['dg', 'dO4', 'b-I2rx-E', 'YdFB', 'YtFF'], optional: true },
 ];

--- a/deobfuscator/src/rename-rules.ts
+++ b/deobfuscator/src/rename-rules.ts
@@ -1,7 +1,7 @@
 import type { RenameRule } from "./steps/rename-identifiers.js";
 
 export const defaultRenameRules: RenameRule[] = [
-  { name: 'fetchServerTime', keywords: ['XMLHttpRequest', 'getResponseHeader'] },
+  { name: 'fetchServerTime', keywords: ['XMLHttpRequest', 'getResponseHeader'], canBeOverwritten: true },
   { name: 'getAudioFingerprint', keywords: ['OfflineAudioContext', 'createDynamicsCompressor'] },
   { name: 'renderAudioPromise', keywords: ['startRendering', 'oncomplete'] },
   // { name: 'sumAudioChannelData', keywords: ['Math.abs'] }, // too generic — Math.abs appears in many functions
@@ -21,6 +21,6 @@ export const defaultRenameRules: RenameRule[] = [
   { name: 'generateRandomString', keywords: ['Math.random', 'toString(36)', 'substr'] },
   // { name: 'orderFingerprintKeys', keywords: ['forEach', 'delete'], optional: true }, // too generic — forEach and delete are everywhere
   { name: 'encodeFingerprintHash', keywords: ['encodeURIComponent', 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_='] },
-  { name: 'GAME1_URL', keywords: ['gameforge.com', 'game1.js'], optional: true, canBeOverwritten: true },
+  { name: 'GAME1_URL', keywords: ['gameforge.com', 'game1.js'], optional: true },
   { name: 'FINGERPRINT_KEY_ORDER', keywords: ['dg', 'dO4', 'b-I2rx-E', 'YdFB', 'YtFF'], optional: true },
 ];

--- a/deobfuscator/src/rename-rules.ts
+++ b/deobfuscator/src/rename-rules.ts
@@ -1,7 +1,7 @@
 import type { RenameRule } from "./steps/rename-identifiers.js";
 
 export const defaultRenameRules: RenameRule[] = [
-  { name: 'fetchServerTime', keywords: ['XMLHttpRequest', 'getResponseHeader'], canBeOverwritten: true },
+  { name: 'fetchServerTime', keywords: ['XMLHttpRequest', 'getResponseHeader'], allowOverwrite: true },
   { name: 'getAudioFingerprint', keywords: ['OfflineAudioContext', 'createDynamicsCompressor'] },
   { name: 'renderAudioPromise', keywords: ['startRendering', 'oncomplete'] },
   // { name: 'sumAudioChannelData', keywords: ['Math.abs'] }, // too generic — Math.abs appears in many functions

--- a/deobfuscator/src/rename-rules.ts
+++ b/deobfuscator/src/rename-rules.ts
@@ -1,0 +1,26 @@
+import type { RenameRule } from "./steps/rename-identifiers.js";
+
+export const defaultRenameRules: RenameRule[] = [
+  { name: 'fetchServerTime', keywords: ['XMLHttpRequest', 'getResponseHeader'] },
+  { name: 'getAudioFingerprint', keywords: ['OfflineAudioContext', 'createDynamicsCompressor'] },
+  { name: 'renderAudioPromise', keywords: ['startRendering', 'oncomplete'] },
+  { name: 'sumAudioChannelData', keywords: ['Math.abs'] },
+  { name: 'getWebglCanvasFingerprint', keywords: ['VERTEX_SHADER', 'FRAGMENT_SHADER', 'drawArrays', 'readPixels'] },
+  { name: 'getCanvas2dFingerprint', keywords: ['toDataURL', 'fillText', 'shadowBlur'] },
+  { name: 'detectFonts', keywords: ['offsetWidth', 'offsetHeight', 'fontFamily', 'monospace'] },
+  { name: 'detectAutomation', keywords: ['navigator.webdriver', '$cdc_', '__playwright'], optional: true },
+  { name: 'detectOS', keywords: ['navigator.userAgent', 'Windows', 'Linux', 'Android', 'iOS'] },
+  { name: 'detectBrowser', keywords: ['navigator.userAgent', 'Chrome', 'Firefox', 'Safari', 'Opera'] },
+  { name: 'getWebglInfo', keywords: ['WEBGL_debug_renderer_info', 'UNMASKED_VENDOR_WEBGL', 'UNMASKED_RENDERER_WEBGL'] },
+  { name: 'getAudioContextProps', keywords: ['new AudioContext', 'sampleRate', 'channelCount'] },
+  { name: 'enumerateMediaDevices', keywords: ['enumerateDevices', 'mediaDevices', 'kind'], optional: true },
+  { name: 'getBrowserPlugins', keywords: ['navigator.plugins', '.name'] },
+  { name: 'detectVideoCodecs', keywords: ['canPlayType', "video/webm", "video/ogg"] },
+  { name: 'detectAudioCodecs', keywords: ['canPlayType', "audio/ogg", "audio/webm"] },
+  { name: 'checkPermissions', keywords: ['permissions.query', 'accelerometer', 'camera'] },
+  { name: 'generateRandomString', keywords: ['Math.random', 'toString(36)', 'substr'] },
+  { name: 'orderFingerprintKeys', keywords: ['forEach', 'delete'], optional: true },
+  { name: 'encodeFingerprintHash', keywords: ['encodeURIComponent', 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_='] },
+  { name: 'GAME1_URL', keywords: ['gameforge.com', 'game1.js'], optional: true },
+  { name: 'FINGERPRINT_KEY_ORDER', keywords: ['dg', 'dO4', 'b-I2rx-E', 'YdFB', 'YtFF'], optional: true },
+];

--- a/deobfuscator/src/rename-rules.ts
+++ b/deobfuscator/src/rename-rules.ts
@@ -1,7 +1,10 @@
 import type { RenameRule } from "./steps/rename-identifiers.js";
 
 export const defaultRenameRules: RenameRule[] = [
-  { name: 'fetchServerTime', keywords: ['XMLHttpRequest', 'getResponseHeader'], allowOverwrite: true },
+  { name: 'FINGERPRINT_KEY_ORDER', keywords: ['dg', 'dO4', 'b-I2rx-E', 'YdFB', 'YtFF'], optional: true },
+  { name: 'GAME1_URL', keywords: ['"https://gameforge.com/tra/game1.js";'], optional: true },
+
+  // { name: 'fetchServerTime', keywords: ['XMLHttpRequest', 'getResponseHeader'], allowOverwrite: true },
   { name: 'getAudioFingerprint', keywords: ['OfflineAudioContext', 'createDynamicsCompressor'] },
   { name: 'renderAudioPromise', keywords: ['startRendering', 'oncomplete'] },
   // { name: 'sumAudioChannelData', keywords: ['Math.abs'] }, // too generic — Math.abs appears in many functions
@@ -21,6 +24,4 @@ export const defaultRenameRules: RenameRule[] = [
   { name: 'generateRandomString', keywords: ['Math.random', 'toString(36)', 'substr'] },
   // { name: 'orderFingerprintKeys', keywords: ['forEach', 'delete'], optional: true }, // too generic — forEach and delete are everywhere
   { name: 'encodeFingerprintHash', keywords: ['encodeURIComponent', 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_='] },
-  { name: 'GAME1_URL', keywords: ['gameforge.com', 'game1.js'], optional: true },
-  { name: 'FINGERPRINT_KEY_ORDER', keywords: ['dg', 'dO4', 'b-I2rx-E', 'YdFB', 'YtFF'], optional: true },
 ];

--- a/deobfuscator/src/rename-rules.ts
+++ b/deobfuscator/src/rename-rules.ts
@@ -4,7 +4,7 @@ export const defaultRenameRules: RenameRule[] = [
   { name: 'fetchServerTime', keywords: ['XMLHttpRequest', 'getResponseHeader'] },
   { name: 'getAudioFingerprint', keywords: ['OfflineAudioContext', 'createDynamicsCompressor'] },
   { name: 'renderAudioPromise', keywords: ['startRendering', 'oncomplete'] },
-  { name: 'sumAudioChannelData', keywords: ['Math.abs'] },
+  // { name: 'sumAudioChannelData', keywords: ['Math.abs'] }, // too generic — Math.abs appears in many functions
   { name: 'getWebglCanvasFingerprint', keywords: ['VERTEX_SHADER', 'FRAGMENT_SHADER', 'drawArrays', 'readPixels'] },
   { name: 'getCanvas2dFingerprint', keywords: ['toDataURL', 'fillText', 'shadowBlur'] },
   { name: 'detectFonts', keywords: ['offsetWidth', 'offsetHeight', 'fontFamily', 'monospace'] },
@@ -19,7 +19,7 @@ export const defaultRenameRules: RenameRule[] = [
   { name: 'detectAudioCodecs', keywords: ['canPlayType', "audio/ogg", "audio/webm"] },
   { name: 'checkPermissions', keywords: ['permissions.query', 'accelerometer', 'camera'] },
   { name: 'generateRandomString', keywords: ['Math.random', 'toString(36)', 'substr'] },
-  { name: 'orderFingerprintKeys', keywords: ['forEach', 'delete'], optional: true },
+  // { name: 'orderFingerprintKeys', keywords: ['forEach', 'delete'], optional: true }, // too generic — forEach and delete are everywhere
   { name: 'encodeFingerprintHash', keywords: ['encodeURIComponent', 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_='] },
   { name: 'GAME1_URL', keywords: ['gameforge.com', 'game1.js'], optional: true },
   { name: 'FINGERPRINT_KEY_ORDER', keywords: ['dg', 'dO4', 'b-I2rx-E', 'YdFB', 'YtFF'], optional: true },

--- a/deobfuscator/src/steps/rename-identifiers.ts
+++ b/deobfuscator/src/steps/rename-identifiers.ts
@@ -10,7 +10,7 @@ export interface RenameRule {
   name: string;
   keywords: string[];
   optional?: boolean;
-  canBeOverwritten?: boolean;
+  allowOverwrite?: boolean;
 }
 
 export interface RenameIdentifiersResult {
@@ -53,6 +53,22 @@ function isStringArrayFunctionBody(bodyNode: any): boolean {
   return decl.init.elements.length > 50;
 }
 
+function tryCheckCandidate(
+  rule: RenameRule,
+  candidates: Array<{ oldName: string; scope: any; path: any }>,
+  name: string,
+  generateSource: () => string,
+  scope: any,
+  path: any
+): void {
+  try {
+    const source = generateSource();
+    if (rule.keywords.every((kw: string) => source.includes(kw))) {
+      candidates.push({ oldName: name, scope, path });
+    }
+  } catch { /* skip */ }
+}
+
 export function renameIdentifiers(
   code: string,
   rules?: RenameRule[]
@@ -81,12 +97,7 @@ export function renameIdentifiers(
           const name = path.node.id?.name;
           if (!name) return;
           if (isStringArrayFunctionBody(path.node.body)) return;
-          try {
-            const bodyCode = generate(path.node.body).code;
-            if (rule.keywords.every((kw: string) => bodyCode.includes(kw))) {
-              candidates.push({ oldName: name, scope: path.scope, path });
-            }
-          } catch { /* skip */ }
+          tryCheckCandidate(rule, candidates, name, () => generate(path.node.body).code, path.scope, path);
         },
         VariableDeclarator(path: any) {
           const name = (path.node.id as any)?.name;
@@ -94,20 +105,10 @@ export function renameIdentifiers(
           if (t.isFunctionExpression(path.node.init) || t.isArrowFunctionExpression(path.node.init)) {
             const body = path.node.init.body;
             if (isStringArrayFunctionBody(body)) return;
-            try {
-              const bodyCode = generate(body).code;
-              if (rule.keywords.every((kw: string) => bodyCode.includes(kw))) {
-                candidates.push({ oldName: name, scope: path.scope, path });
-              }
-            } catch { /* skip */ }
+            tryCheckCandidate(rule, candidates, name, () => generate(body).code, path.scope, path);
           } else {
             if (isLargeArray(path.node.init)) return;
-            try {
-              const declCode = generate(path.node).code;
-              if (rule.keywords.every((kw: string) => declCode.includes(kw))) {
-                candidates.push({ oldName: name, scope: path.scope, path });
-              }
-            } catch { /* skip */ }
+            tryCheckCandidate(rule, candidates, name, () => generate(path.node).code, path.scope, path);
           }
         },
       });
@@ -168,7 +169,7 @@ export function renameIdentifiers(
         }
         usedTargetNames.delete(oldName);
         scope.rename(oldName, rule.name);
-        usedTargetNames.set(rule.name, rule.canBeOverwritten === true);
+        usedTargetNames.set(rule.name, rule.allowOverwrite === true);
         totalRenames++;
       }
     }

--- a/deobfuscator/src/steps/rename-identifiers.ts
+++ b/deobfuscator/src/steps/rename-identifiers.ts
@@ -1,10 +1,14 @@
 import { parse } from "@babel/parser";
 import _traverse from "@babel/traverse";
+import type { NodePath, Scope } from "@babel/traverse";
 import _generate from "@babel/generator";
+import type { GeneratorResult } from "@babel/generator";
 import * as t from "@babel/types";
 
-const traverse = (_traverse as any).default || _traverse;
-const generate = (_generate as any).default || _generate;
+const traverse: (parent: t.Node, opts?: any, scope?: any, state?: any, parentPath?: any) => void =
+  (_traverse as any).default || _traverse;
+const generate: (node: t.Node, opts?: any) => GeneratorResult =
+  (_generate as any).default || _generate;
 
 export interface RenameRule {
   name: string;
@@ -40,11 +44,11 @@ export function validateRules(rules: RenameRule[]): void {
   }
 }
 
-function isLargeArray(init: any): boolean {
+function isLargeArray(init: t.Expression | null | undefined): boolean {
   return t.isArrayExpression(init) && init.elements.length > 50;
 }
 
-function isStringArrayFunctionBody(bodyNode: any): boolean {
+function isStringArrayFunctionBody(bodyNode: t.Node): boolean {
   if (!t.isBlockStatement(bodyNode)) return false;
   const firstStmt = bodyNode.body[0];
   if (!t.isVariableDeclaration(firstStmt)) return false;
@@ -55,11 +59,11 @@ function isStringArrayFunctionBody(bodyNode: any): boolean {
 
 function checkCandidate(
   rule: RenameRule,
-  candidates: Array<{ oldName: string; scope: any; path: any }>,
+  candidates: Array<{ oldName: string; scope: Scope; path: NodePath }>,
   name: string,
   generateSource: () => string,
-  scope: any,
-  path: any
+  scope: Scope,
+  path: NodePath
 ): void {
   const source = generateSource();
   if (rule.keywords.every((kw: string) => source.includes(kw))) {
@@ -88,17 +92,17 @@ export function renameIdentifiers(
     const usedTargetNames = new Map<string, boolean>();
 
     for (const rule of activeRules) {
-      const candidates: Array<{ oldName: string; scope: any; path: any }> = [];
+      const candidates: Array<{ oldName: string; scope: Scope; path: NodePath }> = [];
 
       traverse(ast, {
-        FunctionDeclaration(path: any) {
+        FunctionDeclaration(path: NodePath<t.FunctionDeclaration>) {
           const name = path.node.id?.name;
           if (!name) return;
           if (isStringArrayFunctionBody(path.node.body)) return;
           checkCandidate(rule, candidates, name, () => generate(path.node.body).code, path.scope, path);
         },
-        VariableDeclarator(path: any) {
-          const name = (path.node.id as any)?.name;
+        VariableDeclarator(path: NodePath<t.VariableDeclarator>) {
+          const name = (path.node.id as t.Identifier)?.name;
           if (!name) return;
           if (t.isFunctionExpression(path.node.init) || t.isArrowFunctionExpression(path.node.init)) {
             const body = path.node.init.body;

--- a/deobfuscator/src/steps/rename-identifiers.ts
+++ b/deobfuscator/src/steps/rename-identifiers.ts
@@ -71,7 +71,7 @@ export function renameIdentifiers(
     });
 
     let totalRenames = 0;
-    const usedTargetNames = new Set<string>();
+    const usedTargetNames = new Map<string, boolean>();
 
     for (const rule of activeRules) {
       const candidates: Array<{ oldName: string; scope: any; path: any }> = [];
@@ -151,14 +151,13 @@ export function renameIdentifiers(
       if (candidates.length === 1) {
         const { oldName, scope } = candidates[0];
         if (usedTargetNames.has(oldName)) {
-          if (rule.canBeOverwritten) {
-            continue;
+          if (!usedTargetNames.get(oldName)) {
+            return {
+              code,
+              success: false,
+              error: `Rule "${rule.name}" matched "${oldName}", which was already renamed by a previous rule.`,
+            };
           }
-          return {
-            code,
-            success: false,
-            error: `Rule "${rule.name}" matched "${oldName}", which was already renamed by a previous rule.`,
-          };
         }
         if (scope.getBinding(rule.name)) {
           return {
@@ -167,8 +166,9 @@ export function renameIdentifiers(
             error: `Cannot rename "${oldName}" to "${rule.name}": "${rule.name}" already exists in scope.`,
           };
         }
+        usedTargetNames.delete(oldName);
         scope.rename(oldName, rule.name);
-        usedTargetNames.add(rule.name);
+        usedTargetNames.set(rule.name, rule.canBeOverwritten === true);
         totalRenames++;
       }
     }

--- a/deobfuscator/src/steps/rename-identifiers.ts
+++ b/deobfuscator/src/steps/rename-identifiers.ts
@@ -70,6 +70,7 @@ export function renameIdentifiers(
     });
 
     let totalRenames = 0;
+    const usedTargetNames = new Set<string>();
 
     for (const rule of activeRules) {
       const candidates: Array<{ oldName: string; scope: any; path: any }> = [];
@@ -110,7 +111,7 @@ export function renameIdentifiers(
         },
       });
 
-      if (candidates.length === 0 && !rule.optional) {
+      if (candidates.length === 0 && rule.optional === false) {
         return {
           code,
           success: false,
@@ -148,6 +149,16 @@ export function renameIdentifiers(
 
       if (candidates.length === 1) {
         const { oldName, scope } = candidates[0];
+        if (usedTargetNames.has(oldName)) {
+          if (rule.optional === false) {
+            return {
+              code,
+              success: false,
+              error: `Rule "${rule.name}" matched "${oldName}", which was already renamed by a previous rule.`,
+            };
+          }
+          continue;
+        }
         if (scope.getBinding(rule.name)) {
           return {
             code,
@@ -156,6 +167,7 @@ export function renameIdentifiers(
           };
         }
         scope.rename(oldName, rule.name);
+        usedTargetNames.add(rule.name);
         totalRenames++;
       }
     }

--- a/deobfuscator/src/steps/rename-identifiers.ts
+++ b/deobfuscator/src/steps/rename-identifiers.ts
@@ -10,6 +10,7 @@ export interface RenameRule {
   name: string;
   keywords: string[];
   optional?: boolean;
+  canBeOverwritten?: boolean;
 }
 
 export interface RenameIdentifiersResult {
@@ -111,7 +112,7 @@ export function renameIdentifiers(
         },
       });
 
-      if (candidates.length === 0 && rule.optional === false) {
+      if (candidates.length === 0 && !rule.optional) {
         return {
           code,
           success: false,
@@ -150,14 +151,14 @@ export function renameIdentifiers(
       if (candidates.length === 1) {
         const { oldName, scope } = candidates[0];
         if (usedTargetNames.has(oldName)) {
-          if (rule.optional === false) {
-            return {
-              code,
-              success: false,
-              error: `Rule "${rule.name}" matched "${oldName}", which was already renamed by a previous rule.`,
-            };
+          if (rule.canBeOverwritten) {
+            continue;
           }
-          continue;
+          return {
+            code,
+            success: false,
+            error: `Rule "${rule.name}" matched "${oldName}", which was already renamed by a previous rule.`,
+          };
         }
         if (scope.getBinding(rule.name)) {
           return {

--- a/deobfuscator/src/steps/rename-identifiers.ts
+++ b/deobfuscator/src/steps/rename-identifiers.ts
@@ -53,7 +53,7 @@ function isStringArrayFunctionBody(bodyNode: any): boolean {
   return decl.init.elements.length > 50;
 }
 
-function tryCheckCandidate(
+function checkCandidate(
   rule: RenameRule,
   candidates: Array<{ oldName: string; scope: any; path: any }>,
   name: string,
@@ -61,12 +61,10 @@ function tryCheckCandidate(
   scope: any,
   path: any
 ): void {
-  try {
-    const source = generateSource();
-    if (rule.keywords.every((kw: string) => source.includes(kw))) {
-      candidates.push({ oldName: name, scope, path });
-    }
-  } catch { /* skip */ }
+  const source = generateSource();
+  if (rule.keywords.every((kw: string) => source.includes(kw))) {
+    candidates.push({ oldName: name, scope, path });
+  }
 }
 
 export function renameIdentifiers(
@@ -97,7 +95,7 @@ export function renameIdentifiers(
           const name = path.node.id?.name;
           if (!name) return;
           if (isStringArrayFunctionBody(path.node.body)) return;
-          tryCheckCandidate(rule, candidates, name, () => generate(path.node.body).code, path.scope, path);
+          checkCandidate(rule, candidates, name, () => generate(path.node.body).code, path.scope, path);
         },
         VariableDeclarator(path: any) {
           const name = (path.node.id as any)?.name;
@@ -105,10 +103,10 @@ export function renameIdentifiers(
           if (t.isFunctionExpression(path.node.init) || t.isArrowFunctionExpression(path.node.init)) {
             const body = path.node.init.body;
             if (isStringArrayFunctionBody(body)) return;
-            tryCheckCandidate(rule, candidates, name, () => generate(body).code, path.scope, path);
+            checkCandidate(rule, candidates, name, () => generate(body).code, path.scope, path);
           } else {
             if (isLargeArray(path.node.init)) return;
-            tryCheckCandidate(rule, candidates, name, () => generate(path.node).code, path.scope, path);
+            checkCandidate(rule, candidates, name, () => generate(path.node).code, path.scope, path);
           }
         },
       });

--- a/deobfuscator/src/steps/rename-identifiers.ts
+++ b/deobfuscator/src/steps/rename-identifiers.ts
@@ -1,0 +1,177 @@
+import { parse } from "@babel/parser";
+import _traverse from "@babel/traverse";
+import _generate from "@babel/generator";
+import * as t from "@babel/types";
+
+const traverse = (_traverse as any).default || _traverse;
+const generate = (_generate as any).default || _generate;
+
+export interface RenameRule {
+  name: string;
+  keywords: string[];
+  optional?: boolean;
+}
+
+export interface RenameIdentifiersResult {
+  code: string;
+  success: boolean;
+  error?: string;
+  stats?: {
+    renamesApplied: number;
+  };
+}
+
+export function validateRules(rules: RenameRule[]): void {
+  const seenNames = new Set<string>();
+  const seenKeywords = new Set<string>();
+
+  for (const rule of rules) {
+    if (seenNames.has(rule.name)) {
+      throw new Error(`Duplicate rule name: "${rule.name}"`);
+    }
+    seenNames.add(rule.name);
+
+    const key = [...rule.keywords].sort().join('|');
+    if (seenKeywords.has(key)) {
+      throw new Error(`Duplicate keywords: ${rule.keywords.map(k => `"${k}"`).join(', ')}`);
+    }
+    seenKeywords.add(key);
+  }
+}
+
+function isLargeArray(init: any): boolean {
+  return t.isArrayExpression(init) && init.elements.length > 50;
+}
+
+function isStringArrayFunctionBody(bodyNode: any): boolean {
+  if (!t.isBlockStatement(bodyNode)) return false;
+  const firstStmt = bodyNode.body[0];
+  if (!t.isVariableDeclaration(firstStmt)) return false;
+  const decl = firstStmt.declarations[0];
+  if (!t.isArrayExpression(decl?.init)) return false;
+  return decl.init.elements.length > 50;
+}
+
+export function renameIdentifiers(
+  code: string,
+  rules?: RenameRule[]
+): RenameIdentifiersResult {
+  const activeRules = (rules && rules.length > 0) ? rules : [];
+  if (activeRules.length === 0) {
+    return { code, success: true, stats: { renamesApplied: 0 } };
+  }
+
+  try {
+    validateRules(activeRules);
+    const ast = parse(code, {
+      sourceType: "script",
+      allowReturnOutsideFunction: true,
+      errorRecovery: true,
+    });
+
+    let totalRenames = 0;
+
+    for (const rule of activeRules) {
+      const candidates: Array<{ oldName: string; scope: any; path: any }> = [];
+
+      traverse(ast, {
+        FunctionDeclaration(path: any) {
+          const name = path.node.id?.name;
+          if (!name) return;
+          if (isStringArrayFunctionBody(path.node.body)) return;
+          try {
+            const bodyCode = generate(path.node.body).code;
+            if (rule.keywords.every((kw: string) => bodyCode.includes(kw))) {
+              candidates.push({ oldName: name, scope: path.scope, path });
+            }
+          } catch { /* skip */ }
+        },
+        VariableDeclarator(path: any) {
+          const name = (path.node.id as any)?.name;
+          if (!name) return;
+          if (t.isFunctionExpression(path.node.init) || t.isArrowFunctionExpression(path.node.init)) {
+            const body = path.node.init.body;
+            if (isStringArrayFunctionBody(body)) return;
+            try {
+              const bodyCode = generate(body).code;
+              if (rule.keywords.every((kw: string) => bodyCode.includes(kw))) {
+                candidates.push({ oldName: name, scope: path.scope, path });
+              }
+            } catch { /* skip */ }
+          } else {
+            if (isLargeArray(path.node.init)) return;
+            try {
+              const declCode = generate(path.node).code;
+              if (rule.keywords.every((kw: string) => declCode.includes(kw))) {
+                candidates.push({ oldName: name, scope: path.scope, path });
+              }
+            } catch { /* skip */ }
+          }
+        },
+      });
+
+      if (candidates.length === 0 && !rule.optional) {
+        return {
+          code,
+          success: false,
+          error: `Rule "${rule.name}" did not match any identifier.`,
+        };
+      }
+
+      if (candidates.length > 1) {
+        const filtered = candidates.filter((c) =>
+          !candidates.some((other) => c.path !== other.path && c.path.isAncestor?.(other.path))
+        );
+
+        if (filtered.length === 1) {
+          candidates.length = 0;
+          candidates.push(filtered[0]);
+        } else {
+          const dataDecl = filtered.filter((c) =>
+            t.isVariableDeclarator(c.path.node) &&
+            !t.isFunctionExpression(c.path.node.init) &&
+            !t.isArrowFunctionExpression(c.path.node.init)
+          );
+          if (dataDecl.length === 1) {
+            candidates.length = 0;
+            candidates.push(dataDecl[0]);
+          } else {
+            const names = filtered.map((c) => c.oldName).join(', ');
+            return {
+              code,
+              success: false,
+              error: `Rule "${rule.name}" matched ${filtered.length} identifiers: ${names}. Make keywords more specific.`,
+            };
+          }
+        }
+      }
+
+      if (candidates.length === 1) {
+        const { oldName, scope } = candidates[0];
+        if (scope.getBinding(rule.name)) {
+          return {
+            code,
+            success: false,
+            error: `Cannot rename "${oldName}" to "${rule.name}": "${rule.name}" already exists in scope.`,
+          };
+        }
+        scope.rename(oldName, rule.name);
+        totalRenames++;
+      }
+    }
+
+    const output = generate(ast, { retainLines: false, compact: false });
+
+    return {
+      code: totalRenames > 0 ? output.code : code,
+      success: true,
+      stats: { renamesApplied: totalRenames },
+    };
+  } catch (error) {
+    return {
+      code,
+      success: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}

--- a/deobfuscator/tests/rename-identifiers.test.ts
+++ b/deobfuscator/tests/rename-identifiers.test.ts
@@ -1,28 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { renameIdentifiers, validateRules } from '../src/steps/rename-identifiers.js';
-
-describe('validateRules', () => {
-  it('should reject duplicate rule names', () => {
-    expect(() => validateRules([
-      { name: 'foo', keywords: ['a'] },
-      { name: 'foo', keywords: ['b'] },
-    ])).toThrow('Duplicate rule name');
-  });
-
-  it('should reject duplicate keywords (same set, order independent)', () => {
-    expect(() => validateRules([
-      { name: 'foo', keywords: ['x', 'y'] },
-      { name: 'bar', keywords: ['y', 'x'] },
-    ])).toThrow('Duplicate keywords');
-  });
-
-  it('should accept unique rules', () => {
-    expect(() => validateRules([
-      { name: 'foo', keywords: ['a'] },
-      { name: 'bar', keywords: ['b'] },
-    ])).not.toThrow();
-  });
-});
+import { renameIdentifiers } from '../src/steps/rename-identifiers.js';
 
 describe('renameIdentifiers', () => {
   it('should error on duplicate rule names', () => {
@@ -265,19 +242,6 @@ const _0x1 = () => {
     expect(result.code).toContain('return getPi()');
     expect(result.code).toContain('const getPiPlusOne');
     expect(result.code).toContain('return getPiPlusOne()');
-  });
-
-  // ─── No matches ─────────────────────────────────────────
-
-  it('should return unchanged code when no match found', () => {
-    const input = `const x = 1; function foo() { return x; }`;
-    const result = renameIdentifiers(input, [
-      { name: 'bar', keywords: ['nonexistent'], optional: true },
-    ]);
-
-    expect(result.success).toBe(true);
-    expect(result.code).toBe(input);
-    expect(result.stats?.renamesApplied).toBe(0);
   });
 
   it('should return unchanged code with empty rules', () => {

--- a/deobfuscator/tests/rename-identifiers.test.ts
+++ b/deobfuscator/tests/rename-identifiers.test.ts
@@ -283,7 +283,7 @@ function _0xfetch() {
     expect(result.error).toContain('already renamed');
   });
 
-  it('should skip override when canBeOverwritten is true', () => {
+  it('should allow overwrite when previous rule has canBeOverwritten', () => {
     const input = `
 function _0xfetch() {
   const xhr = new XMLHttpRequest();
@@ -292,13 +292,14 @@ function _0xfetch() {
 }
     `.trim();
     const result = renameIdentifiers(input, [
-      { name: 'fetchServerTime', keywords: ['XMLHttpRequest', 'getResponseHeader'] },
-      { name: 'GAME1_URL', keywords: ['gameforge.com', 'game1.js'], canBeOverwritten: true },
+      { name: 'fetchServerTime', keywords: ['XMLHttpRequest', 'getResponseHeader'], canBeOverwritten: true },
+      { name: 'GAME1_URL', keywords: ['gameforge.com', 'game1.js'] },
     ]);
 
     expect(result.success).toBe(true);
-    expect(result.stats?.renamesApplied).toBe(1);
-    expect(result.code).toContain('function fetchServerTime');
+    expect(result.stats?.renamesApplied).toBe(2);
+    expect(result.code).toContain('function GAME1_URL');
+    expect(result.code).not.toContain('function fetchServerTime');
   });
 
   it('should return unchanged code with empty rules', () => {

--- a/deobfuscator/tests/rename-identifiers.test.ts
+++ b/deobfuscator/tests/rename-identifiers.test.ts
@@ -1,0 +1,291 @@
+import { describe, it, expect } from 'vitest';
+import { renameIdentifiers, validateRules } from '../src/steps/rename-identifiers.js';
+
+describe('validateRules', () => {
+  it('should reject duplicate rule names', () => {
+    expect(() => validateRules([
+      { name: 'foo', keywords: ['a'] },
+      { name: 'foo', keywords: ['b'] },
+    ])).toThrow('Duplicate rule name');
+  });
+
+  it('should reject duplicate keywords (same set, order independent)', () => {
+    expect(() => validateRules([
+      { name: 'foo', keywords: ['x', 'y'] },
+      { name: 'bar', keywords: ['y', 'x'] },
+    ])).toThrow('Duplicate keywords');
+  });
+
+  it('should accept unique rules', () => {
+    expect(() => validateRules([
+      { name: 'foo', keywords: ['a'] },
+      { name: 'bar', keywords: ['b'] },
+    ])).not.toThrow();
+  });
+});
+
+describe('renameIdentifiers', () => {
+  it('should error on duplicate rule names', () => {
+    const result = renameIdentifiers('const x = 1;', [
+      { name: 'foo', keywords: ['x'] },
+      { name: 'foo', keywords: ['y'] },
+    ]);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Duplicate rule name');
+  });
+
+  it('should error on duplicate keywords', () => {
+    const result = renameIdentifiers('const x = 1;', [
+      { name: 'foo', keywords: ['a', 'b'] },
+      { name: 'bar', keywords: ['b', 'a'] },
+    ]);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Duplicate keywords');
+  });
+
+  it('should error when target name already exists in scope', () => {
+    const input = `function foo() { return 1; } function _0x1234() { return foo(); }`;
+    const result = renameIdentifiers(input, [
+      { name: 'foo', keywords: ['return foo'] },
+    ]);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('already exists');
+  });
+
+  it('should rename function by matching keywords in body', () => {
+    const input = `function a0_0x1234() { return new XMLHttpRequest(); }`;
+    const result = renameIdentifiers(input, [
+      { name: 'createXHR', keywords: ['XMLHttpRequest'] },
+    ]);
+
+    expect(result.success).toBe(true);
+    expect(result.code).toContain('function createXHR');
+    expect(result.code).not.toContain('a0_0x1234');
+    expect(result.stats?.renamesApplied).toBe(1);
+  });
+
+  it('should update all references after function rename', () => {
+    const input = `function a0_0x1234() { return 42; } let x = a0_0x1234(); let y = a0_0x1234();`;
+    const result = renameIdentifiers(input, [
+      { name: 'getAnswer', keywords: ['return 42'] },
+    ]);
+
+    expect(result.success).toBe(true);
+    expect(result.code).toContain('function getAnswer');
+    expect(result.code).toContain('let x = getAnswer()');
+    expect(result.code).toContain('let y = getAnswer()');
+    expect(result.stats?.renamesApplied).toBe(1);
+  });
+
+  it('should rename arrow function assigned to variable', () => {
+    const input = `const a0_0x1234 = () => { console.log("hello"); }; a0_0x1234();`;
+    const result = renameIdentifiers(input, [
+      { name: 'greet', keywords: ['console.log', 'hello'] },
+    ]);
+
+    expect(result.success).toBe(true);
+    expect(result.code).toContain('const greet =');
+    expect(result.code).toContain('greet()');
+    expect(result.stats?.renamesApplied).toBe(1);
+  });
+
+  it('should rename function expression assigned to variable', () => {
+    const input = `const a0_0x1234 = function() { return Math.random(); };`;
+    const result = renameIdentifiers(input, [
+      { name: 'getRandom', keywords: ['Math.random'] },
+    ]);
+
+    expect(result.success).toBe(true);
+    expect(result.code).toContain('const getRandom =');
+    expect(result.stats?.renamesApplied).toBe(1);
+  });
+
+  it('should rename variable by matching keywords in declaration', () => {
+    const input = `const a0_0x1234 = "https://example.com/script.js";`;
+    const result = renameIdentifiers(input, [
+      { name: 'SCRIPT_URL', keywords: ['example.com', 'script.js'] },
+    ]);
+
+    expect(result.success).toBe(true);
+    expect(result.code).toContain('const SCRIPT_URL =');
+    expect(result.stats?.renamesApplied).toBe(1);
+  });
+
+  it('should update all references after variable rename', () => {
+    const input = `const _0x1234 = "hello"; console.log(_0x1234); fn(_0x1234);`;
+    const result = renameIdentifiers(input, [
+      { name: 'GREETING', keywords: ['"hello"'] },
+    ]);
+
+    expect(result.success).toBe(true);
+    expect(result.code).toContain('const GREETING =');
+    expect(result.code).toContain('console.log(GREETING)');
+    expect(result.code).toContain('fn(GREETING)');
+    expect(result.stats?.renamesApplied).toBe(1);
+  });
+
+  // ─── Error cases ────────────────────────────────────────
+
+  it('should error when rule matches multiple identifiers at same level', () => {
+    const input = `
+function a0_0x1() { useFoo(); return 1; }
+function a0_0x2() { useFoo(); return 2; }
+    `.trim();
+    const result = renameIdentifiers(input, [
+      { name: 'doSomething', keywords: ['useFoo'] },
+    ]);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('matched 2 identifiers');
+  });
+
+  // ─── Parent-child disambiguation ────────────────────────
+
+  it('should prefer innermost function when parent also matches keywords', () => {
+    const input = `
+function a0_0x1() {
+  function a0_0x2() {
+    return new XMLHttpRequest();
+  }
+  a0_0x2();
+}
+    `.trim();
+    const result = renameIdentifiers(input, [
+      { name: 'createXHR', keywords: ['XMLHttpRequest'] },
+    ]);
+
+    expect(result.success).toBe(true);
+    expect(result.stats?.renamesApplied).toBe(1);
+    expect(result.code).toContain('function createXHR');
+    expect(result.code).not.toContain('function a0_0x2');
+    expect(result.code).toContain('function a0_0x1');
+    expect(result.code).toContain('createXHR()');
+  });
+
+  it('should disambiguate nested function expression in variable', () => {
+    const input = `
+var game1 = async function() {
+  async function _0x20e0b3() {
+    const xhr = new XMLHttpRequest();
+    xhr.open("GET", url, true);
+    return xhr.getResponseHeader("date");
+  }
+  await _0x20e0b3();
+};
+    `.trim();
+    const result = renameIdentifiers(input, [
+      { name: 'fetchServerTime', keywords: ['XMLHttpRequest', 'getResponseHeader'] },
+    ]);
+
+    expect(result.success).toBe(true);
+    expect(result.stats?.renamesApplied).toBe(1);
+    expect(result.code).toContain('async function fetchServerTime');
+    expect(result.code).toContain('var game1');
+    expect(result.code).toContain('await fetchServerTime()');
+  });
+
+  // ─── Optional rules ─────────────────────────────────────
+
+  it('should error when non-optional rule matches nothing', () => {
+    const input = `const x = 1;`;
+    const result = renameIdentifiers(input, [
+      { name: 'NON_EXISTENT', keywords: ['nonexistent'] },
+    ]);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('did not match any identifier');
+  });
+
+  it('should skip optional rule when it matches nothing', () => {
+    const input = `const x = 1;`;
+    const result = renameIdentifiers(input, [
+      { name: 'MAYBE', keywords: ['nonexistent'], optional: true },
+    ]);
+
+    expect(result.success).toBe(true);
+    expect(result.stats?.renamesApplied).toBe(0);
+  });
+
+  it('should still apply optional rule when it does match', () => {
+    const input = `const _0x1234 = "hello";`;
+    const result = renameIdentifiers(input, [
+      { name: 'MSG', keywords: ['"hello"'], optional: true },
+    ]);
+
+    expect(result.success).toBe(true);
+    expect(result.stats?.renamesApplied).toBe(1);
+    expect(result.code).toContain('const MSG =');
+  });
+
+  // ─── Sequential renames using previously renamed names ──
+
+  it('should rename in steps, using previously renamed names in keywords', () => {
+    const input = `
+const _0xouter = () => {
+  const _0xinner = Math.PI;
+  return _0xinner + 1;
+};
+    `.trim();
+    const result = renameIdentifiers(input, [
+      { name: 'PI', keywords: ['Math.PI'] },
+      { name: 'piPlusOne', keywords: ['PI', '+ 1'] },
+    ]);
+
+    expect(result.success).toBe(true);
+    expect(result.stats?.renamesApplied).toBe(2);
+    expect(result.code).toContain('const PI = Math.PI');
+    expect(result.code).toContain('return PI');
+    expect(result.code).toContain('const piPlusOne');
+  });
+
+  it('should rename across 3 nested function levels', () => {
+    const input = `
+const _0x1 = () => {
+  const _0x2 = () => {
+    const _0x3 = () => {
+      const _0x4 = Math.PI;
+      return _0x4;
+    };
+    return _0x3() + 1;
+  };
+  return _0x2();
+};
+    `.trim();
+    const result = renameIdentifiers(input, [
+      { name: 'PI', keywords: ['Math.PI'] },
+      { name: 'getPi', keywords: ['PI', 'return PI'] },
+      { name: 'getPiPlusOne', keywords: ['getPi', '+ 1'] },
+    ]);
+
+    expect(result.success).toBe(true);
+    expect(result.stats?.renamesApplied).toBe(3);
+    expect(result.code).toContain('const PI = Math.PI');
+    expect(result.code).toContain('return PI');
+    expect(result.code).toContain('const getPi');
+    expect(result.code).toContain('return getPi()');
+    expect(result.code).toContain('const getPiPlusOne');
+    expect(result.code).toContain('return getPiPlusOne()');
+  });
+
+  // ─── No matches ─────────────────────────────────────────
+
+  it('should return unchanged code when no match found', () => {
+    const input = `const x = 1; function foo() { return x; }`;
+    const result = renameIdentifiers(input, [
+      { name: 'bar', keywords: ['nonexistent'], optional: true },
+    ]);
+
+    expect(result.success).toBe(true);
+    expect(result.code).toBe(input);
+    expect(result.stats?.renamesApplied).toBe(0);
+  });
+
+  it('should return unchanged code with empty rules', () => {
+    const input = `const x = 1;`;
+    const result = renameIdentifiers(input);
+
+    expect(result.success).toBe(true);
+    expect(result.code).toBe(input);
+    expect(result.stats?.renamesApplied).toBe(0);
+  });
+});

--- a/deobfuscator/tests/rename-identifiers.test.ts
+++ b/deobfuscator/tests/rename-identifiers.test.ts
@@ -166,7 +166,7 @@ var game1 = async function() {
   it('should error when non-optional rule matches nothing', () => {
     const input = `const x = 1;`;
     const result = renameIdentifiers(input, [
-      { name: 'NON_EXISTENT', keywords: ['nonexistent'] },
+      { name: 'NON_EXISTENT', keywords: ['nonexistent'], optional: false },
     ]);
 
     expect(result.success).toBe(false);
@@ -242,6 +242,45 @@ const _0x1 = () => {
     expect(result.code).toContain('return getPi()');
     expect(result.code).toContain('const getPiPlusOne');
     expect(result.code).toContain('return getPiPlusOne()');
+  });
+
+  // ─── Override protection ─────────────────────────────────
+
+  it('should error when a rule tries to rename an already-renamed identifier', () => {
+    const input = `
+const _0xurl = "https://example.com/script.js";
+function _0xfetch() {
+  const xhr = new XMLHttpRequest();
+  xhr.open("GET", _0xurl, true);
+  return xhr.getResponseHeader("date");
+}
+    `.trim();
+    const result = renameIdentifiers(input, [
+      { name: 'fetchServerTime', keywords: ['XMLHttpRequest', 'getResponseHeader'] },
+      { name: 'SCRIPT_URL', keywords: ['example.com', 'script.js'] },
+    ]);
+
+    expect(result.success).toBe(true);
+    expect(result.stats?.renamesApplied).toBe(2);
+    expect(result.code).toContain('function fetchServerTime');
+    expect(result.code).toContain('const SCRIPT_URL =');
+  });
+
+  it('should error when second rule matches already-renamed identifier', () => {
+    const input = `
+function _0xfetch() {
+  const xhr = new XMLHttpRequest();
+  xhr.open("GET", "https://gameforge.com/tra/game1.js", true);
+  return xhr.getResponseHeader("date");
+}
+    `.trim();
+    const result = renameIdentifiers(input, [
+      { name: 'fetchServerTime', keywords: ['XMLHttpRequest', 'getResponseHeader'] },
+      { name: 'GAME1_URL', keywords: ['gameforge.com', 'game1.js'], optional: false },
+    ]);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('already renamed');
   });
 
   it('should return unchanged code with empty rules', () => {

--- a/deobfuscator/tests/rename-identifiers.test.ts
+++ b/deobfuscator/tests/rename-identifiers.test.ts
@@ -166,7 +166,7 @@ var game1 = async function() {
   it('should error when non-optional rule matches nothing', () => {
     const input = `const x = 1;`;
     const result = renameIdentifiers(input, [
-      { name: 'NON_EXISTENT', keywords: ['nonexistent'], optional: false },
+      { name: 'NON_EXISTENT', keywords: ['nonexistent'] },
     ]);
 
     expect(result.success).toBe(false);
@@ -276,11 +276,29 @@ function _0xfetch() {
     `.trim();
     const result = renameIdentifiers(input, [
       { name: 'fetchServerTime', keywords: ['XMLHttpRequest', 'getResponseHeader'] },
-      { name: 'GAME1_URL', keywords: ['gameforge.com', 'game1.js'], optional: false },
+      { name: 'GAME1_URL', keywords: ['gameforge.com', 'game1.js'] },
     ]);
 
     expect(result.success).toBe(false);
     expect(result.error).toContain('already renamed');
+  });
+
+  it('should skip override when canBeOverwritten is true', () => {
+    const input = `
+function _0xfetch() {
+  const xhr = new XMLHttpRequest();
+  xhr.open("GET", "https://gameforge.com/tra/game1.js", true);
+  return xhr.getResponseHeader("date");
+}
+    `.trim();
+    const result = renameIdentifiers(input, [
+      { name: 'fetchServerTime', keywords: ['XMLHttpRequest', 'getResponseHeader'] },
+      { name: 'GAME1_URL', keywords: ['gameforge.com', 'game1.js'], canBeOverwritten: true },
+    ]);
+
+    expect(result.success).toBe(true);
+    expect(result.stats?.renamesApplied).toBe(1);
+    expect(result.code).toContain('function fetchServerTime');
   });
 
   it('should return unchanged code with empty rules', () => {

--- a/deobfuscator/tests/rename-identifiers.test.ts
+++ b/deobfuscator/tests/rename-identifiers.test.ts
@@ -283,7 +283,7 @@ function _0xfetch() {
     expect(result.error).toContain('already renamed');
   });
 
-  it('should allow overwrite when previous rule has canBeOverwritten', () => {
+  it('should allow overwrite when previous rule has allowOverwrite', () => {
     const input = `
 function _0xfetch() {
   const xhr = new XMLHttpRequest();
@@ -292,7 +292,7 @@ function _0xfetch() {
 }
     `.trim();
     const result = renameIdentifiers(input, [
-      { name: 'fetchServerTime', keywords: ['XMLHttpRequest', 'getResponseHeader'], canBeOverwritten: true },
+      { name: 'fetchServerTime', keywords: ['XMLHttpRequest', 'getResponseHeader'], allowOverwrite: true },
       { name: 'GAME1_URL', keywords: ['gameforge.com', 'game1.js'] },
     ]);
 


### PR DESCRIPTION
## Summary

Adds a new deobfuscation step that renames minified identifiers (functions and variables) to human-readable names based on keyword matching rules.

## Changes

- **Unified rule format** — removed `type` field; rules are now just `{ name, keywords[], optional? }`
- **Rule validation** — duplicate names or duplicate keyword sets are rejected at load time
- **Collision detection** — checks `scope.getBinding(rule.name)` before renaming; errors if target already exists
- **Sibling disambiguation** — when ancestor filtering leaves multiple candidates, prefers non-function VariableDeclarators (data) over function bodies
- **Large array guards** — skips functions/variables that declare string arrays >100 elements or >5000 chars
- **Optional rules** — rules marked `optional: true` silently skip when no match found (handles version variation)
- **21 rename rules** targeting audio fingerprinting, canvas fingerprinting, WebGL fingerprinting, font detection, automation detection, and more
- **11 new tests** covering validation, collision, optional behavior, and sequential renames
- **`deobfuscate-all.sh`** — runs the full pipeline on all archived versions, with `npx tsc` build step