### PR TITLE
More rename rules + re-deobfuscate all scripts

### DIFF
--- a/archived_game1_scripts/2025-12-24T122655/game1.js.deobfuscated.js
+++ b/archived_game1_scripts/2025-12-24T122655/game1.js.deobfuscated.js
@@ -1086,7 +1086,7 @@ try {
       let _0xccf4b5 = 0;
       _0x3db5c0.oncomplete = _0x6232ad => _0x347231(_0x6232ad.renderedBuffer);
       const _0x23016f = () => {
-        setTimeout(() => _0xa17208(a0_0x510773("timeout")), Math.min(500, _0xccf4b5 + 5000 - Date.now()));
+        setTimeout(() => _0xa17208(createError("timeout")), Math.min(500, _0xccf4b5 + 5000 - Date.now()));
       };
       const _0x48d286 = () => {
         try {
@@ -1103,7 +1103,7 @@ try {
                 _0x50639f++;
               }
               if (_0x33cc7e && _0x50639f >= 3) {
-                _0xa17208(a0_0x510773('suspended'));
+                _0xa17208(createError('suspended'));
               } else {
                 setTimeout(_0x48d286, 500);
               }
@@ -1132,7 +1132,7 @@ try {
     }
     return _0x139fb6;
   }
-  function a0_0x510773(_0x2d7c85) {
+  function createError(_0x2d7c85) {
     const _0x2783dc = new Error(_0x2d7c85);
     _0x2783dc.name = _0x2d7c85;
     return _0x2783dc;
@@ -1417,12 +1417,12 @@ try {
       const _0x4952fa = new Uint8Array(131072);
       _0x47fa4a.readPixels(0, 0, 256, 128, _0x47fa4a.RGBA, _0x47fa4a.UNSIGNED_BYTE, _0x4952fa);
       let _0x253d27 = JSON.stringify(_0x4952fa).replace(/,?"[0-9]+":/g, '');
-      return a0_0x3f952b(_0x253d27);
+      return hashSHA256(_0x253d27);
     } catch (_0x4e72f0) {
       return '-1';
     }
   };
-  const a0_0x3f952b = function () {
+  const hashSHA256 = function () {
     let _0x5d3c89 = 1;
     let _0x573d17;
     let _0x2fd175 = [];
@@ -1653,36 +1653,36 @@ try {
   const generateRandomString = _0x593ccd => {
     return new Array(_0x593ccd).fill(0).map(() => Math.random().toString(36).substr(2, 9)).reduce((_0x3386ad, _0x3ca29b) => _0x3386ad + _0x3ca29b, '');
   };
-  const a0_0x1548d0 = async () => {
+  const collectFingerprint = async () => {
     const _0x43eca2 = await Promise.all([checkPermissions(), enumerateMediaDevices(), getAudioFingerprint()]);
-    const _0x3b78d7 = detectBrowser();
-    const _0x516cce = detectOS();
-    const _0x74a6db = getWebglInfo();
-    const _0x515826 = a0_0x3f952b(JSON.stringify(detectFonts()));
+    const detectedBrowser = detectBrowser();
+    const detectedOS = detectOS();
+    const detectedWebglInfo = getWebglInfo();
+    const _0x515826 = hashSHA256(JSON.stringify(detectFonts()));
     const _0x399205 = getWebglCanvasFingerprint();
     const _0x5d8a8a = getCanvas2dFingerprint();
     return {
       'dg': 11,
       'dO4': Intl.DateTimeFormat().resolvedOptions().timeZone,
-      'b-I2rx-E': _0x516cce.name,
-      'YdFB': _0x3b78d7.name,
+      'b-I2rx-E': detectedOS.name,
+      'YdFB': detectedBrowser.name,
       'dttJrRyO': navigator.vendor,
       'bdI_': navigator.deviceMemory || 0,
       'Y9JA': navigator.hardwareConcurrency || 0,
       'bM07og': navigator.languages.join(','),
-      'cNxRuCGPAg': a0_0x3f952b(JSON.stringify(getBrowserPlugins())),
-      'Z9dM': _0x74a6db.vendor + ',' + _0x74a6db.renderer,
+      'cNxRuCGPAg': hashSHA256(JSON.stringify(getBrowserPlugins())),
+      'Z9dM': detectedWebglInfo.vendor + ',' + detectedWebglInfo.renderer,
       'ZtVDtyo': _0x515826,
-      'YdY6oxJV': a0_0x3f952b(JSON.stringify(getAudioContextProps())),
-      'b-I4nQ-C61rI': _0x516cce.version,
+      'YdY6oxJV': hashSHA256(JSON.stringify(getAudioContextProps())),
+      'b-I4nQ-C61rI': detectedOS.version,
       'd-BEuCA': window.screen.availWidth,
       'aM02nQV5': window.screen.availHeight,
       'bL8zohR5': Boolean(localStorage),
       'c8Y6qRuA': Boolean(sessionStorage),
-      'dt9DqBc': a0_0x3f952b(JSON.stringify(detectVideoCodecs())),
-      'YdY6oxI': a0_0x3f952b(JSON.stringify(detectAudioCodecs())),
-      'bdI2nwA': a0_0x3f952b(JSON.stringify(_0x43eca2[1])),
-      'cNVHtB2QA2zbSbw': a0_0x3f952b(JSON.stringify(_0x43eca2[0])),
+      'dt9DqBc': hashSHA256(JSON.stringify(detectVideoCodecs())),
+      'YdY6oxI': hashSHA256(JSON.stringify(detectAudioCodecs())),
+      'bdI2nwA': hashSHA256(JSON.stringify(_0x43eca2[1])),
+      'cNVHtB2QA2zbSbw': hashSHA256(JSON.stringify(_0x43eca2[0])),
       'YdY6oxJYqA': _0x43eca2[2],
       'd9w-pRFXpw': _0x399205,
       'Y8QyqAl8whI': _0x5d8a8a
@@ -1721,37 +1721,37 @@ try {
     return _0x3d0233(_0x235160);
   }
   var game1 = async function (_0x2ca7e0, _0x5a4e31 = null) {
-    let _0x245690 = new Date().getTime();
-    let _0x118783 = localStorage.getItem("x-game");
+    let timeNowUnixMs = new Date().getTime();
+    let xGame = localStorage.getItem("x-game");
     let _0x696e51;
     let _0x3e4ebd;
     try {
-      let _0x556164 = localStorage.getItem("x-vec");
-      let _0x6f1a6b = _0x556164.lastIndexOf(" ");
-      _0x696e51 = _0x556164.substr(0, _0x6f1a6b).split('');
-      _0x3e4ebd = parseInt(_0x556164.substr(_0x6f1a6b + 1));
+      let xVec = localStorage.getItem("x-vec");
+      let _0x6f1a6b = xVec.lastIndexOf(" ");
+      _0x696e51 = xVec.substr(0, _0x6f1a6b).split('');
+      _0x3e4ebd = parseInt(xVec.substr(_0x6f1a6b + 1));
     } catch (_0x998ff4) {
       _0x696e51 = Array.from(Array(100), _0x2c1c1a => String.fromCharCode(32 + Math.random() * 94 | 0));
-      _0x3e4ebd = _0x245690;
+      _0x3e4ebd = timeNowUnixMs;
     }
     let _0x120081 = _0x696e51.join('') + " " + _0x3e4ebd;
     localStorage.setItem("x-vec", _0x120081);
-    if (_0x3e4ebd + 1000 < _0x245690) {
+    if (_0x3e4ebd + 1000 < timeNowUnixMs) {
       _0x696e51.shift();
       _0x696e51.push(String.fromCharCode(32 + Math.random() * 94 | 0));
-      _0x120081 = _0x696e51.join('') + " " + _0x245690;
+      _0x120081 = _0x696e51.join('') + " " + timeNowUnixMs;
       localStorage.setItem("x-vec", _0x120081);
     }
-    if (!_0x118783) {
-      _0x118783 = generateRandomString(3);
-      localStorage.setItem("x-game", _0x118783);
+    if (!xGame) {
+      xGame = generateRandomString(3);
+      localStorage.setItem("x-game", xGame);
     }
-    let _0x2eb1b = await a0_0x1548d0();
+    let _0x2eb1b = await collectFingerprint();
     _0x2eb1b.Y9U6mw9451U = new Date().toISOString();
-    _0x2eb1b.depTtw = _0x118783;
+    _0x2eb1b.depTtw = xGame;
     _0x2eb1b["dts-siGT"] = window.btoa(_0x120081);
-    _0x2eb1b.ZA = new Date().getTime() - _0x245690;
-    async function _0x5eadd5() {
+    _0x2eb1b.ZA = new Date().getTime() - timeNowUnixMs;
+    async function getServerTime() {
       return new Promise((_0x2ec540, _0xee223a) => {
         const _0x3f0b61 = new XMLHttpRequest();
         _0x3f0b61.onreadystatechange = function () {
@@ -1769,7 +1769,7 @@ try {
         _0x3f0b61.send();
       });
     }
-    _0x2eb1b.c9hKwCWX61TBJm_dKn0 = await _0x5eadd5();
+    _0x2eb1b.c9hKwCWX61TBJm_dKn0 = await getServerTime();
     _0x2eb1b.dehNvwBnzDqu = navigator.userAgent;
     _0x2eb1b.ctdIvSKVCQ = _0x5a4e31;
     _0x2eb1b = a0_0x36288c(_0x2eb1b);

--- a/archived_game1_scripts/2026-01-14T003915/game1.js.deobfuscated.js
+++ b/archived_game1_scripts/2026-01-14T003915/game1.js.deobfuscated.js
@@ -1108,7 +1108,7 @@ try {
       let _0x33aaeb = 0;
       _0x4ae932.oncomplete = _0x5734c3 => _0x2e449e(_0x5734c3.renderedBuffer);
       const _0x17d334 = () => {
-        setTimeout(() => _0x2bdc5a(a0_0x3907b8("timeout")), Math.min(500, _0x33aaeb + 5000 - Date.now()));
+        setTimeout(() => _0x2bdc5a(createError("timeout")), Math.min(500, _0x33aaeb + 5000 - Date.now()));
       };
       const _0x5af77e = () => {
         try {
@@ -1125,7 +1125,7 @@ try {
                 _0x371e88++;
               }
               if (_0x2a7cc4 && _0x371e88 >= 3) {
-                _0x2bdc5a(a0_0x3907b8("suspended"));
+                _0x2bdc5a(createError("suspended"));
               } else {
                 setTimeout(_0x5af77e, 500);
               }
@@ -1154,7 +1154,7 @@ try {
     }
     return _0xea2d10;
   }
-  function a0_0x3907b8(_0x4b7ed9) {
+  function createError(_0x4b7ed9) {
     const _0x4192d0 = new Error(_0x4b7ed9);
     _0x4192d0.name = _0x4b7ed9;
     return _0x4192d0;
@@ -1449,12 +1449,12 @@ try {
       const _0x4ad22e = new Uint8Array(131072);
       _0x1746ec.readPixels(0, 0, 256, 128, _0x1746ec.RGBA, _0x1746ec.UNSIGNED_BYTE, _0x4ad22e);
       let _0x502074 = JSON.stringify(_0x4ad22e).replace(/,?"[0-9]+":/g, '');
-      return a0_0x41ec8a(_0x502074);
+      return hashSHA256(_0x502074);
     } catch (_0x48e00f) {
       return '-1';
     }
   };
-  const a0_0x41ec8a = function () {
+  const hashSHA256 = function () {
     let _0x4b188b = 1;
     let _0x34277a;
     let _0x3e0d05 = [];
@@ -1776,43 +1776,43 @@ try {
   const generateRandomString = _0x62215a => {
     return new Array(_0x62215a).fill(0).map(() => Math.random().toString(36).substr(2, 9)).reduce((_0x9c7334, _0x4a01d8) => _0x9c7334 + _0x4a01d8, '');
   };
-  const a0_0x18c47c = async () => {
+  const collectFingerprint = async () => {
     const _0xd2653b = await Promise.all([checkPermissions(), enumerateMediaDevices(), getAudioFingerprint()]);
-    const _0x21b1d6 = detectBrowser();
-    const _0x2559a2 = detectOS();
-    const _0x47839b = getWebglInfo();
-    const _0xf4944d = a0_0x41ec8a(JSON.stringify(detectFonts()));
+    const detectedBrowser = detectBrowser();
+    const detectedOS = detectOS();
+    const detectedWebglInfo = getWebglInfo();
+    const _0xf4944d = hashSHA256(JSON.stringify(detectFonts()));
     const _0x3e56bb = getWebglCanvasFingerprint();
     const _0x11eaba = getCanvas2dFingerprint();
     return {
       'dg': 12,
       'dO4': Intl.DateTimeFormat().resolvedOptions().timeZone,
-      'b-I2rx-E': _0x2559a2.name,
-      'YdFB': _0x21b1d6.name,
+      'b-I2rx-E': detectedOS.name,
+      'YdFB': detectedBrowser.name,
       'dttJrRyO': navigator.vendor,
       'bdI_': navigator.deviceMemory || 0,
       'Y9JA': navigator.hardwareConcurrency || 0,
       'bM07og': navigator.languages.join(','),
-      'cNxRuCGPAg': a0_0x41ec8a(JSON.stringify(getBrowserPlugins())),
-      'Z9dM': _0x47839b.vendor + ',' + _0x47839b.renderer,
+      'cNxRuCGPAg': hashSHA256(JSON.stringify(getBrowserPlugins())),
+      'Z9dM': detectedWebglInfo.vendor + ',' + detectedWebglInfo.renderer,
       'ZtVDtyo': _0xf4944d,
-      'YdY6oxJV': a0_0x41ec8a(JSON.stringify(getAudioContextProps())),
-      'b-I4nQ-C61rI': _0x2559a2.version,
+      'YdY6oxJV': hashSHA256(JSON.stringify(getAudioContextProps())),
+      'b-I4nQ-C61rI': detectedOS.version,
       'd-BEuCA': window.screen.availWidth,
       'aM02nQV5': window.screen.availHeight,
       'bL8zohR5': Boolean(localStorage),
       'c8Y6qRuA': Boolean(sessionStorage),
-      'dt9DqBc': a0_0x41ec8a(JSON.stringify(detectVideoCodecs())),
-      'YdY6oxI': a0_0x41ec8a(JSON.stringify(detectAudioCodecs())),
-      'bdI2nwA': a0_0x41ec8a(JSON.stringify(_0xd2653b[1])),
-      'cNVHtB2QA2zbSbw': a0_0x41ec8a(JSON.stringify(_0xd2653b[0])),
+      'dt9DqBc': hashSHA256(JSON.stringify(detectVideoCodecs())),
+      'YdY6oxI': hashSHA256(JSON.stringify(detectAudioCodecs())),
+      'bdI2nwA': hashSHA256(JSON.stringify(_0xd2653b[1])),
+      'cNVHtB2QA2zbSbw': hashSHA256(JSON.stringify(_0xd2653b[0])),
       'YdY6oxJYqA': _0xd2653b[2],
       'd9w-pRFXpw': _0x3e56bb,
       'Y8QyqAl8whI': _0x11eaba,
       'YtFF': detectAutomation()
     };
   };
-  function a0_0x1ef051(_0x5e4aa8) {
+  function orderFingerprintKeys(_0x5e4aa8) {
     let _0x161b68 = [];
     FINGERPRINT_KEY_ORDER.forEach(_0x5cf230 => {
       _0x161b68.push(_0x5e4aa8[_0x5cf230]);
@@ -1845,36 +1845,36 @@ try {
     return _0x1fbbb4(_0x42b059);
   }
   var game1 = async function (_0x5651c9, _0x2ab8a1 = null) {
-    let _0x321107 = new Date().getTime();
-    let _0x548ae9 = localStorage.getItem("x-game");
+    let timeNowUnixMs = new Date().getTime();
+    let xGame = localStorage.getItem("x-game");
     let _0x5a7eea;
     let _0x2dc050;
     try {
-      let _0x84bae3 = localStorage.getItem("x-vec");
-      let _0x17d056 = _0x84bae3.lastIndexOf(" ");
-      _0x5a7eea = _0x84bae3.substr(0, _0x17d056).split('');
-      _0x2dc050 = parseInt(_0x84bae3.substr(_0x17d056 + 1));
+      let xVec = localStorage.getItem("x-vec");
+      let _0x17d056 = xVec.lastIndexOf(" ");
+      _0x5a7eea = xVec.substr(0, _0x17d056).split('');
+      _0x2dc050 = parseInt(xVec.substr(_0x17d056 + 1));
     } catch (_0x11da51) {
       _0x5a7eea = Array.from(Array(100), _0x1db483 => String.fromCharCode(32 + Math.random() * 94 | 0));
-      _0x2dc050 = _0x321107;
+      _0x2dc050 = timeNowUnixMs;
     }
     let _0x49d940 = _0x5a7eea.join('') + " " + _0x2dc050;
     localStorage.setItem('x-vec', _0x49d940);
-    if (_0x2dc050 + 1000 < _0x321107) {
+    if (_0x2dc050 + 1000 < timeNowUnixMs) {
       _0x5a7eea.shift();
       _0x5a7eea.push(String.fromCharCode(32 + Math.random() * 94 | 0));
-      _0x49d940 = _0x5a7eea.join('') + " " + _0x321107;
+      _0x49d940 = _0x5a7eea.join('') + " " + timeNowUnixMs;
       localStorage.setItem("x-vec", _0x49d940);
     }
-    if (!_0x548ae9) {
-      _0x548ae9 = generateRandomString(3);
-      localStorage.setItem("x-game", _0x548ae9);
+    if (!xGame) {
+      xGame = generateRandomString(3);
+      localStorage.setItem("x-game", xGame);
     }
-    let _0x290cfd = await a0_0x18c47c();
+    let _0x290cfd = await collectFingerprint();
     _0x290cfd.Y9U6mw9451U = new Date().toISOString();
-    _0x290cfd.depTtw = _0x548ae9;
+    _0x290cfd.depTtw = xGame;
     _0x290cfd['dts-siGT'] = window.btoa(_0x49d940);
-    _0x290cfd.ZA = new Date().getTime() - _0x321107;
+    _0x290cfd.ZA = new Date().getTime() - timeNowUnixMs;
     async function _0x24cb06() {
       return new Promise((_0x4d21e4, _0x45b997) => {
         const _0x4d1acb = new XMLHttpRequest();
@@ -1896,7 +1896,7 @@ try {
     _0x290cfd.c9hKwCWX61TBJm_dKn0 = await _0x24cb06();
     _0x290cfd.dehNvwBnzDqu = navigator.userAgent;
     _0x290cfd.ctdIvSKVCQ = _0x2ab8a1;
-    _0x290cfd = a0_0x1ef051(_0x290cfd);
+    _0x290cfd = orderFingerprintKeys(_0x290cfd);
     let _0x256400 = encodeFingerprintHash(JSON.stringify(_0x290cfd));
     _0x5651c9(_0x256400);
   };

--- a/archived_game1_scripts/2026-04-01T005630/game1.js.deobfuscated.js
+++ b/archived_game1_scripts/2026-04-01T005630/game1.js.deobfuscated.js
@@ -1101,7 +1101,7 @@ try {
       let _0x100310 = 0;
       _0x27b087.oncomplete = _0x3bd4ac => _0x3742dc(_0x3bd4ac.renderedBuffer);
       const _0x2c1ebd = () => {
-        setTimeout(() => _0x50b8b9(a0_0x7ad9db('timeout')), Math.min(500, _0x100310 + 5000 - Date.now()));
+        setTimeout(() => _0x50b8b9(createError('timeout')), Math.min(500, _0x100310 + 5000 - Date.now()));
       };
       const _0x539d94 = () => {
         try {
@@ -1118,7 +1118,7 @@ try {
                 _0x1b59a2++;
               }
               if (_0x53893d && _0x1b59a2 >= 3) {
-                _0x50b8b9(a0_0x7ad9db("suspended"));
+                _0x50b8b9(createError("suspended"));
               } else {
                 setTimeout(_0x539d94, 500);
               }
@@ -1147,7 +1147,7 @@ try {
     }
     return _0x24e974;
   }
-  function a0_0x7ad9db(_0x13c09f) {
+  function createError(_0x13c09f) {
     const _0x585ec4 = new Error(_0x13c09f);
     _0x585ec4.name = _0x13c09f;
     return _0x585ec4;
@@ -1435,12 +1435,12 @@ try {
       const _0x9ee2fe = new Uint8Array(131072);
       _0x39ba39.readPixels(0, 0, 256, 128, _0x39ba39.RGBA, _0x39ba39.UNSIGNED_BYTE, _0x9ee2fe);
       let _0x29148f = JSON.stringify(_0x9ee2fe).replace(/,?"[0-9]+":/g, '');
-      return a0_0x32c22a(_0x29148f);
+      return hashSHA256(_0x29148f);
     } catch (_0x4e7e9f) {
       return '-1';
     }
   };
-  const a0_0x32c22a = function () {
+  const hashSHA256 = function () {
     let _0x496ae0 = 1;
     let _0x5a904a;
     let _0x279b52 = [];
@@ -1763,36 +1763,36 @@ try {
   const generateRandomString = _0xa8d2bc => {
     return new Array(_0xa8d2bc).fill(0).map(() => Math.random().toString(36).substr(2, 9)).reduce((_0x361881, _0x2ce132) => _0x361881 + _0x2ce132, '');
   };
-  const a0_0x3707e2 = async () => {
+  const collectFingerprint = async () => {
     const _0x35ede7 = await Promise.all([checkPermissions(), enumerateMediaDevices(), getAudioFingerprint()]);
-    const _0x1b77ae = detectBrowser();
-    const _0x126ce4 = detectOS();
-    const _0x2e4922 = getWebglInfo();
-    const _0x401876 = a0_0x32c22a(JSON.stringify(detectFonts()));
+    const detectedBrowser = detectBrowser();
+    const detectedOS = detectOS();
+    const detectedWebglInfo = getWebglInfo();
+    const _0x401876 = hashSHA256(JSON.stringify(detectFonts()));
     const _0x11612d = getWebglCanvasFingerprint();
     const _0x2c2432 = getCanvas2dFingerprint();
     return {
       'dg': 12,
       'dO4': Intl.DateTimeFormat().resolvedOptions().timeZone,
-      'b-I2rx-E': _0x126ce4.name,
-      'YdFB': _0x1b77ae.name,
+      'b-I2rx-E': detectedOS.name,
+      'YdFB': detectedBrowser.name,
       'dttJrRyO': navigator.vendor,
       'bdI_': navigator.deviceMemory || 0,
       'Y9JA': navigator.hardwareConcurrency || 0,
       'bM07og': navigator.languages.join(','),
-      'cNxRuCGPAg': a0_0x32c22a(JSON.stringify(getBrowserPlugins())),
-      'Z9dM': _0x2e4922.vendor + ',' + _0x2e4922.renderer,
+      'cNxRuCGPAg': hashSHA256(JSON.stringify(getBrowserPlugins())),
+      'Z9dM': detectedWebglInfo.vendor + ',' + detectedWebglInfo.renderer,
       'ZtVDtyo': _0x401876,
-      'YdY6oxJV': a0_0x32c22a(JSON.stringify(getAudioContextProps())),
-      'b-I4nQ-C61rI': _0x126ce4.version,
+      'YdY6oxJV': hashSHA256(JSON.stringify(getAudioContextProps())),
+      'b-I4nQ-C61rI': detectedOS.version,
       'd-BEuCA': window.screen.availWidth,
       'aM02nQV5': window.screen.availHeight,
       'bL8zohR5': Boolean(localStorage),
       'c8Y6qRuA': Boolean(sessionStorage),
-      'dt9DqBc': a0_0x32c22a(JSON.stringify(detectVideoCodecs())),
-      'YdY6oxI': a0_0x32c22a(JSON.stringify(detectAudioCodecs())),
-      'bdI2nwA': a0_0x32c22a(JSON.stringify(_0x35ede7[1])),
-      'cNVHtB2QA2zbSbw': a0_0x32c22a(JSON.stringify(_0x35ede7[0])),
+      'dt9DqBc': hashSHA256(JSON.stringify(detectVideoCodecs())),
+      'YdY6oxI': hashSHA256(JSON.stringify(detectAudioCodecs())),
+      'bdI2nwA': hashSHA256(JSON.stringify(_0x35ede7[1])),
+      'cNVHtB2QA2zbSbw': hashSHA256(JSON.stringify(_0x35ede7[0])),
       'YdY6oxJYqA': _0x35ede7[2],
       'd9w-pRFXpw': _0x11612d,
       'Y8QyqAl8whI': _0x2c2432,
@@ -1812,7 +1812,7 @@ try {
     let _0x59edc8 = _0x357840[_0x510123];
     return _0x59edc8;
   }
-  function a0_0x2fccbc(_0x3e79d9) {
+  function orderFingerprintKeys(_0x3e79d9) {
     let _0x556f3b = [];
     FINGERPRINT_KEY_ORDER.forEach(_0x9fbed5 => {
       _0x556f3b.push(_0x3e79d9[_0x9fbed5]);
@@ -1845,37 +1845,37 @@ try {
     return _0x53abb3(_0x45f5ef);
   }
   var game1 = async function (_0x447f01, _0x3b0e5c = null) {
-    let _0x5b1de0 = new Date().getTime();
+    let timeNowUnixMs = new Date().getTime();
     let _0x3d11d7 = localStorage.getItem('x-game');
     let _0x4227f2;
     let _0xa27eb3;
     try {
-      let _0x324a4d = localStorage.getItem("x-vec");
-      let _0xc2ba33 = _0x324a4d.lastIndexOf(" ");
-      _0x4227f2 = _0x324a4d.substr(0, _0xc2ba33).split('');
-      _0xa27eb3 = parseInt(_0x324a4d.substr(_0xc2ba33 + 1));
+      let xVec = localStorage.getItem("x-vec");
+      let _0xc2ba33 = xVec.lastIndexOf(" ");
+      _0x4227f2 = xVec.substr(0, _0xc2ba33).split('');
+      _0xa27eb3 = parseInt(xVec.substr(_0xc2ba33 + 1));
     } catch (_0x5c2e3b) {
       _0x4227f2 = Array.from(Array(100), _0x402b82 => String.fromCharCode(32 + Math.random() * 94 | 0));
-      _0xa27eb3 = _0x5b1de0;
+      _0xa27eb3 = timeNowUnixMs;
     }
     let _0x8d6faa = _0x4227f2.join('') + " " + _0xa27eb3;
     localStorage.setItem('x-vec', _0x8d6faa);
-    if (_0xa27eb3 + 1000 < _0x5b1de0) {
+    if (_0xa27eb3 + 1000 < timeNowUnixMs) {
       _0x4227f2.shift();
       _0x4227f2.push(String.fromCharCode(32 + Math.random() * 94 | 0));
-      _0x8d6faa = _0x4227f2.join('') + " " + _0x5b1de0;
+      _0x8d6faa = _0x4227f2.join('') + " " + timeNowUnixMs;
       localStorage.setItem("x-vec", _0x8d6faa);
     }
     if (!_0x3d11d7) {
       _0x3d11d7 = generateRandomString(3);
       localStorage.setItem("x-game", _0x3d11d7);
     }
-    let _0x17efe9 = await a0_0x3707e2();
+    let _0x17efe9 = await collectFingerprint();
     _0x17efe9.Y9U6mw9451U = new Date().toISOString();
     _0x17efe9.depTtw = _0x3d11d7;
     _0x17efe9["dts-siGT"] = window.btoa(_0x8d6faa);
-    _0x17efe9.ZA = new Date().getTime() - _0x5b1de0;
-    async function _0x4d8aa3() {
+    _0x17efe9.ZA = new Date().getTime() - timeNowUnixMs;
+    async function getServerTime() {
       return new Promise((_0x37ad07, _0x19e783) => {
         const _0x126fb7 = new XMLHttpRequest();
         _0x126fb7.onreadystatechange = function () {
@@ -1893,10 +1893,10 @@ try {
         _0x126fb7.send();
       });
     }
-    _0x17efe9.c9hKwCWX61TBJm_dKn0 = await _0x4d8aa3();
+    _0x17efe9.c9hKwCWX61TBJm_dKn0 = await getServerTime();
     _0x17efe9.dehNvwBnzDqu = navigator.userAgent;
     _0x17efe9.ctdIvSKVCQ = _0x3b0e5c;
-    _0x17efe9 = a0_0x2fccbc(_0x17efe9);
+    _0x17efe9 = orderFingerprintKeys(_0x17efe9);
     let _0x27cdbd = encodeFingerprintHash(JSON.stringify(_0x17efe9));
     _0x447f01(_0x27cdbd);
   };

--- a/archived_game1_scripts/2026-04-02T004842/game1.js.deobfuscated.js
+++ b/archived_game1_scripts/2026-04-02T004842/game1.js.deobfuscated.js
@@ -1102,7 +1102,7 @@ try {
       let _0x7776ec = 0;
       _0x33487a.oncomplete = _0x3d97f0 => _0x524d9b(_0x3d97f0.renderedBuffer);
       const _0x32d64f = () => {
-        setTimeout(() => _0x203fe5(a0_0x55f155('timeout')), Math.min(500, _0x7776ec + 5000 - Date.now()));
+        setTimeout(() => _0x203fe5(createError('timeout')), Math.min(500, _0x7776ec + 5000 - Date.now()));
       };
       const _0x31396f = () => {
         try {
@@ -1119,7 +1119,7 @@ try {
                 _0x5b1332++;
               }
               if (_0x5707de && _0x5b1332 >= 3) {
-                _0x203fe5(a0_0x55f155('suspended'));
+                _0x203fe5(createError('suspended'));
               } else {
                 setTimeout(_0x31396f, 500);
               }
@@ -1148,7 +1148,7 @@ try {
     }
     return _0x2515e3;
   }
-  function a0_0x55f155(_0xf39073) {
+  function createError(_0xf39073) {
     const _0x20e8a9 = new Error(_0xf39073);
     _0x20e8a9.name = _0xf39073;
     return _0x20e8a9;
@@ -1435,12 +1435,12 @@ try {
       const _0x5d5e9a = new Uint8Array(131072);
       _0x28b5e4.readPixels(0, 0, 256, 128, _0x28b5e4.RGBA, _0x28b5e4.UNSIGNED_BYTE, _0x5d5e9a);
       let _0x3a0af1 = JSON.stringify(_0x5d5e9a).replace(/,?"[0-9]+":/g, '');
-      return a0_0x563112(_0x3a0af1);
+      return hashSHA256(_0x3a0af1);
     } catch (_0x18e24b) {
       return '-1';
     }
   };
-  const a0_0x563112 = function () {
+  const hashSHA256 = function () {
     let _0x107bfb = 1;
     let _0x30ef69;
     let _0x2b30ac = [];
@@ -1763,43 +1763,43 @@ try {
   const generateRandomString = _0xc2f3c5 => {
     return new Array(_0xc2f3c5).fill(0).map(() => Math.random().toString(36).substr(2, 9)).reduce((_0x1c59ec, _0x11f49e) => _0x1c59ec + _0x11f49e, '');
   };
-  const a0_0x562127 = async () => {
+  const collectFingerprint = async () => {
     const _0x54e821 = await Promise.all([checkPermissions(), enumerateMediaDevices(), getAudioFingerprint()]);
-    const _0x1f0a7d = detectBrowser();
-    const _0x1aa5fc = detectOS();
-    const _0x5e09dc = getWebglInfo();
-    const _0x378a15 = a0_0x563112(JSON.stringify(detectFonts()));
+    const detectedBrowser = detectBrowser();
+    const detectedOS = detectOS();
+    const detectedWebglInfo = getWebglInfo();
+    const _0x378a15 = hashSHA256(JSON.stringify(detectFonts()));
     const _0x17f1df = getWebglCanvasFingerprint();
     const _0x1f58c2 = getCanvas2dFingerprint();
     return {
       'dg': 12,
       'dO4': Intl.DateTimeFormat().resolvedOptions().timeZone,
-      'b-I2rx-E': _0x1aa5fc.name,
-      'YdFB': _0x1f0a7d.name,
+      'b-I2rx-E': detectedOS.name,
+      'YdFB': detectedBrowser.name,
       'dttJrRyO': navigator.vendor,
       'bdI_': navigator.deviceMemory || 0,
       'Y9JA': navigator.hardwareConcurrency || 0,
       'bM07og': navigator.languages.join(','),
-      'cNxRuCGPAg': a0_0x563112(JSON.stringify(getBrowserPlugins())),
-      'Z9dM': _0x5e09dc.vendor + ',' + _0x5e09dc.renderer,
+      'cNxRuCGPAg': hashSHA256(JSON.stringify(getBrowserPlugins())),
+      'Z9dM': detectedWebglInfo.vendor + ',' + detectedWebglInfo.renderer,
       'ZtVDtyo': _0x378a15,
-      'YdY6oxJV': a0_0x563112(JSON.stringify(getAudioContextProps())),
-      'b-I4nQ-C61rI': _0x1aa5fc.version,
+      'YdY6oxJV': hashSHA256(JSON.stringify(getAudioContextProps())),
+      'b-I4nQ-C61rI': detectedOS.version,
       'd-BEuCA': window.screen.availWidth,
       'aM02nQV5': window.screen.availHeight,
       'bL8zohR5': Boolean(localStorage),
       'c8Y6qRuA': Boolean(sessionStorage),
-      'dt9DqBc': a0_0x563112(JSON.stringify(detectVideoCodecs())),
-      'YdY6oxI': a0_0x563112(JSON.stringify(detectAudioCodecs())),
-      'bdI2nwA': a0_0x563112(JSON.stringify(_0x54e821[1])),
-      'cNVHtB2QA2zbSbw': a0_0x563112(JSON.stringify(_0x54e821[0])),
+      'dt9DqBc': hashSHA256(JSON.stringify(detectVideoCodecs())),
+      'YdY6oxI': hashSHA256(JSON.stringify(detectAudioCodecs())),
+      'bdI2nwA': hashSHA256(JSON.stringify(_0x54e821[1])),
+      'cNVHtB2QA2zbSbw': hashSHA256(JSON.stringify(_0x54e821[0])),
       'YdY6oxJYqA': _0x54e821[2],
       'd9w-pRFXpw': _0x17f1df,
       'Y8QyqAl8whI': _0x1f58c2,
       'YtFF': detectAutomation()
     };
   };
-  function a0_0x57c6de(_0x4612df) {
+  function orderFingerprintKeys(_0x4612df) {
     let _0xf0e509 = [];
     FINGERPRINT_KEY_ORDER.forEach(_0x333e20 => {
       _0xf0e509.push(_0x4612df[_0x333e20]);
@@ -1845,8 +1845,8 @@ try {
     return a0_0x2599();
   }
   var game1 = async function (_0x3ce276, _0x5eba7d = null) {
-    let _0xa4b63e = new Date().getTime();
-    let _0x41198a = localStorage.getItem("x-game");
+    let timeNowUnixMs = new Date().getTime();
+    let xGame = localStorage.getItem("x-game");
     let _0xafa61c;
     let _0x2de561;
     try {
@@ -1856,25 +1856,25 @@ try {
       _0x2de561 = parseInt(_0x3bb7c4.substr(_0x23643b + 1));
     } catch (_0x107eb6) {
       _0xafa61c = Array.from(Array(100), _0x317483 => String.fromCharCode(32 + Math.random() * 94 | 0));
-      _0x2de561 = _0xa4b63e;
+      _0x2de561 = timeNowUnixMs;
     }
     let _0x314aee = _0xafa61c.join('') + " " + _0x2de561;
     localStorage.setItem("x-vec", _0x314aee);
-    if (_0x2de561 + 1000 < _0xa4b63e) {
+    if (_0x2de561 + 1000 < timeNowUnixMs) {
       _0xafa61c.shift();
       _0xafa61c.push(String.fromCharCode(32 + Math.random() * 94 | 0));
-      _0x314aee = _0xafa61c.join('') + " " + _0xa4b63e;
+      _0x314aee = _0xafa61c.join('') + " " + timeNowUnixMs;
       localStorage.setItem("x-vec", _0x314aee);
     }
-    if (!_0x41198a) {
-      _0x41198a = generateRandomString(3);
-      localStorage.setItem("x-game", _0x41198a);
+    if (!xGame) {
+      xGame = generateRandomString(3);
+      localStorage.setItem("x-game", xGame);
     }
-    let _0x3db138 = await a0_0x562127();
+    let _0x3db138 = await collectFingerprint();
     _0x3db138.Y9U6mw9451U = new Date().toISOString();
-    _0x3db138.depTtw = _0x41198a;
+    _0x3db138.depTtw = xGame;
     _0x3db138["dts-siGT"] = window.btoa(_0x314aee);
-    _0x3db138.ZA = new Date().getTime() - _0xa4b63e;
+    _0x3db138.ZA = new Date().getTime() - timeNowUnixMs;
     async function _0x35cb1c() {
       return new Promise((_0x50e388, _0x404a90) => {
         const _0x9d3d22 = new XMLHttpRequest();
@@ -1896,7 +1896,7 @@ try {
     _0x3db138.c9hKwCWX61TBJm_dKn0 = await _0x35cb1c();
     _0x3db138.dehNvwBnzDqu = navigator.userAgent;
     _0x3db138.ctdIvSKVCQ = _0x5eba7d;
-    _0x3db138 = a0_0x57c6de(_0x3db138);
+    _0x3db138 = orderFingerprintKeys(_0x3db138);
     let _0x321a48 = encodeFingerprintHash(JSON.stringify(_0x3db138));
     _0x3ce276(_0x321a48);
   };

--- a/archived_game1_scripts/2026-04-30T010605/game1.js.deobfuscated.js
+++ b/archived_game1_scripts/2026-04-30T010605/game1.js.deobfuscated.js
@@ -1102,7 +1102,7 @@ try {
       let _0x3ef82e = 0;
       _0x2ab565.oncomplete = _0x372440 => _0x3f9f2e(_0x372440.renderedBuffer);
       const _0x18bb85 = () => {
-        setTimeout(() => _0x3183f6(a0_0x492c15("timeout")), Math.min(500, _0x3ef82e + 5000 - Date.now()));
+        setTimeout(() => _0x3183f6(createError("timeout")), Math.min(500, _0x3ef82e + 5000 - Date.now()));
       };
       const _0x23fd36 = () => {
         try {
@@ -1119,7 +1119,7 @@ try {
                 _0x30c3af++;
               }
               if (_0x52ae22 && _0x30c3af >= 3) {
-                _0x3183f6(a0_0x492c15("suspended"));
+                _0x3183f6(createError("suspended"));
               } else {
                 setTimeout(_0x23fd36, 500);
               }
@@ -1148,7 +1148,7 @@ try {
     }
     return _0x31795e;
   }
-  function a0_0x492c15(_0x37718a) {
+  function createError(_0x37718a) {
     const _0x1a5e8a = new Error(_0x37718a);
     _0x1a5e8a.name = _0x37718a;
     return _0x1a5e8a;
@@ -1441,12 +1441,12 @@ try {
       const _0x1a9379 = new Uint8Array(131072);
       _0x579f72.readPixels(0, 0, 256, 128, _0x579f72.RGBA, _0x579f72.UNSIGNED_BYTE, _0x1a9379);
       let _0x2d7d5e = JSON.stringify(_0x1a9379).replace(/,?"[0-9]+":/g, '');
-      return a0_0x2b86af(_0x2d7d5e);
+      return hashSHA256(_0x2d7d5e);
     } catch (_0x4cc5eb) {
       return '-1';
     }
   };
-  const a0_0x2b86af = function () {
+  const hashSHA256 = function () {
     let _0x171c39 = 1;
     let _0x45f5ac;
     let _0x9e2c4f = [];
@@ -1768,43 +1768,43 @@ try {
   const generateRandomString = _0x4bb7b7 => {
     return new Array(_0x4bb7b7).fill(0).map(() => Math.random().toString(36).substr(2, 9)).reduce((_0x12a106, _0x354ae4) => _0x12a106 + _0x354ae4, '');
   };
-  const a0_0x25c6db = async () => {
+  const collectFingerprint = async () => {
     const _0x5b025c = await Promise.all([checkPermissions(), enumerateMediaDevices(), getAudioFingerprint()]);
-    const _0x236a5a = detectBrowser();
-    const _0x339340 = detectOS();
-    const _0x242377 = getWebglInfo();
-    const _0x357f98 = a0_0x2b86af(JSON.stringify(detectFonts()));
+    const detectedBrowser = detectBrowser();
+    const detectedOS = detectOS();
+    const detectedWebglInfo = getWebglInfo();
+    const _0x357f98 = hashSHA256(JSON.stringify(detectFonts()));
     const _0x880f99 = getWebglCanvasFingerprint();
     const _0x531fae = getCanvas2dFingerprint();
     return {
       'dg': 12,
       'dO4': Intl.DateTimeFormat().resolvedOptions().timeZone,
-      'b-I2rx-E': _0x339340.name,
-      'YdFB': _0x236a5a.name,
+      'b-I2rx-E': detectedOS.name,
+      'YdFB': detectedBrowser.name,
       'dttJrRyO': navigator.vendor,
       'bdI_': navigator.deviceMemory || 0,
       'Y9JA': navigator.hardwareConcurrency || 0,
       'bM07og': navigator.languages.join(','),
-      'cNxRuCGPAg': a0_0x2b86af(JSON.stringify(getBrowserPlugins())),
-      'Z9dM': _0x242377.vendor + ',' + _0x242377.renderer,
+      'cNxRuCGPAg': hashSHA256(JSON.stringify(getBrowserPlugins())),
+      'Z9dM': detectedWebglInfo.vendor + ',' + detectedWebglInfo.renderer,
       'ZtVDtyo': _0x357f98,
-      'YdY6oxJV': a0_0x2b86af(JSON.stringify(getAudioContextProps())),
-      'b-I4nQ-C61rI': _0x339340.version,
+      'YdY6oxJV': hashSHA256(JSON.stringify(getAudioContextProps())),
+      'b-I4nQ-C61rI': detectedOS.version,
       'd-BEuCA': window.screen.availWidth,
       'aM02nQV5': window.screen.availHeight,
       'bL8zohR5': Boolean(localStorage),
       'c8Y6qRuA': Boolean(sessionStorage),
-      'dt9DqBc': a0_0x2b86af(JSON.stringify(detectVideoCodecs())),
-      'YdY6oxI': a0_0x2b86af(JSON.stringify(detectAudioCodecs())),
-      'bdI2nwA': a0_0x2b86af(JSON.stringify(_0x5b025c[1])),
-      'cNVHtB2QA2zbSbw': a0_0x2b86af(JSON.stringify(_0x5b025c[0])),
+      'dt9DqBc': hashSHA256(JSON.stringify(detectVideoCodecs())),
+      'YdY6oxI': hashSHA256(JSON.stringify(detectAudioCodecs())),
+      'bdI2nwA': hashSHA256(JSON.stringify(_0x5b025c[1])),
+      'cNVHtB2QA2zbSbw': hashSHA256(JSON.stringify(_0x5b025c[0])),
       'YdY6oxJYqA': _0x5b025c[2],
       'd9w-pRFXpw': _0x880f99,
       'Y8QyqAl8whI': _0x531fae,
       'YtFF': detectAutomation()
     };
   };
-  function a0_0x5b519f(_0x3fed98) {
+  function orderFingerprintKeys(_0x3fed98) {
     let _0x512619 = [];
     FINGERPRINT_KEY_ORDER.forEach(_0x2d0ad8 => {
       _0x512619.push(_0x3fed98[_0x2d0ad8]);
@@ -1844,36 +1844,36 @@ try {
     return _0x1170f5(_0x2b8154);
   }
   var game1 = async function (_0x1a8427, _0x553096 = null) {
-    let _0x53e23c = new Date().getTime();
-    let _0x3acb31 = localStorage.getItem("x-game");
+    let timeNowUnixMs = new Date().getTime();
+    let xGame = localStorage.getItem("x-game");
     let _0x1da6a9;
     let _0x46151f;
     try {
-      let _0x19f66e = localStorage.getItem("x-vec");
-      let _0x3cb2c1 = _0x19f66e.lastIndexOf(" ");
-      _0x1da6a9 = _0x19f66e.substr(0, _0x3cb2c1).split('');
-      _0x46151f = parseInt(_0x19f66e.substr(_0x3cb2c1 + 1));
+      let xVec = localStorage.getItem("x-vec");
+      let _0x3cb2c1 = xVec.lastIndexOf(" ");
+      _0x1da6a9 = xVec.substr(0, _0x3cb2c1).split('');
+      _0x46151f = parseInt(xVec.substr(_0x3cb2c1 + 1));
     } catch (_0xe2d4ac) {
       _0x1da6a9 = Array.from(Array(100), _0x7ccaab => String.fromCharCode(32 + Math.random() * 94 | 0));
-      _0x46151f = _0x53e23c;
+      _0x46151f = timeNowUnixMs;
     }
     let _0x4d026a = _0x1da6a9.join('') + " " + _0x46151f;
     localStorage.setItem("x-vec", _0x4d026a);
-    if (_0x46151f + 1000 < _0x53e23c) {
+    if (_0x46151f + 1000 < timeNowUnixMs) {
       _0x1da6a9.shift();
       _0x1da6a9.push(String.fromCharCode(32 + Math.random() * 94 | 0));
-      _0x4d026a = _0x1da6a9.join('') + " " + _0x53e23c;
+      _0x4d026a = _0x1da6a9.join('') + " " + timeNowUnixMs;
       localStorage.setItem('x-vec', _0x4d026a);
     }
-    if (!_0x3acb31) {
-      _0x3acb31 = generateRandomString(3);
-      localStorage.setItem("x-game", _0x3acb31);
+    if (!xGame) {
+      xGame = generateRandomString(3);
+      localStorage.setItem("x-game", xGame);
     }
-    let _0xaec2a5 = await a0_0x25c6db();
+    let _0xaec2a5 = await collectFingerprint();
     _0xaec2a5.Y9U6mw9451U = new Date().toISOString();
-    _0xaec2a5.depTtw = _0x3acb31;
+    _0xaec2a5.depTtw = xGame;
     _0xaec2a5['dts-siGT'] = window.btoa(_0x4d026a);
-    _0xaec2a5.ZA = new Date().getTime() - _0x53e23c;
+    _0xaec2a5.ZA = new Date().getTime() - timeNowUnixMs;
     async function _0x13cd87() {
       return new Promise((_0x31d438, _0x1450ab) => {
         const _0x56302e = new XMLHttpRequest();
@@ -1895,7 +1895,7 @@ try {
     _0xaec2a5.c9hKwCWX61TBJm_dKn0 = await _0x13cd87();
     _0xaec2a5.dehNvwBnzDqu = navigator.userAgent;
     _0xaec2a5.ctdIvSKVCQ = _0x553096;
-    _0xaec2a5 = a0_0x5b519f(_0xaec2a5);
+    _0xaec2a5 = orderFingerprintKeys(_0xaec2a5);
     let _0x625cdc = encodeFingerprintHash(JSON.stringify(_0xaec2a5));
     _0x1a8427(_0x625cdc);
   };

--- a/archived_game1_scripts/2026-05-08T010634/game1.js.deobfuscated.js
+++ b/archived_game1_scripts/2026-05-08T010634/game1.js.deobfuscated.js
@@ -1107,7 +1107,7 @@ try {
       let _0x49e0a3 = 0;
       _0xcc4a65.oncomplete = _0x4d3b2d => _0x42cb33(_0x4d3b2d.renderedBuffer);
       const _0x2e1627 = () => {
-        setTimeout(() => _0x1a6581(a0_0x50f4de('timeout')), Math.min(500, _0x49e0a3 + 5000 - Date.now()));
+        setTimeout(() => _0x1a6581(createError('timeout')), Math.min(500, _0x49e0a3 + 5000 - Date.now()));
       };
       const _0x540e4e = () => {
         try {
@@ -1124,7 +1124,7 @@ try {
                 _0x21017f++;
               }
               if (_0x5e07dc && _0x21017f >= 3) {
-                _0x1a6581(a0_0x50f4de("suspended"));
+                _0x1a6581(createError("suspended"));
               } else {
                 setTimeout(_0x540e4e, 500);
               }
@@ -1153,7 +1153,7 @@ try {
     }
     return _0x3fa3cc;
   }
-  function a0_0x50f4de(_0x4863d5) {
+  function createError(_0x4863d5) {
     const _0x118cfc = new Error(_0x4863d5);
     _0x118cfc.name = _0x4863d5;
     return _0x118cfc;
@@ -1441,12 +1441,12 @@ try {
       const _0x5b5846 = new Uint8Array(131072);
       _0x25a3f4.readPixels(0, 0, 256, 128, _0x25a3f4.RGBA, _0x25a3f4.UNSIGNED_BYTE, _0x5b5846);
       let _0x1f167e = JSON.stringify(_0x5b5846).replace(/,?"[0-9]+":/g, '');
-      return a0_0x5e8901(_0x1f167e);
+      return hashSHA256(_0x1f167e);
     } catch (_0x25cf45) {
       return '-1';
     }
   };
-  const a0_0x5e8901 = function () {
+  const hashSHA256 = function () {
     let _0x50d049 = 1;
     let _0x108c58;
     let _0x115654 = [];
@@ -1768,43 +1768,43 @@ try {
   const generateRandomString = _0x32c0ac => {
     return new Array(_0x32c0ac).fill(0).map(() => Math.random().toString(36).substr(2, 9)).reduce((_0x211572, _0x509fa7) => _0x211572 + _0x509fa7, '');
   };
-  const a0_0x43d52a = async () => {
+  const collectFingerprint = async () => {
     const _0x461136 = await Promise.all([checkPermissions(), enumerateMediaDevices(), getAudioFingerprint()]);
-    const _0x4a2b82 = detectBrowser();
-    const _0x116bfe = detectOS();
-    const _0x5c488f = getWebglInfo();
-    const _0x1041d9 = a0_0x5e8901(JSON.stringify(detectFonts()));
+    const detectedBrowser = detectBrowser();
+    const detectedOS = detectOS();
+    const detectedWebglInfo = getWebglInfo();
+    const _0x1041d9 = hashSHA256(JSON.stringify(detectFonts()));
     const _0x5f2556 = getWebglCanvasFingerprint();
     const _0x528227 = getCanvas2dFingerprint();
     return {
       'dg': 12,
       'dO4': Intl.DateTimeFormat().resolvedOptions().timeZone,
-      'b-I2rx-E': _0x116bfe.name,
-      'YdFB': _0x4a2b82.name,
+      'b-I2rx-E': detectedOS.name,
+      'YdFB': detectedBrowser.name,
       'dttJrRyO': navigator.vendor,
       'bdI_': navigator.deviceMemory || 0,
       'Y9JA': navigator.hardwareConcurrency || 0,
       'bM07og': navigator.languages.join(','),
-      'cNxRuCGPAg': a0_0x5e8901(JSON.stringify(getBrowserPlugins())),
-      'Z9dM': _0x5c488f.vendor + ',' + _0x5c488f.renderer,
+      'cNxRuCGPAg': hashSHA256(JSON.stringify(getBrowserPlugins())),
+      'Z9dM': detectedWebglInfo.vendor + ',' + detectedWebglInfo.renderer,
       'ZtVDtyo': _0x1041d9,
-      'YdY6oxJV': a0_0x5e8901(JSON.stringify(getAudioContextProps())),
-      'b-I4nQ-C61rI': _0x116bfe.version,
+      'YdY6oxJV': hashSHA256(JSON.stringify(getAudioContextProps())),
+      'b-I4nQ-C61rI': detectedOS.version,
       'd-BEuCA': window.screen.availWidth,
       'aM02nQV5': window.screen.availHeight,
       'bL8zohR5': Boolean(localStorage),
       'c8Y6qRuA': Boolean(sessionStorage),
-      'dt9DqBc': a0_0x5e8901(JSON.stringify(detectVideoCodecs())),
-      'YdY6oxI': a0_0x5e8901(JSON.stringify(detectAudioCodecs())),
-      'bdI2nwA': a0_0x5e8901(JSON.stringify(_0x461136[1])),
-      'cNVHtB2QA2zbSbw': a0_0x5e8901(JSON.stringify(_0x461136[0])),
+      'dt9DqBc': hashSHA256(JSON.stringify(detectVideoCodecs())),
+      'YdY6oxI': hashSHA256(JSON.stringify(detectAudioCodecs())),
+      'bdI2nwA': hashSHA256(JSON.stringify(_0x461136[1])),
+      'cNVHtB2QA2zbSbw': hashSHA256(JSON.stringify(_0x461136[0])),
       'YdY6oxJYqA': _0x461136[2],
       'd9w-pRFXpw': _0x5f2556,
       'Y8QyqAl8whI': _0x528227,
       'YtFF': detectAutomation()
     };
   };
-  function a0_0x131611(_0x8e3d2) {
+  function orderFingerprintKeys(_0x8e3d2) {
     let _0x446978 = [];
     FINGERPRINT_KEY_ORDER.forEach(_0x245f1c => {
       _0x446978.push(_0x8e3d2[_0x245f1c]);
@@ -1837,37 +1837,37 @@ try {
     return _0x41c20f(_0x47445f);
   }
   var game1 = async function (_0x39a95a, _0x406fd0 = null) {
-    let _0x123bd9 = new Date().getTime();
-    let _0x49c17b = localStorage.getItem("x-game");
+    let timeNowUnixMs = new Date().getTime();
+    let xGame = localStorage.getItem("x-game");
     let _0x2bf389;
     let _0x5b3a00;
     try {
-      let _0x1dc1ad = localStorage.getItem("x-vec");
-      let _0x21a80f = _0x1dc1ad.lastIndexOf(" ");
-      _0x2bf389 = _0x1dc1ad.substr(0, _0x21a80f).split('');
-      _0x5b3a00 = parseInt(_0x1dc1ad.substr(_0x21a80f + 1));
+      let xVec = localStorage.getItem("x-vec");
+      let _0x21a80f = xVec.lastIndexOf(" ");
+      _0x2bf389 = xVec.substr(0, _0x21a80f).split('');
+      _0x5b3a00 = parseInt(xVec.substr(_0x21a80f + 1));
     } catch (_0x3e2794) {
       _0x2bf389 = Array.from(Array(100), _0x111355 => String.fromCharCode(32 + Math.random() * 94 | 0));
-      _0x5b3a00 = _0x123bd9;
+      _0x5b3a00 = timeNowUnixMs;
     }
     let _0x1181df = _0x2bf389.join('') + " " + _0x5b3a00;
     localStorage.setItem('x-vec', _0x1181df);
-    if (_0x5b3a00 + 1000 < _0x123bd9) {
+    if (_0x5b3a00 + 1000 < timeNowUnixMs) {
       _0x2bf389.shift();
       _0x2bf389.push(String.fromCharCode(32 + Math.random() * 94 | 0));
-      _0x1181df = _0x2bf389.join('') + " " + _0x123bd9;
+      _0x1181df = _0x2bf389.join('') + " " + timeNowUnixMs;
       localStorage.setItem("x-vec", _0x1181df);
     }
-    if (!_0x49c17b) {
-      _0x49c17b = generateRandomString(3);
-      localStorage.setItem("x-game", _0x49c17b);
+    if (!xGame) {
+      xGame = generateRandomString(3);
+      localStorage.setItem("x-game", xGame);
     }
-    let _0x122ec0 = await a0_0x43d52a();
+    let _0x122ec0 = await collectFingerprint();
     _0x122ec0.Y9U6mw9451U = new Date().toISOString();
-    _0x122ec0.depTtw = _0x49c17b;
+    _0x122ec0.depTtw = xGame;
     _0x122ec0["dts-siGT"] = window.btoa(_0x1181df);
-    _0x122ec0.ZA = new Date().getTime() - _0x123bd9;
-    async function _0x39dfb5() {
+    _0x122ec0.ZA = new Date().getTime() - timeNowUnixMs;
+    async function getServerTime() {
       return new Promise((_0x2fcb19, _0x53b404) => {
         const _0x2c97b7 = new XMLHttpRequest();
         _0x2c97b7.onreadystatechange = function () {
@@ -1885,10 +1885,10 @@ try {
         _0x2c97b7.send();
       });
     }
-    _0x122ec0.c9hKwCWX61TBJm_dKn0 = await _0x39dfb5();
+    _0x122ec0.c9hKwCWX61TBJm_dKn0 = await getServerTime();
     _0x122ec0.dehNvwBnzDqu = navigator.userAgent;
     _0x122ec0.ctdIvSKVCQ = _0x406fd0;
-    _0x122ec0 = a0_0x131611(_0x122ec0);
+    _0x122ec0 = orderFingerprintKeys(_0x122ec0);
     let _0x4593e5 = encodeFingerprintHash(JSON.stringify(_0x122ec0));
     _0x39a95a(_0x4593e5);
   };

--- a/archived_game1_scripts/2026-05-13T011015/game1.js.deobfuscated.js
+++ b/archived_game1_scripts/2026-05-13T011015/game1.js.deobfuscated.js
@@ -1107,7 +1107,7 @@ try {
       let _0x52cacf = 0;
       _0x2c054f.oncomplete = _0xebe59a => _0x212cb3(_0xebe59a.renderedBuffer);
       const _0x9cd96d = () => {
-        setTimeout(() => _0xc18f9f(a0_0x4d44f3("timeout")), Math.min(500, _0x52cacf + 5000 - Date.now()));
+        setTimeout(() => _0xc18f9f(createError("timeout")), Math.min(500, _0x52cacf + 5000 - Date.now()));
       };
       const _0x165d8f = () => {
         try {
@@ -1124,7 +1124,7 @@ try {
                 _0x481d08++;
               }
               if (_0x52c9c4 && _0x481d08 >= 3) {
-                _0xc18f9f(a0_0x4d44f3('suspended'));
+                _0xc18f9f(createError('suspended'));
               } else {
                 setTimeout(_0x165d8f, 500);
               }
@@ -1153,7 +1153,7 @@ try {
     }
     return _0xf9755a;
   }
-  function a0_0x4d44f3(_0x347edf) {
+  function createError(_0x347edf) {
     const _0x4fc17d = new Error(_0x347edf);
     _0x4fc17d.name = _0x347edf;
     return _0x4fc17d;
@@ -1440,12 +1440,12 @@ try {
       const _0x36b95c = new Uint8Array(131072);
       _0x16f5f7.readPixels(0, 0, 256, 128, _0x16f5f7.RGBA, _0x16f5f7.UNSIGNED_BYTE, _0x36b95c);
       let _0x36a8c1 = JSON.stringify(_0x36b95c).replace(/,?"[0-9]+":/g, '');
-      return a0_0x1a3735(_0x36a8c1);
+      return hashSHA256(_0x36a8c1);
     } catch (_0x40c53e) {
       return '-1';
     }
   };
-  const a0_0x1a3735 = function () {
+  const hashSHA256 = function () {
     let _0x46736d = 1;
     let _0x4b0efe;
     let _0xf5404c = [];
@@ -1767,43 +1767,43 @@ try {
   const generateRandomString = _0xa1f2ca => {
     return new Array(_0xa1f2ca).fill(0).map(() => Math.random().toString(36).substr(2, 9)).reduce((_0x34cdff, _0xe0937c) => _0x34cdff + _0xe0937c, '');
   };
-  const a0_0x20499a = async () => {
+  const collectFingerprint = async () => {
     const _0x186cfa = await Promise.all([checkPermissions(), enumerateMediaDevices(), getAudioFingerprint()]);
-    const _0x4217af = detectBrowser();
-    const _0x393997 = detectOS();
-    const _0x3e908c = getWebglInfo();
-    const _0x5218da = a0_0x1a3735(JSON.stringify(detectFonts()));
+    const detectedBrowser = detectBrowser();
+    const detectedOS = detectOS();
+    const detectedWebglInfo = getWebglInfo();
+    const _0x5218da = hashSHA256(JSON.stringify(detectFonts()));
     const _0x48bf4b = getWebglCanvasFingerprint();
     const _0x42ff92 = getCanvas2dFingerprint();
     return {
       'dg': 12,
       'dO4': Intl.DateTimeFormat().resolvedOptions().timeZone,
-      'b-I2rx-E': _0x393997.name,
-      'YdFB': _0x4217af.name,
+      'b-I2rx-E': detectedOS.name,
+      'YdFB': detectedBrowser.name,
       'dttJrRyO': navigator.vendor,
       'bdI_': navigator.deviceMemory || 0,
       'Y9JA': navigator.hardwareConcurrency || 0,
       'bM07og': navigator.languages.join(','),
-      'cNxRuCGPAg': a0_0x1a3735(JSON.stringify(getBrowserPlugins())),
-      'Z9dM': _0x3e908c.vendor + ',' + _0x3e908c.renderer,
+      'cNxRuCGPAg': hashSHA256(JSON.stringify(getBrowserPlugins())),
+      'Z9dM': detectedWebglInfo.vendor + ',' + detectedWebglInfo.renderer,
       'ZtVDtyo': _0x5218da,
-      'YdY6oxJV': a0_0x1a3735(JSON.stringify(getAudioContextProps())),
-      'b-I4nQ-C61rI': _0x393997.version,
+      'YdY6oxJV': hashSHA256(JSON.stringify(getAudioContextProps())),
+      'b-I4nQ-C61rI': detectedOS.version,
       'd-BEuCA': window.screen.availWidth,
       'aM02nQV5': window.screen.availHeight,
       'bL8zohR5': Boolean(localStorage),
       'c8Y6qRuA': Boolean(sessionStorage),
-      'dt9DqBc': a0_0x1a3735(JSON.stringify(detectVideoCodecs())),
-      'YdY6oxI': a0_0x1a3735(JSON.stringify(detectAudioCodecs())),
-      'bdI2nwA': a0_0x1a3735(JSON.stringify(_0x186cfa[1])),
-      'cNVHtB2QA2zbSbw': a0_0x1a3735(JSON.stringify(_0x186cfa[0])),
+      'dt9DqBc': hashSHA256(JSON.stringify(detectVideoCodecs())),
+      'YdY6oxI': hashSHA256(JSON.stringify(detectAudioCodecs())),
+      'bdI2nwA': hashSHA256(JSON.stringify(_0x186cfa[1])),
+      'cNVHtB2QA2zbSbw': hashSHA256(JSON.stringify(_0x186cfa[0])),
       'YdY6oxJYqA': _0x186cfa[2],
       'd9w-pRFXpw': _0x48bf4b,
       'Y8QyqAl8whI': _0x42ff92,
       'YtFF': detectAutomation()
     };
   };
-  function a0_0x98f360(_0x152865) {
+  function orderFingerprintKeys(_0x152865) {
     let _0x72982f = [];
     FINGERPRINT_KEY_ORDER.forEach(_0x30966f => {
       _0x72982f.push(_0x152865[_0x30966f]);
@@ -1843,36 +1843,36 @@ try {
     return _0x3b3ac5(_0x117561);
   }
   var game1 = async function (_0x242df1, _0x3b7aae = null) {
-    let _0x4e8adb = new Date().getTime();
-    let _0x4a04ff = localStorage.getItem("x-game");
+    let timeNowUnixMs = new Date().getTime();
+    let xGame = localStorage.getItem("x-game");
     let _0x351003;
     let _0x4f9e18;
     try {
-      let _0x2b72f3 = localStorage.getItem("x-vec");
-      let _0x57c2a1 = _0x2b72f3.lastIndexOf(" ");
-      _0x351003 = _0x2b72f3.substr(0, _0x57c2a1).split('');
-      _0x4f9e18 = parseInt(_0x2b72f3.substr(_0x57c2a1 + 1));
+      let xVec = localStorage.getItem("x-vec");
+      let _0x57c2a1 = xVec.lastIndexOf(" ");
+      _0x351003 = xVec.substr(0, _0x57c2a1).split('');
+      _0x4f9e18 = parseInt(xVec.substr(_0x57c2a1 + 1));
     } catch (_0x362a96) {
       _0x351003 = Array.from(Array(100), _0x3f4fec => String.fromCharCode(32 + Math.random() * 94 | 0));
-      _0x4f9e18 = _0x4e8adb;
+      _0x4f9e18 = timeNowUnixMs;
     }
     let _0x1c53a4 = _0x351003.join('') + " " + _0x4f9e18;
     localStorage.setItem("x-vec", _0x1c53a4);
-    if (_0x4f9e18 + 1000 < _0x4e8adb) {
+    if (_0x4f9e18 + 1000 < timeNowUnixMs) {
       _0x351003.shift();
       _0x351003.push(String.fromCharCode(32 + Math.random() * 94 | 0));
-      _0x1c53a4 = _0x351003.join('') + " " + _0x4e8adb;
+      _0x1c53a4 = _0x351003.join('') + " " + timeNowUnixMs;
       localStorage.setItem("x-vec", _0x1c53a4);
     }
-    if (!_0x4a04ff) {
-      _0x4a04ff = generateRandomString(3);
-      localStorage.setItem("x-game", _0x4a04ff);
+    if (!xGame) {
+      xGame = generateRandomString(3);
+      localStorage.setItem("x-game", xGame);
     }
-    let _0x1cbec3 = await a0_0x20499a();
+    let _0x1cbec3 = await collectFingerprint();
     _0x1cbec3.Y9U6mw9451U = new Date().toISOString();
-    _0x1cbec3.depTtw = _0x4a04ff;
+    _0x1cbec3.depTtw = xGame;
     _0x1cbec3["dts-siGT"] = window.btoa(_0x1c53a4);
-    _0x1cbec3.ZA = new Date().getTime() - _0x4e8adb;
+    _0x1cbec3.ZA = new Date().getTime() - timeNowUnixMs;
     async function _0x102006() {
       return new Promise((_0x1295ad, _0x4e4f07) => {
         const _0x384876 = new XMLHttpRequest();
@@ -1894,7 +1894,7 @@ try {
     _0x1cbec3.c9hKwCWX61TBJm_dKn0 = await _0x102006();
     _0x1cbec3.dehNvwBnzDqu = navigator.userAgent;
     _0x1cbec3.ctdIvSKVCQ = _0x3b7aae;
-    _0x1cbec3 = a0_0x98f360(_0x1cbec3);
+    _0x1cbec3 = orderFingerprintKeys(_0x1cbec3);
     let _0x362e6b = encodeFingerprintHash(JSON.stringify(_0x1cbec3));
     _0x242df1(_0x362e6b);
   };

--- a/archived_game1_scripts/2026-05-20T011525/game1.js.deobfuscated.js
+++ b/archived_game1_scripts/2026-05-20T011525/game1.js.deobfuscated.js
@@ -1115,7 +1115,7 @@ try {
       let _0x12c798 = 0;
       _0x241498.oncomplete = _0x38015c => _0x209a37(_0x38015c.renderedBuffer);
       const _0x4c75e9 = () => {
-        setTimeout(() => _0x26abcf(a0_0x47dc3e("timeout")), Math.min(500, _0x12c798 + 5000 - Date.now()));
+        setTimeout(() => _0x26abcf(createError("timeout")), Math.min(500, _0x12c798 + 5000 - Date.now()));
       };
       const _0x1df3da = () => {
         try {
@@ -1132,7 +1132,7 @@ try {
                 _0x86cf58++;
               }
               if (_0x2fb57f && _0x86cf58 >= 3) {
-                _0x26abcf(a0_0x47dc3e("suspended"));
+                _0x26abcf(createError("suspended"));
               } else {
                 setTimeout(_0x1df3da, 500);
               }
@@ -1161,7 +1161,7 @@ try {
     }
     return _0x26f34c;
   }
-  function a0_0x47dc3e(_0x5cb51c) {
+  function createError(_0x5cb51c) {
     const _0x2d958a = new Error(_0x5cb51c);
     _0x2d958a.name = _0x5cb51c;
     return _0x2d958a;
@@ -1449,12 +1449,12 @@ try {
       const _0x11e5f8 = new Uint8Array(131072);
       _0x435e64.readPixels(0, 0, 256, 128, _0x435e64.RGBA, _0x435e64.UNSIGNED_BYTE, _0x11e5f8);
       let _0x43b056 = JSON.stringify(_0x11e5f8).replace(/,?"[0-9]+":/g, '');
-      return a0_0x22c935(_0x43b056);
+      return hashSHA256(_0x43b056);
     } catch (_0x469edd) {
       return '-1';
     }
   };
-  const a0_0x22c935 = function () {
+  const hashSHA256 = function () {
     let _0x2c8504 = 1;
     let _0x1aaab2;
     let _0x506879 = [];
@@ -1777,43 +1777,43 @@ try {
   const generateRandomString = _0x51c359 => {
     return new Array(_0x51c359).fill(0).map(() => Math.random().toString(36).substr(2, 9)).reduce((_0x56400b, _0x184183) => _0x56400b + _0x184183, '');
   };
-  const a0_0x5d95bf = async () => {
+  const collectFingerprint = async () => {
     const _0x9026b0 = await Promise.all([checkPermissions(), enumerateMediaDevices(), getAudioFingerprint()]);
-    const _0x353416 = detectBrowser();
-    const _0x589745 = detectOS();
-    const _0x2db387 = getWebglInfo();
-    const _0x26ccf3 = a0_0x22c935(JSON.stringify(detectFonts()));
+    const detectedBrowser = detectBrowser();
+    const detectedOS = detectOS();
+    const detectedWebglInfo = getWebglInfo();
+    const _0x26ccf3 = hashSHA256(JSON.stringify(detectFonts()));
     const _0x11deed = getWebglCanvasFingerprint();
     const _0x482516 = getCanvas2dFingerprint();
     return {
       'dg': 12,
       'dO4': Intl.DateTimeFormat().resolvedOptions().timeZone,
-      'b-I2rx-E': _0x589745.name,
-      'YdFB': _0x353416.name,
+      'b-I2rx-E': detectedOS.name,
+      'YdFB': detectedBrowser.name,
       'dttJrRyO': navigator.vendor,
       'bdI_': navigator.deviceMemory || 0,
       'Y9JA': navigator.hardwareConcurrency || 0,
       'bM07og': navigator.languages.join(','),
-      'cNxRuCGPAg': a0_0x22c935(JSON.stringify(getBrowserPlugins())),
-      'Z9dM': _0x2db387.vendor + ',' + _0x2db387.renderer,
+      'cNxRuCGPAg': hashSHA256(JSON.stringify(getBrowserPlugins())),
+      'Z9dM': detectedWebglInfo.vendor + ',' + detectedWebglInfo.renderer,
       'ZtVDtyo': _0x26ccf3,
-      'YdY6oxJV': a0_0x22c935(JSON.stringify(getAudioContextProps())),
-      'b-I4nQ-C61rI': _0x589745.version,
+      'YdY6oxJV': hashSHA256(JSON.stringify(getAudioContextProps())),
+      'b-I4nQ-C61rI': detectedOS.version,
       'd-BEuCA': window.screen.availWidth,
       'aM02nQV5': window.screen.availHeight,
       'bL8zohR5': Boolean(localStorage),
       'c8Y6qRuA': Boolean(sessionStorage),
-      'dt9DqBc': a0_0x22c935(JSON.stringify(detectVideoCodecs())),
-      'YdY6oxI': a0_0x22c935(JSON.stringify(detectAudioCodecs())),
-      'bdI2nwA': a0_0x22c935(JSON.stringify(_0x9026b0[1])),
-      'cNVHtB2QA2zbSbw': a0_0x22c935(JSON.stringify(_0x9026b0[0])),
+      'dt9DqBc': hashSHA256(JSON.stringify(detectVideoCodecs())),
+      'YdY6oxI': hashSHA256(JSON.stringify(detectAudioCodecs())),
+      'bdI2nwA': hashSHA256(JSON.stringify(_0x9026b0[1])),
+      'cNVHtB2QA2zbSbw': hashSHA256(JSON.stringify(_0x9026b0[0])),
       'YdY6oxJYqA': _0x9026b0[2],
       'd9w-pRFXpw': _0x11deed,
       'Y8QyqAl8whI': _0x482516,
       'YtFF': detectAutomation()
     };
   };
-  function a0_0x387a15(_0x4832ae) {
+  function orderFingerprintKeys(_0x4832ae) {
     let _0x154435 = [];
     FINGERPRINT_KEY_ORDER.forEach(_0x1ec555 => {
       _0x154435.push(_0x4832ae[_0x1ec555]);
@@ -1846,36 +1846,36 @@ try {
     return _0x3345da(_0x329747);
   }
   var game1 = async function (_0x15e743, _0x209565 = null) {
-    let _0x2313a7 = new Date().getTime();
-    let _0x2a2bb6 = localStorage.getItem("x-game");
+    let timeNowUnixMs = new Date().getTime();
+    let xGame = localStorage.getItem("x-game");
     let _0x54a606;
     let _0x585db4;
     try {
-      let _0x3a9e05 = localStorage.getItem("x-vec");
-      let _0x28eaad = _0x3a9e05.lastIndexOf(" ");
-      _0x54a606 = _0x3a9e05.substr(0, _0x28eaad).split('');
-      _0x585db4 = parseInt(_0x3a9e05.substr(_0x28eaad + 1));
+      let xVec = localStorage.getItem("x-vec");
+      let _0x28eaad = xVec.lastIndexOf(" ");
+      _0x54a606 = xVec.substr(0, _0x28eaad).split('');
+      _0x585db4 = parseInt(xVec.substr(_0x28eaad + 1));
     } catch (_0x57e297) {
       _0x54a606 = Array.from(Array(100), _0x1d8b65 => String.fromCharCode(32 + Math.random() * 94 | 0));
-      _0x585db4 = _0x2313a7;
+      _0x585db4 = timeNowUnixMs;
     }
     let _0x447707 = _0x54a606.join('') + " " + _0x585db4;
     localStorage.setItem("x-vec", _0x447707);
-    if (_0x585db4 + 1000 < _0x2313a7) {
+    if (_0x585db4 + 1000 < timeNowUnixMs) {
       _0x54a606.shift();
       _0x54a606.push(String.fromCharCode(32 + Math.random() * 94 | 0));
-      _0x447707 = _0x54a606.join('') + " " + _0x2313a7;
+      _0x447707 = _0x54a606.join('') + " " + timeNowUnixMs;
       localStorage.setItem('x-vec', _0x447707);
     }
-    if (!_0x2a2bb6) {
-      _0x2a2bb6 = generateRandomString(3);
-      localStorage.setItem('x-game', _0x2a2bb6);
+    if (!xGame) {
+      xGame = generateRandomString(3);
+      localStorage.setItem('x-game', xGame);
     }
-    let _0xe8e478 = await a0_0x5d95bf();
+    let _0xe8e478 = await collectFingerprint();
     _0xe8e478.Y9U6mw9451U = new Date().toISOString();
-    _0xe8e478.depTtw = _0x2a2bb6;
+    _0xe8e478.depTtw = xGame;
     _0xe8e478["dts-siGT"] = window.btoa(_0x447707);
-    _0xe8e478.ZA = new Date().getTime() - _0x2313a7;
+    _0xe8e478.ZA = new Date().getTime() - timeNowUnixMs;
     async function _0xd56507() {
       return new Promise((_0x478ca3, _0x2e6ed2) => {
         const _0xf7df53 = new XMLHttpRequest();
@@ -1897,7 +1897,7 @@ try {
     _0xe8e478.c9hKwCWX61TBJm_dKn0 = await _0xd56507();
     _0xe8e478.dehNvwBnzDqu = navigator.userAgent;
     _0xe8e478.ctdIvSKVCQ = _0x209565;
-    _0xe8e478 = a0_0x387a15(_0xe8e478);
+    _0xe8e478 = orderFingerprintKeys(_0xe8e478);
     let _0x5bf706 = encodeFingerprintHash(JSON.stringify(_0xe8e478));
     _0x15e743(_0x5bf706);
   };

--- a/archived_game1_scripts/2026-06-24T011007/game1.js.deobfuscated.js
+++ b/archived_game1_scripts/2026-06-24T011007/game1.js.deobfuscated.js
@@ -1108,7 +1108,7 @@ try {
       let _0x4f44d4 = 0;
       _0x2d842f.oncomplete = _0x3efecc => _0x51b03d(_0x3efecc.renderedBuffer);
       const _0x2cb730 = () => {
-        setTimeout(() => _0x40424c(a0_0x26fbd7("timeout")), Math.min(500, _0x4f44d4 + 5000 - Date.now()));
+        setTimeout(() => _0x40424c(createError("timeout")), Math.min(500, _0x4f44d4 + 5000 - Date.now()));
       };
       const _0x5aee26 = () => {
         try {
@@ -1125,7 +1125,7 @@ try {
                 _0x4548ca++;
               }
               if (_0x566eea && _0x4548ca >= 3) {
-                _0x40424c(a0_0x26fbd7("suspended"));
+                _0x40424c(createError("suspended"));
               } else {
                 setTimeout(_0x5aee26, 500);
               }
@@ -1154,7 +1154,7 @@ try {
     }
     return _0x18331c;
   }
-  function a0_0x26fbd7(_0xcf80b3) {
+  function createError(_0xcf80b3) {
     const _0x4d1550 = new Error(_0xcf80b3);
     _0x4d1550.name = _0xcf80b3;
     return _0x4d1550;
@@ -1442,12 +1442,12 @@ try {
       const _0x36de5a = new Uint8Array(131072);
       _0x1a0787.readPixels(0, 0, 256, 128, _0x1a0787.RGBA, _0x1a0787.UNSIGNED_BYTE, _0x36de5a);
       let _0x406419 = JSON.stringify(_0x36de5a).replace(/,?"[0-9]+":/g, '');
-      return a0_0x41c694(_0x406419);
+      return hashSHA256(_0x406419);
     } catch (_0x5b02e6) {
       return '-1';
     }
   };
-  const a0_0x41c694 = function () {
+  const hashSHA256 = function () {
     let _0x5637ca = 1;
     let _0x38104d;
     let _0x167dbc = [];
@@ -1770,43 +1770,43 @@ try {
   const generateRandomString = _0x1394ba => {
     return new Array(_0x1394ba).fill(0).map(() => Math.random().toString(36).substr(2, 9)).reduce((_0x1c56b2, _0x4de8c6) => _0x1c56b2 + _0x4de8c6, '');
   };
-  const a0_0x1874d0 = async () => {
+  const collectFingerprint = async () => {
     const _0x53b35a = await Promise.all([checkPermissions(), enumerateMediaDevices(), getAudioFingerprint()]);
-    const _0x581e12 = detectBrowser();
-    const _0x37547e = detectOS();
-    const _0x2e1dd8 = getWebglInfo();
-    const _0x22c36c = a0_0x41c694(JSON.stringify(detectFonts()));
+    const detectedBrowser = detectBrowser();
+    const detectedOS = detectOS();
+    const detectedWebglInfo = getWebglInfo();
+    const _0x22c36c = hashSHA256(JSON.stringify(detectFonts()));
     const _0x61bd34 = getWebglCanvasFingerprint();
     const _0x18d1ea = getCanvas2dFingerprint();
     return {
       'dg': 12,
       'dO4': Intl.DateTimeFormat().resolvedOptions().timeZone,
-      'b-I2rx-E': _0x37547e.name,
-      'YdFB': _0x581e12.name,
+      'b-I2rx-E': detectedOS.name,
+      'YdFB': detectedBrowser.name,
       'dttJrRyO': navigator.vendor,
       'bdI_': navigator.deviceMemory || 0,
       'Y9JA': navigator.hardwareConcurrency || 0,
       'bM07og': navigator.languages.join(','),
-      'cNxRuCGPAg': a0_0x41c694(JSON.stringify(getBrowserPlugins())),
-      'Z9dM': _0x2e1dd8.vendor + ',' + _0x2e1dd8.renderer,
+      'cNxRuCGPAg': hashSHA256(JSON.stringify(getBrowserPlugins())),
+      'Z9dM': detectedWebglInfo.vendor + ',' + detectedWebglInfo.renderer,
       'ZtVDtyo': _0x22c36c,
-      'YdY6oxJV': a0_0x41c694(JSON.stringify(getAudioContextProps())),
-      'b-I4nQ-C61rI': _0x37547e.version,
+      'YdY6oxJV': hashSHA256(JSON.stringify(getAudioContextProps())),
+      'b-I4nQ-C61rI': detectedOS.version,
       'd-BEuCA': window.screen.availWidth,
       'aM02nQV5': window.screen.availHeight,
       'bL8zohR5': Boolean(localStorage),
       'c8Y6qRuA': Boolean(sessionStorage),
-      'dt9DqBc': a0_0x41c694(JSON.stringify(detectVideoCodecs())),
-      'YdY6oxI': a0_0x41c694(JSON.stringify(detectAudioCodecs())),
-      'bdI2nwA': a0_0x41c694(JSON.stringify(_0x53b35a[1])),
-      'cNVHtB2QA2zbSbw': a0_0x41c694(JSON.stringify(_0x53b35a[0])),
+      'dt9DqBc': hashSHA256(JSON.stringify(detectVideoCodecs())),
+      'YdY6oxI': hashSHA256(JSON.stringify(detectAudioCodecs())),
+      'bdI2nwA': hashSHA256(JSON.stringify(_0x53b35a[1])),
+      'cNVHtB2QA2zbSbw': hashSHA256(JSON.stringify(_0x53b35a[0])),
       'YdY6oxJYqA': _0x53b35a[2],
       'd9w-pRFXpw': _0x61bd34,
       'Y8QyqAl8whI': _0x18d1ea,
       'YtFF': detectAutomation()
     };
   };
-  function a0_0x5d8cc5(_0x41764b) {
+  function orderFingerprintKeys(_0x41764b) {
     let _0x311489 = [];
     FINGERPRINT_KEY_ORDER.forEach(_0x110355 => {
       _0x311489.push(_0x41764b[_0x110355]);
@@ -1846,8 +1846,8 @@ try {
     return a0_0x4eae();
   }
   var game1 = async function (_0x39cc81, _0x48535f = null) {
-    let _0x2ba5c7 = new Date().getTime();
-    let _0x56cc74 = localStorage.getItem("x-game");
+    let timeNowUnixMs = new Date().getTime();
+    let xGame = localStorage.getItem("x-game");
     let _0x3f8c66;
     let _0x567f94;
     try {
@@ -1857,25 +1857,25 @@ try {
       _0x567f94 = parseInt(_0x2372db.substr(_0x395d2 + 1));
     } catch (_0x5db8ca) {
       _0x3f8c66 = Array.from(Array(100), _0x1c1082 => String.fromCharCode(32 + Math.random() * 94 | 0));
-      _0x567f94 = _0x2ba5c7;
+      _0x567f94 = timeNowUnixMs;
     }
     let _0x23e9cf = _0x3f8c66.join('') + " " + _0x567f94;
     localStorage.setItem("x-vec", _0x23e9cf);
-    if (_0x567f94 + 1000 < _0x2ba5c7) {
+    if (_0x567f94 + 1000 < timeNowUnixMs) {
       _0x3f8c66.shift();
       _0x3f8c66.push(String.fromCharCode(32 + Math.random() * 94 | 0));
-      _0x23e9cf = _0x3f8c66.join('') + " " + _0x2ba5c7;
+      _0x23e9cf = _0x3f8c66.join('') + " " + timeNowUnixMs;
       localStorage.setItem("x-vec", _0x23e9cf);
     }
-    if (!_0x56cc74) {
-      _0x56cc74 = generateRandomString(3);
-      localStorage.setItem("x-game", _0x56cc74);
+    if (!xGame) {
+      xGame = generateRandomString(3);
+      localStorage.setItem("x-game", xGame);
     }
-    let _0x527acf = await a0_0x1874d0();
+    let _0x527acf = await collectFingerprint();
     _0x527acf.Y9U6mw9451U = new Date().toISOString();
-    _0x527acf.depTtw = _0x56cc74;
+    _0x527acf.depTtw = xGame;
     _0x527acf["dts-siGT"] = window.btoa(_0x23e9cf);
-    _0x527acf.ZA = new Date().getTime() - _0x2ba5c7;
+    _0x527acf.ZA = new Date().getTime() - timeNowUnixMs;
     async function _0x5e0733() {
       return new Promise((_0x390e7f, _0xf91840) => {
         const _0x1da321 = new XMLHttpRequest();
@@ -1897,7 +1897,7 @@ try {
     _0x527acf.c9hKwCWX61TBJm_dKn0 = await _0x5e0733();
     _0x527acf.dehNvwBnzDqu = navigator.userAgent;
     _0x527acf.ctdIvSKVCQ = _0x48535f;
-    _0x527acf = a0_0x5d8cc5(_0x527acf);
+    _0x527acf = orderFingerprintKeys(_0x527acf);
     let _0x2c439e = encodeFingerprintHash(JSON.stringify(_0x527acf));
     _0x39cc81(_0x2c439e);
   };

--- a/archived_game1_scripts/2026-07-01T011942/game1.js.deobfuscated.js
+++ b/archived_game1_scripts/2026-07-01T011942/game1.js.deobfuscated.js
@@ -1107,7 +1107,7 @@ try {
       let _0x14f32c = 0;
       _0x314c6c.oncomplete = _0x38a4a5 => _0x3e460e(_0x38a4a5.renderedBuffer);
       const _0x11a72d = () => {
-        setTimeout(() => _0x29fdd5(a0_0xa64da6("timeout")), Math.min(500, _0x14f32c + 5000 - Date.now()));
+        setTimeout(() => _0x29fdd5(createError("timeout")), Math.min(500, _0x14f32c + 5000 - Date.now()));
       };
       const _0x5d31f1 = () => {
         try {
@@ -1124,7 +1124,7 @@ try {
                 _0x20c801++;
               }
               if (_0x5a0037 && _0x20c801 >= 3) {
-                _0x29fdd5(a0_0xa64da6("suspended"));
+                _0x29fdd5(createError("suspended"));
               } else {
                 setTimeout(_0x5d31f1, 500);
               }
@@ -1160,7 +1160,7 @@ try {
     };
     return a0_0x523b();
   }
-  function a0_0xa64da6(_0x183929) {
+  function createError(_0x183929) {
     const _0x5effed = new Error(_0x183929);
     _0x5effed.name = _0x183929;
     return _0x5effed;
@@ -1448,12 +1448,12 @@ try {
       const _0x140cd3 = new Uint8Array(131072);
       _0x2f53c7.readPixels(0, 0, 256, 128, _0x2f53c7.RGBA, _0x2f53c7.UNSIGNED_BYTE, _0x140cd3);
       let _0x42d6ed = JSON.stringify(_0x140cd3).replace(/,?"[0-9]+":/g, '');
-      return a0_0x4cca20(_0x42d6ed);
+      return hashSHA256(_0x42d6ed);
     } catch (_0x376a11) {
       return '-1';
     }
   };
-  const a0_0x4cca20 = function () {
+  const hashSHA256 = function () {
     let _0x5c7aa6 = 1;
     let _0xdcba9e;
     let _0x243e02 = [];
@@ -1775,43 +1775,43 @@ try {
   const generateRandomString = _0x35b012 => {
     return new Array(_0x35b012).fill(0).map(() => Math.random().toString(36).substr(2, 9)).reduce((_0x27b1e8, _0x59e099) => _0x27b1e8 + _0x59e099, '');
   };
-  const a0_0x385393 = async () => {
+  const collectFingerprint = async () => {
     const _0x242fb1 = await Promise.all([checkPermissions(), enumerateMediaDevices(), getAudioFingerprint()]);
-    const _0x3a3483 = detectBrowser();
-    const _0x1f0b0c = detectOS();
-    const _0x3668f3 = getWebglInfo();
-    const _0x1d0eda = a0_0x4cca20(JSON.stringify(detectFonts()));
+    const detectedBrowser = detectBrowser();
+    const detectedOS = detectOS();
+    const detectedWebglInfo = getWebglInfo();
+    const _0x1d0eda = hashSHA256(JSON.stringify(detectFonts()));
     const _0x141f60 = getWebglCanvasFingerprint();
     const _0x4b575c = getCanvas2dFingerprint();
     return {
       'dg': 12,
       'dO4': Intl.DateTimeFormat().resolvedOptions().timeZone,
-      'b-I2rx-E': _0x1f0b0c.name,
-      'YdFB': _0x3a3483.name,
+      'b-I2rx-E': detectedOS.name,
+      'YdFB': detectedBrowser.name,
       'dttJrRyO': navigator.vendor,
       'bdI_': navigator.deviceMemory || 0,
       'Y9JA': navigator.hardwareConcurrency || 0,
       'bM07og': navigator.languages.join(','),
-      'cNxRuCGPAg': a0_0x4cca20(JSON.stringify(getBrowserPlugins())),
-      'Z9dM': _0x3668f3.vendor + ',' + _0x3668f3.renderer,
+      'cNxRuCGPAg': hashSHA256(JSON.stringify(getBrowserPlugins())),
+      'Z9dM': detectedWebglInfo.vendor + ',' + detectedWebglInfo.renderer,
       'ZtVDtyo': _0x1d0eda,
-      'YdY6oxJV': a0_0x4cca20(JSON.stringify(getAudioContextProps())),
-      'b-I4nQ-C61rI': _0x1f0b0c.version,
+      'YdY6oxJV': hashSHA256(JSON.stringify(getAudioContextProps())),
+      'b-I4nQ-C61rI': detectedOS.version,
       'd-BEuCA': window.screen.availWidth,
       'aM02nQV5': window.screen.availHeight,
       'bL8zohR5': Boolean(localStorage),
       'c8Y6qRuA': Boolean(sessionStorage),
-      'dt9DqBc': a0_0x4cca20(JSON.stringify(detectVideoCodecs())),
-      'YdY6oxI': a0_0x4cca20(JSON.stringify(detectAudioCodecs())),
-      'bdI2nwA': a0_0x4cca20(JSON.stringify(_0x242fb1[1])),
-      'cNVHtB2QA2zbSbw': a0_0x4cca20(JSON.stringify(_0x242fb1[0])),
+      'dt9DqBc': hashSHA256(JSON.stringify(detectVideoCodecs())),
+      'YdY6oxI': hashSHA256(JSON.stringify(detectAudioCodecs())),
+      'bdI2nwA': hashSHA256(JSON.stringify(_0x242fb1[1])),
+      'cNVHtB2QA2zbSbw': hashSHA256(JSON.stringify(_0x242fb1[0])),
       'YdY6oxJYqA': _0x242fb1[2],
       'd9w-pRFXpw': _0x141f60,
       'Y8QyqAl8whI': _0x4b575c,
       'YtFF': detectAutomation()
     };
   };
-  function a0_0x300792(_0x1741a5) {
+  function orderFingerprintKeys(_0x1741a5) {
     let _0x228b43 = [];
     FINGERPRINT_KEY_ORDER.forEach(_0x152215 => {
       _0x228b43.push(_0x1741a5[_0x152215]);
@@ -1844,8 +1844,8 @@ try {
     return _0x59b200(_0x343230);
   }
   var game1 = async function (_0x264b23, _0x4557cf = null) {
-    let _0x92dfe6 = new Date().getTime();
-    let _0x442419 = localStorage.getItem("x-game");
+    let timeNowUnixMs = new Date().getTime();
+    let xGame = localStorage.getItem("x-game");
     let _0xbf6dc4;
     let _0x55cb6f;
     try {
@@ -1855,26 +1855,26 @@ try {
       _0x55cb6f = parseInt(_0x3166b4.substr(_0x1091a8 + 1));
     } catch (_0x2d031e) {
       _0xbf6dc4 = Array.from(Array(100), _0x594a33 => String.fromCharCode(32 + Math.random() * 94 | 0));
-      _0x55cb6f = _0x92dfe6;
+      _0x55cb6f = timeNowUnixMs;
     }
     let _0x246e57 = _0xbf6dc4.join('') + " " + _0x55cb6f;
     localStorage.setItem("x-vec", _0x246e57);
-    if (_0x55cb6f + 1000 < _0x92dfe6) {
+    if (_0x55cb6f + 1000 < timeNowUnixMs) {
       _0xbf6dc4.shift();
       _0xbf6dc4.push(String.fromCharCode(32 + Math.random() * 94 | 0));
-      _0x246e57 = _0xbf6dc4.join('') + " " + _0x92dfe6;
+      _0x246e57 = _0xbf6dc4.join('') + " " + timeNowUnixMs;
       localStorage.setItem("x-vec", _0x246e57);
     }
-    if (!_0x442419) {
-      _0x442419 = generateRandomString(3);
-      localStorage.setItem("x-game", _0x442419);
+    if (!xGame) {
+      xGame = generateRandomString(3);
+      localStorage.setItem("x-game", xGame);
     }
-    let _0xc978de = await a0_0x385393();
+    let _0xc978de = await collectFingerprint();
     _0xc978de.Y9U6mw9451U = new Date().toISOString();
-    _0xc978de.depTtw = _0x442419;
+    _0xc978de.depTtw = xGame;
     _0xc978de['dts-siGT'] = window.btoa(_0x246e57);
-    _0xc978de.ZA = new Date().getTime() - _0x92dfe6;
-    async function _0x20e0b3() {
+    _0xc978de.ZA = new Date().getTime() - timeNowUnixMs;
+    async function getServerTime() {
       return new Promise((_0x387845, _0x147193) => {
         const _0x398f31 = new XMLHttpRequest();
         _0x398f31.onreadystatechange = function () {
@@ -1892,10 +1892,10 @@ try {
         _0x398f31.send();
       });
     }
-    _0xc978de.c9hKwCWX61TBJm_dKn0 = await _0x20e0b3();
+    _0xc978de.c9hKwCWX61TBJm_dKn0 = await getServerTime();
     _0xc978de.dehNvwBnzDqu = navigator.userAgent;
     _0xc978de.ctdIvSKVCQ = _0x4557cf;
-    _0xc978de = a0_0x300792(_0xc978de);
+    _0xc978de = orderFingerprintKeys(_0xc978de);
     let _0x33de64 = encodeFingerprintHash(JSON.stringify(_0xc978de));
     _0x264b23(_0x33de64);
   };

--- a/deobfuscate-all.sh
+++ b/deobfuscate-all.sh
@@ -6,7 +6,7 @@ cd "$ROOT/deobfuscator"
 
 npx tsc
 
-find "$ROOT/archived_game1_scripts" -name 'game1.js' ! -name '*.deobfuscated.js' -print0 | sort -z | while IFS= read -r -d '' f; do
+find "$ROOT/archived_game1_scripts" -name 'game1.js' ! -name '*.deobfuscated.js' -print0 | sort -zr | while IFS= read -r -d '' f; do
   echo "==> $f"
   node dist/index.js deobfuscate "$f" "${f}.deobfuscated.js"
 done

--- a/deobfuscator/src/rename-rules.ts
+++ b/deobfuscator/src/rename-rules.ts
@@ -7,7 +7,10 @@ export const defaultRenameRules: RenameRule[] = [
   // { name: 'fetchServerTime', keywords: ['XMLHttpRequest', 'getResponseHeader'], allowOverwrite: true },
   { name: 'getAudioFingerprint', keywords: ['OfflineAudioContext', 'createDynamicsCompressor'] },
   { name: 'renderAudioPromise', keywords: ['startRendering', 'oncomplete'] },
+  { name: 'createError', keywords: ['new Error(', '.name ='] },
   // { name: 'sumAudioChannelData', keywords: ['Math.abs'] }, // too generic — Math.abs appears in many functions
+  { name: 'hashSHA256', keywords: ['unescape(encodeURI(', '0x100000000'] },
+  { name: 'collectFingerprint', keywords: ['Intl.DateTimeFormat', 'deviceMemory'] },
   { name: 'getWebglCanvasFingerprint', keywords: ['VERTEX_SHADER', 'FRAGMENT_SHADER', 'drawArrays', 'readPixels'] },
   { name: 'getCanvas2dFingerprint', keywords: ['toDataURL', 'fillText', 'shadowBlur'] },
   { name: 'detectFonts', keywords: ['offsetWidth', 'offsetHeight', 'fontFamily', 'monospace'] },
@@ -22,6 +25,15 @@ export const defaultRenameRules: RenameRule[] = [
   { name: 'detectAudioCodecs', keywords: ['canPlayType', "audio/ogg", "audio/webm"] },
   { name: 'checkPermissions', keywords: ['permissions.query', 'accelerometer', 'camera'] },
   { name: 'generateRandomString', keywords: ['Math.random', 'toString(36)', 'substr'] },
-  // { name: 'orderFingerprintKeys', keywords: ['forEach', 'delete'], optional: true }, // too generic — forEach and delete are everywhere
+  { name: 'orderFingerprintKeys', keywords: ['FINGERPRINT_KEY_ORDER.forEach'], optional: true },
   { name: 'encodeFingerprintHash', keywords: ['encodeURIComponent', 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_='] },
+
+  { name: 'detectedOS', keywords: ["detectOS()"]},
+  { name: 'detectedBrowser', keywords: ["detectBrowser()"]},
+  { name: 'detectedWebglInfo', keywords: ["getWebglInfo()"]},
+  { name: 'timeNowUnixMs', keywords: ["new Date().getTime()"], optional: true },
+  { name: 'xGame', keywords: ['localStorage.getItem("x-game")'], optional: true },
+  { name: 'xVec', keywords: ['localStorage.getItem("x-vec")'], optional: true },
+
+  { name: 'getServerTime', keywords: ['XMLHttpRequest', 'getResponseHeader("date")', 'toISOString', 'game1.js'], optional: true },
 ];

--- a/deobfuscator/tests/rename-identifiers.test.ts
+++ b/deobfuscator/tests/rename-identifiers.test.ts
@@ -29,6 +29,56 @@ describe('renameIdentifiers', () => {
     expect(result.error).toContain('already exists');
   });
 
+  it('should error when target name collides with a const declaration', () => {
+    const input = `const existing = 42; const _0x1234 = () => existing + 1;`;
+    const result = renameIdentifiers(input, [
+      { name: 'existing', keywords: ['+ 1'] },
+    ]);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('already exists');
+  });
+
+  it('should error when target name collides with a function parameter', () => {
+    const input = `function calc(total) { const _0x1234 = total * 2; return _0x1234; }`;
+    const result = renameIdentifiers(input, [
+      { name: 'total', keywords: ['total * 2'] },
+    ]);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('already exists');
+  });
+
+  it('should error when target name exists in the function body scope', () => {
+    const input = `
+function _0xouter() {
+  const inner = 1;
+  return inner + 2;
+}
+    `.trim();
+    const result = renameIdentifiers(input, [
+      { name: 'inner', keywords: ['inner + 2'] },
+    ]);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('already exists');
+  });
+
+  it('should error when target name collides with a let variable', () => {
+    const input = `let counter = 0; function _0xinc() { counter++; }`;
+    const result = renameIdentifiers(input, [
+      { name: 'counter', keywords: ['counter++'] },
+    ]);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('already exists');
+  });
+
+  it('should error when target name collides with a var declaration', () => {
+    const input = `var temp = "hello"; const _0x1234 = () => temp + " world";`;
+    const result = renameIdentifiers(input, [
+      { name: 'temp', keywords: ['" world"'] },
+    ]);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('already exists');
+  });
+
   it('should rename function by matching keywords in body', () => {
     const input = `function a0_0x1234() { return new XMLHttpRequest(); }`;
     const result = renameIdentifiers(input, [

--- a/deobfuscator/tests/rename-identifiers.test.ts
+++ b/deobfuscator/tests/rename-identifiers.test.ts
@@ -29,10 +29,13 @@ describe('renameIdentifiers', () => {
     expect(result.error).toContain('already exists');
   });
 
-  it('should error when target name collides with a const declaration', () => {
-    const input = `const existing = 42; const _0x1234 = () => existing + 1;`;
+  it.each([
+    { kind: 'const', input: `const existing = 42; const _0x1234 = () => existing + 1;`, keyword: '+ 1', name: 'existing' },
+    { kind: 'let', input: `let counter = 0; function _0xinc() { counter++; }`, keyword: 'counter++', name: 'counter' },
+    { kind: 'var', input: `var temp = "hello"; const _0x1234 = () => temp + " world";`, keyword: '" world"', name: 'temp' },
+  ])('should error when target name collides with a $kind declaration', ({ input, keyword, name }) => {
     const result = renameIdentifiers(input, [
-      { name: 'existing', keywords: ['+ 1'] },
+      { name, keywords: [keyword] },
     ]);
     expect(result.success).toBe(false);
     expect(result.error).toContain('already exists');
@@ -56,24 +59,6 @@ function _0xouter() {
     `.trim();
     const result = renameIdentifiers(input, [
       { name: 'inner', keywords: ['inner + 2'] },
-    ]);
-    expect(result.success).toBe(false);
-    expect(result.error).toContain('already exists');
-  });
-
-  it('should error when target name collides with a let variable', () => {
-    const input = `let counter = 0; function _0xinc() { counter++; }`;
-    const result = renameIdentifiers(input, [
-      { name: 'counter', keywords: ['counter++'] },
-    ]);
-    expect(result.success).toBe(false);
-    expect(result.error).toContain('already exists');
-  });
-
-  it('should error when target name collides with a var declaration', () => {
-    const input = `var temp = "hello"; const _0x1234 = () => temp + " world";`;
-    const result = renameIdentifiers(input, [
-      { name: 'temp', keywords: ['" world"'] },
     ]);
     expect(result.success).toBe(false);
     expect(result.error).toContain('already exists');


### PR DESCRIPTION
Adds 10 new rename rules and re-generates all archived `.deobfuscated.js` files.

**New rules:**
- `hashSHA256` — SHA-256 hash function (`unescape(encodeURI(`, `0x100000000`)
- `collectFingerprint` — fingerprint orchestrator (`Intl.DateTimeFormat`, `deviceMemory`)
- `createError` — Error factory with custom name (`new Error(`, `.name =`)
- `orderFingerprintKeys` — key ordering helper (`FINGERPRINT_KEY_ORDER.forEach`)
- `detectedOS` / `detectedBrowser` / `detectedWebglInfo` — result variables for probe calls
- `timeNowUnixMs` / `xGame` / `xVec` — local state variables (optional)
- `getServerTime` — server date fetch via XHR (optional)

**Other:**
- `deobfuscate-all.sh`: reverse sort order for latest-first processing
- All 10 archived deobfuscated files regenerated with new rules

All 51 tests pass across all archived versions.